### PR TITLE
DM-1661: czar log4cxx link/load bug on Ubuntu 14.04

### DIFF
--- a/core/modules/SConscript
+++ b/core/modules/SConscript
@@ -113,6 +113,11 @@ shProducts = { "xrdfs" : {'mods' : """proto xrdfs
 
                }
 
+# external libs for shmods
+shmodLibs = {
+  'css': ['log']
+}
+
 # modules used in shProducts
 modList = [m for m in chain(*map(lambda d: d['mods'],
                                 shProducts.values()))]
@@ -209,7 +214,7 @@ shmods = set(chain(*[product.get('shmods', [])
                      for product in shProducts.values()]))
 # Compute shared lib targets used by products
 for m in shmods:
-    out = env.SharedLibrary("libqserv_"+m, libProducts[m])
+    out = env.SharedLibrary("libqserv_"+m, libProducts[m], LIBS=shmodLibs[m])
     shlibs[m] = out
     for f in out:
         extraTgts['dist'].append(('lib', f))


### PR DESCRIPTION
On Ubuntu 14.04, the czar would fall over at load time with an unresolved
sym (for typeinfo for log4cxx::helpers::ObjectPtrBase) while loading the
css python wrapper shared lib. It seems the linker was tripping up chasing
transitive dependencies through the shared libs.

This cl tweaks core/modules/Sconscript to provide additional explicit link libs
to "shmod" shared modules to hint the linker.
