### PR TITLE
Fixes DM-1673: Allow override for broken SWIG installations.

### DIFF
--- a/core/modules/css/SConscript
+++ b/core/modules/css/SConscript
@@ -15,14 +15,12 @@ def _debug_dist_target():
              for (path, f) in extraTgts['dist']]
         state.log.debug("extraTgts['dist']" + "\n".join(t))
 
-localCpppath = env['CPPPATH']
-if type(localCpppath) == type(""): localCpppath = [localCpppath]
-localCpppath.append(distutils.sysconfig.get_python_inc())
+pythonInc = distutils.sysconfig.get_python_inc()
+cppPath = cctarget.getList(env, 'CPPPATH') + [pythonInc]
 swigged = env.SharedObject(source="cssLib.i",
                             SWIGFLAGS=['-python', '-c++', '-Iinclude'],
-                            SWIGPATH=['..',
-                                      distutils.sysconfig.get_python_inc()],
-                            CPPPATH=localCpppath,
+                            SWIGPATH=['..', pythonInc],
+                            CPPPATH=cppPath,
                             LDMODULEPREFIX='_', LDMODULESUFFIX='.so'
                             )
 

--- a/core/modules/czar/SConscript
+++ b/core/modules/czar/SConscript
@@ -4,6 +4,7 @@ import distutils.sysconfig
 import errno
 import os
 import state
+import cctarget
 import pytarget
 
 Import('env')
@@ -31,16 +32,17 @@ depends = ['ccontrol/dispatcher.h',
            'xrdc/xrdfile.h']
 depends = map(lambda f: env.File("../"+f), depends)
 
-localCpppath = env['CPPPATH']
-if type(localCpppath) == type(""): localCpppath = [localCpppath]
-localCpppath.append(distutils.sysconfig.get_python_inc())
+pythonInc = distutils.sysconfig.get_python_inc()
+cppPath = cctarget.getList(env, 'CPPPATH') + [pythonInc]
 swigged = env.SharedObject(source="czarLib.i",
                            SWIGFLAGS=['-python', '-c++', '-Iinclude'],
-                           SWIGPATH=['..',
-                                     distutils.sysconfig.get_python_inc()],
-                           CPPPATH=localCpppath,
-                           LDMODULEPREFIX='_', LDMODULESUFFIX = '.so'
+                           SWIGPATH=['..', pythonInc],
+                           CPPPATH=cppPath,
+                           LDMODULEPREFIX='_',
+                           LDMODULESUFFIX = '.so',
                            )
+
+
 # swigged = env.swig(source="czarLib.i",
 #                    SWIGPATH=['..',
 #                              distutils.sysconfig.get_python_inc()],

--- a/site_scons/cctarget.py
+++ b/site_scons/cctarget.py
@@ -21,7 +21,6 @@
 #
 # cctarget.py -- helpers for modules to publish c++ modules
 import os
-import state
 
 def getDefaultTargets(env, path, ignore=lambda f:False):
     """ 
@@ -34,3 +33,9 @@ def getDefaultTargets(env, path, ignore=lambda f:False):
                    env.Glob(os.path.join(path, "*.cc")))
     files.sort(key=lambda n: n.str_for_display())
     return files
+
+def getList(env, key):
+    value = env[key]
+    if not value: return []
+    elif type(value) == type(""): return [value]
+    return value

--- a/site_scons/state.py
+++ b/site_scons/state.py
@@ -166,6 +166,16 @@ def _setEnvWithDependencies():
             )
         opts.Update(env)
 
+    # SWIG_SWIG_LIB specification: Useful when swig can't find its own *.i files
+    # This is SWIG_LIB, read by swig, not the same as the location of swig's *.so libs
+    # No validation: a custom SWIG_SWIG_LIB is not essential.
+    opts.AddVariables(
+        (PathVariable('SWIG_SWIG_LIB', 'swig SWIG_LIB for broken swig setups', [], PathVariable.PathAccept)) 
+        )
+    opts.Update(env)
+    swig_swig_lib = env['SWIG_SWIG_LIB']
+    if swig_swig_lib and os.path.isdir(swig_swig_lib):
+        env['ENV']['SWIG_LIB'] = swig_swig_lib
     SCons.Script.Help(opts.GenerateHelpText(env))
 
 


### PR DESCRIPTION
SWIG needs an override on the env var SWIG_LIB when it is used outside
of the directory in which it was built and installed. This patch allows
an override via qserv's custom.py mechanism. Includes minor simplifications
in SConscript for swig.
