### PR TITLE
DM-1603: Fix qserv build to use eups version of SWIG

### DIFF
--- a/core/modules/czar/czarLib.i
+++ b/core/modules/czar/czarLib.i
@@ -30,6 +30,8 @@ Access to the classes from the qserv_czar library
 %ignore lsst::qserv::query::operator<<;
 %ignore lsst::qserv::qproc::operator<<;
 
+%ignore lsst::qserv::qdisp::TransactionSpec::Reader;
+
  //%feature("autodoc", "1");
  //%module("threads"=1, package="lsst.qserv.czar", docstring=qserv_czar_DOCSTRING) czarLib
 %module("threads"=1, package="lsst.qserv.czar") czarLib
@@ -38,10 +40,11 @@ Access to the classes from the qserv_czar library
 #include "ccontrol/dispatcher.h"
 #include "ccontrol/queryMsg.h"
 #include "ccontrol/QueryState.h"
+#include "css/KvInterface.h"
+#include "css/KvInterfaceImplMem.h"
 #include "ccontrol/UserQueryFactory.h"
 #include "ccontrol/userQueryProxy.h"
 #include "css/StripingParams.h"
-#include "css/KvInterfaceImplMem.h"
 #include "global/constants.h"
 #include "log/loggerInterface.h"
 #include "qdisp/ChunkMeta.h"
@@ -110,12 +113,8 @@ namespace std {
 
 
 %include "boost_shared_ptr.i"
-SWIG_SHARED_PTR(KvInterface, lsst::qserv::css::KvInterface)
-SWIG_SHARED_PTR_DERIVED(KvInterfaceImplMem, lsst::qserv::css::KvInterface, lsst::qserv::css::KvInterfaceImplMem)
-
-// Define any smart pointers here:
-// SWIG_SHARED_PTR(Persistable, lsst::daf::base::Persistable)
-// SWIG_SHARED_PTR_DERIVED(PropertySet, lsst::daf::base::Persistable, lsst::daf::base::PropertySet)
+%shared_ptr(lsst::qserv::css::KvInterface)
+%shared_ptr(lsst::qserv::css::KvInterfaceImplMem)
 
 // Include all classes to wrap:
 // %include "lsst/qserv/czar/Master.h"
@@ -130,10 +129,11 @@ SWIG_SHARED_PTR_DERIVED(KvInterfaceImplMem, lsst::qserv::css::KvInterface, lsst:
 %include "ccontrol/queryMsg.h"
 %include "ccontrol/queryMsg.h"
 %include "ccontrol/QueryState.h"
+%include "css/KvInterface.h"
+%include "css/KvInterfaceImplMem.h"
 %include "ccontrol/UserQueryFactory.h"
 %include "ccontrol/userQueryProxy.h"
 %include "css/StripingParams.h"
-%include "css/KvInterfaceImplMem.h"
 %include "global/constants.h"
 %include "log/loggerInterface.h"
 %include "qdisp/ChunkMeta.h"

--- a/site_scons/state.py
+++ b/site_scons/state.py
@@ -113,6 +113,7 @@ def _setEnvWithDependencies():
     opts.AddVariables(
             (EnumVariable('debug', 'debug gcc output and symbols', 'yes', allowed_values=('yes', 'no'))),
             (PathVariable('PROTOC', 'protoc binary path', _getBinPath('protoc',"Looking for protoc compiler"), PathVariable.PathIsFile)),
+            (PathVariable('SWIG', 'swig binary path', _getBinPath('swig',"Looking for swig preprocessor"), PathVariable.PathIsFile)),
             # antlr is named runantlr on Ubuntu 13.10 and Debian Wheezy
             (PathVariable('ANTLR', 'antlr binary path', _getBinPathFromBinList(['antlr','runantlr'],'Looking for antlr parser generator'), PathVariable.PathIsFile)),
             (PathVariable('XROOTD_DIR', 'xrootd install dir', _findPrefixFromBin( 'XROOTD_DIR', "xrootd"), PathVariable.PathIsDir)),


### PR DESCRIPTION
- Introduced SWIG binary variable so qserv scons scripts would pick
  up the setup eups version of the swig preprocessor instead of using
  whatever happened to be around in the external environemnt.
- SWIG 3.0.2 compatibility: forward declared nested class
  TransactionSpec::Reader was tripping up swig with a swigregister
  name collision.  %ignore'd TransactionSpec::Reader to workaround.
- SWIG 3.0.2 compatibility: needed to cut over from old SWIG_SHARED_
  POINTER macros to the newer %shared_ptr facility.  Some %include
  reordering was also necessary in czarLib.i, since swig's implicit
  conversion of shared pointers (derived\* to base*) does not work
  correctly with partial/forward type declarations.
