### PR TITLE
Introduce CSS version checking code.

### DIFF
--- a/admin/python/lsst/qserv/admin/qservAdminException.py
+++ b/admin/python/lsst/qserv/admin/qservAdminException.py
@@ -41,5 +41,7 @@ QservAdminException = produceExceptionClass('QservAdminException', [
     (3035, "TB_DOES_NOT_EXIST", "Table does not exist."),
     (3040, "WRONG_PARAM",       "Unrecognized parameter."),
     (3045, "WRONG_PARAM_VAL",   "Unrecognized value for parameter."),
+    (3050, "VERSION_MISMATCH",  "CSS schema/data version does not match current SW version."),
+    (3055, "VERSION_MISSING",   "CSS schema/data version does not exist."),
     (9998, "NOT_IMPLEMENTED",   "Feature not implemented yet."),
     (9999, "INTERNAL",          "Internal error.")])

--- a/core/modules/css/CssError.h
+++ b/core/modules/css/CssError.h
@@ -116,6 +116,24 @@ public:
                    + ", tried allocating up to " + sizeTried + " bytes.") {}
 };
 
+/**
+ * Specialized run-time error: missing version number
+ */
+class VersionMissingError : public CssError {
+public:
+    VersionMissingError(std::string const& key)
+        : CssError("Key for CSS version is not defined: '" + key +"'") {}
+};
+
+/**
+ * Specialized run-time error: version number mismatch
+ */
+class VersionMismatchError : public CssError {
+public:
+    VersionMismatchError(std::string const& expected, std::string const& actual)
+        : CssError("CSS version number mismatch: expected=" + expected +", actual=" + actual) {}
+};
+
 }}} // namespace lsst::qserv::css
 
 #endif // LSST_QSERV_CSSERROR_H

--- a/core/modules/css/Facade.h
+++ b/core/modules/css/Facade.h
@@ -102,6 +102,7 @@ private:
     bool _tableIsSubChunked(std::string const& dbName,
                             std::string const& tableName) const;
     int _getIntValue(std::string const& key, int defaultValue) const;
+    void _versionCheck() const;
 
     friend class FacadeFactory;
 

--- a/core/modules/qana/testPlugins.kvmap
+++ b/core/modules/qana/testPlugins.kvmap
@@ -1,4 +1,6 @@
 /	\N
+/css_meta	\N
+/css_meta/version	1
 /DBS	\N
 /DBS/LSST	READY
 /DBS/LSST/LOCK	\N

--- a/core/modules/qproc/testMap.kvmap
+++ b/core/modules/qproc/testMap.kvmap
@@ -1,4 +1,6 @@
 /	\N
+/css_meta	\N
+/css_meta/version	1
 /DBS	\N
 /DBS/LSST	READY
 /DBS/LSST/LOCK	\N


### PR DESCRIPTION
See ticket DM-1453, CSS code is modified to store version number when
first database is created in CSS in qservAdmin class. All other methods
in qservAdmin check version agains stored version number, same check is
done when css/Facade instance is created. If check fails then
corresponding exception is generated. Version number is defined in two
places nor - qservAdmin.py and css/Facade.cc. Eventually we'd like to
merge that code into one.
