### PR TITLE
First version of multi-worker data loader.

### DIFF
--- a/admin/python/lsst/qserv/admin/chunkMapping.py
+++ b/admin/python/lsst/qserv/admin/chunkMapping.py
@@ -1,0 +1,168 @@
+# LSST Data Management System
+# Copyright 2014 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+"""
+Module defining ChunkMapping class and related methods.
+
+ChunkMapping class is used to manage information about which chunk
+exists on which worker. It stores, retrieves and updates this info
+in CSS.
+
+@author  Andy Salnikov, SLAC
+"""
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+import logging
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+class ChunkMapping(object):
+    """
+    Instances of ChunkMapping class represent updatable mapping between
+    chunk numbers and worker names (host names).
+    """
+
+
+    def __init__(self, workers, database, table, qservAdmin=None):
+        """
+        @param workers:      List of worker names.
+        @param database:     Database name.
+        @param table:        Table name.
+        @param qservAdmin:   Instance of QservAdmin class, CSS interface. This
+                             can be None, but this is only useful for testing.
+        """
+        self.css = qservAdmin
+        self.workers = workers[:]   # need a copy, will modify
+        self.database = database
+        self.table = table
+
+        self.allChunks = {}  # maps chunk number to the set of workers (for all tables)
+        self.chunks = {}  # maps chunk number to the set of workers (for current table)
+        self.newChunks = {}     # maps chunk number to the worker name for new chunks
+
+        self._log = logging.getLogger("chunk_map")
+
+        self._getChunks()
+
+    def _getChunks(self):
+        """
+        Load existing chunk mapping from CSS.
+
+        Currently there is no existing global chunk mapping in CSS, only
+        per-table. We load chunk mappings from all existing tables and
+        merge them.
+        """
+
+        if self.css is None:
+            return
+
+        for table in self.css.tables(self.database):
+
+            chunks = self.css.chunks(self.database, table)
+
+            if chunks:
+                self._log.debug('Loading mapping for table %s', table)
+
+            for chunk, hosts in chunks.items():
+                self.allChunks.setdefault(chunk, set()).update(hosts)
+                if table == self.table:
+                    self.chunks.setdefault(chunk, set()).update(hosts)
+
+    def worker(self, chunk):
+        """
+        Returns worker name for specified chunk number.
+
+        If there is no existing mapping for this chunk yet, then new mapping
+        will be created (currently in round-robin mode from the set of known
+        worker names). New mappings have to be saved later by calling save()
+        method.
+        """
+
+        self._log.debug('Find worker for chunk %s', chunk)
+
+        # try newly-created mapping first
+        worker = self.newChunks.get(chunk)
+        if worker is not None:
+            self._log.debug('Chunk found in new chunks')
+            return worker
+
+        # try mapping for this table
+        workers = self.chunks.get(chunk)
+        if workers is not None:
+            self._log.debug('Chunk found in existing table chunks')
+            # try to chose one worker which is also in self.workers
+            match = set(self.workers) & workers
+            if match:
+                worker = next(iter(match))
+            else:
+                # return one random
+                worker = next(iter(workers))
+            return worker
+
+        # see if other tables define mapping for this chunk
+        workers = self.allChunks.get(chunk)
+        if workers is not None:
+            self._log.debug('Chunk found in existing other-table chunks')
+            # try to chose one worker which is also in self.workers
+            match = set(self.workers) & workers
+            if match:
+                worker = next(iter(match))
+            else:
+                # return one random
+                worker = next(iter(workers))
+            self.newChunks[chunk] = worker
+            return worker
+
+        # will need at least one worker at this point
+        if not self.workers:
+            raise ValueError('ChunkMapping: Worker list is empty')
+
+        # need to find new "best" location for a chunk
+        worker = self._getWorker()
+        self.newChunks[chunk] = worker
+        return worker
+
+    def save(self):
+        """
+        Save all new mappings generated for current table.
+        """
+        if self.css is not None:
+            for chunk, worker in self.newChunks.items():
+                self.css.addChunk(self.database, self.table, chunk, [worker])
+
+    def _getWorker(self):
+        """
+        Get next "best" available worker, for now do round-robin.
+        """
+        worker = self.workers.pop(0)
+        self.workers.append(worker)
+        return worker

--- a/admin/python/lsst/qserv/admin/qservAdmin.py
+++ b/admin/python/lsst/qserv/admin/qservAdmin.py
@@ -180,7 +180,7 @@ class QservAdmin(object):
         with self._getDbLock(dbName):
             try:
                 if self._kvI.exists(dbP):
-                    self._logger.info("createDb database '%s' exists, aborting." % \
+                    self._logger.info("createDb database '%s' exists, aborting.",
                                       dbName)
                     return
                 self._kvI.create(dbP, "PENDING")
@@ -200,12 +200,12 @@ class QservAdmin(object):
                 self._createDbLockSection(dbP)
                 self._kvI.set(dbP, "READY")
             except KvException as e:
-                self._logger.error("Failed to create database '%s', " % dbName +
-                                   "error was: " + e.__str__())
+                self._logger.error("Failed to create database '%s', error was: %s",
+                                   dbName, e)
                 self._deletePacked(dbP)
                 if ptP is not None: self._deletePacked(ptP)
                 raise
-        self._logger.debug("Create database '%s' succeeded." % dbName)
+        self._logger.debug("Create database '%s' succeeded.", dbName)
 
     def createDbLike(self, dbName, templateDbName):
         """
@@ -214,7 +214,7 @@ class QservAdmin(object):
         @param dbName    Database name (of the database to create)
         @param templateDbName   Database name (of the template database)
         """
-        self._logger.info("Creating db '%s' like '%s'" % (dbName, templateDbName))
+        self._logger.info("Creating db '%s' like '%s'", dbName, templateDbName)
 
         # first check version
         self._versionCheck()
@@ -222,7 +222,7 @@ class QservAdmin(object):
         dbP = "/DBS/%s" % dbName
         dbP2 = "/DBS/%s" % templateDbName
         if dbName == templateDbName:
-            raise QservAdminException(QservAdminException.DB_NAME_IS_SELF);
+            raise QservAdminException(QservAdminException.DB_NAME_IS_SELF)
         # Acquire lock in sorted order. Otherwise two admins that run
         # "CREATE DATABASE A LIKE B" and "CREATE DATABASE B LIKE A" can deadlock.
         (name1, name2) = sorted((dbP, dbP2))
@@ -241,9 +241,8 @@ class QservAdmin(object):
             self._createDbLockSection(dbP)
             self._kvI.set(dbP, "READY")
         except KvException as e:
-            self._logger.error("Failed to create database '%s' like '%s', "
-                               % (dbName, templateDbName)
-                               + "error was: " + e.__str__())
+            self._logger.error("Failed to create database '%s' like '%s', error was: %s",
+                               dbName, templateDbName, e)
             self._deletePacked(dbP)
             raise
 
@@ -253,7 +252,7 @@ class QservAdmin(object):
 
         @param dbName    Database name.
         """
-        self._logger.info("Drop database '%s'" % dbName)
+        self._logger.info("Drop database '%s'", dbName)
 
         # first check version
         self._versionCheck()
@@ -261,7 +260,7 @@ class QservAdmin(object):
         with self._getDbLock(dbName):
             dbP = "/DBS/%s" % dbName
             if not self._kvI.exists(dbP):
-                self._logger.info("dropDb database '%s' gone, aborting.." % \
+                self._logger.info("dropDb database '%s' gone, aborting..",
                                   dbName)
                 return
             self._deletePacked(dbP)
@@ -285,6 +284,11 @@ class QservAdmin(object):
         """
         p = "/DBS/%s/TABLES/%s" % (dbName, tableName)
         return self._kvI.exists(p)
+
+    def tables(self, dbName):
+        """ Returns the list of table names defined in CSS """
+        key = "/DBS/%s/TABLES" % (dbName,)
+        return self._cssChildren(key, [])
 
     def createTable(self, dbName, tableName, options):
         """
@@ -311,16 +315,16 @@ class QservAdmin(object):
         @param tableName Table name
         @param options   Dictionary with options (key/value)
         """
-        self._logger.debug("Create table '%s.%s', options: %s"
-                           % (dbName, tableName, str(options)))
+        self._logger.debug("Create table '%s.%s', options: %s",
+                           dbName, tableName, options)
 
         # first check version
         self._versionCheck()
 
         with self._getDbLock(dbName):
             if not self._kvI.exists("/DBS/%s" % dbName):
-                self._logger.info("createTable: database '%s' missing, aborting."
-                                  % dbName)
+                self._logger.info("createTable: database '%s' missing, aborting.",
+                                  dbName)
                 return
             self._createTable(options, dbName, tableName)
 
@@ -331,7 +335,7 @@ class QservAdmin(object):
         @param dbName    Database name
         @param tableName Table name
         """
-        self._logger.debug("Drop table '%s.%s'" % (dbName, tableName))
+        self._logger.debug("Drop table '%s.%s'", dbName, tableName)
 
         with self._getDbLock(dbName):
             tbP = "/DBS/%s/TABLES/%s" % (dbName, tableName)
@@ -342,7 +346,7 @@ class QservAdmin(object):
         def check(d, possible):
             for k in possible:
                 if k not in d:
-                    self._logger.info("'%s' not provided" % k)
+                    self._logger.info("'%s' not provided", k)
         check(tbOpts, possibleOpts["table"])
         check(matchOpts, possibleOpts["match"])
         check(partitionOpts, possibleOpts["partition"])
@@ -368,20 +372,70 @@ class QservAdmin(object):
                 self._addPacked(tbP+"/partitioning", partitionOpts)
             self._kvI.set(tbP, "READY")
         except KvException as e:
-            self._logger.error("Failed to create table '%s.%s', " % \
-                                (dbName, tableName) + "error was: " + e.__str__())
+            self._logger.error("Failed to create table '%s.%s', error was: %s",
+                                dbName, tableName, e)
             self._kvI.delete(tbP, recursive=True)
             raise
-        self._logger.debug("Create table '%s.%s' succeeded." % (dbName, tableName))
+        self._logger.debug("Create table '%s.%s' succeeded.", dbName, tableName)
+
+    #### CHUNKS ####################################################################
+    def chunks(self, dbName, tableName):
+        """
+        Returns all chunks defined in CSS. Returned object is a dictionary with
+        chunk number as a key and list of worker names as value. Empty dict is
+        returned if no chunk info is defined.
+        """
+        res = {}
+        with self._getDbLock(dbName):
+            key = "/DBS/%s/TABLES/%s/CHUNKS" % (dbName, tableName)
+            for chunk in self._cssChildren(key, []):
+                hosts = []
+                replKey = "%s/%s/REPLICAS" % (key, chunk)
+                for repl in self._cssChildren(replKey, []):
+                    host = None
+                    if repl.endswith('.json'):
+                        data = self._cssGet(replKey + '/' + repl)
+                        if data:
+                            data = json.loads(data)
+                            host = data.get('nodeName')
+                    else:
+                        host = self._cssGet(replKey + '/' + repl + '/nodeName')
+                    if host:
+                        hosts.append(host)
+                res[int(chunk)] = hosts
+        return res
+
+    def addChunk(self, dbName, tableName, chunk, hosts):
+        """
+        Retuns all chunks defined in CSS. Returned object is a dictionary with
+        chunk number as a key and list of worker names as value. Empty dict is
+        returned if no chunk info is defined.
+        """
+
+        self._logger.debug("Add chunk replicas '%s.%s', chunk: %s hosts: %s",
+                           dbName, tableName, chunk, hosts)
+
+        with self._getDbLock(dbName):
+
+            key = "/DBS/%s/TABLES/%s/CHUNKS/%s/REPLICAS" % (dbName, tableName, chunk)
+
+            for host in hosts:
+                path = self._kvI.create(key + '/', sequence=True)
+                self._logger.debug("New chunk replica key: %s", path)
+                self._addPacked(path, dict(nodeName=host))
 
     ################################################################################
     def dumpEverything(self, dest=None):
         """
         Dumps entire metadata in CSS. Output goes to file (if provided through
-        "dest"), otherwise to stdout.
+        "dest"), otherwise to stdout. Argument can be a file object instance
+        (anything that has write() method) or a string in which case it is
+        assumed to be a file name to write to.
         """
         if dest is None:
             self._kvI.dumpAll()
+        elif getattr(dest, 'write'):
+            self._kvI.dumpAll(dest)
         else:
             with open(dest, "w") as f:
                 self._kvI.dumpAll(f)
@@ -405,7 +459,7 @@ class QservAdmin(object):
             f = open(fileName, 'r')
             for line in f.readlines():
                 (k, v) = line.rstrip().split()
-                if v == '\N':
+                if v == r'\N':
                     v = ''
                 if k != '/':
                     self._kvI.create(k, v)
@@ -422,7 +476,7 @@ class QservAdmin(object):
         @param dbSrc     Source database name
         @param theList   The list of elements to copy.
         """
-        dbS  = "/DBS/%s" % dbSrc
+        dbS = "/DBS/%s" % dbSrc
         dbD = "/DBS/%s" % dbDest
         for x in theList:
             v = self._kvI.get("%s/%s" % (dbS, x))
@@ -436,7 +490,7 @@ class QservAdmin(object):
         @param dbP    Path to the database.
         """
         lockOptList = "comments estimatedDuration lockedBy lockedTime mode reason"
-        lockOpts = dict([(k,"") for k in lockOptList.split()])
+        lockOpts = dict([(k, "") for k in lockOptList.split()])
         self._addPacked(dbP + "/LOCK", lockOpts)
 
     def _versionCheck(self):
@@ -461,9 +515,22 @@ class QservAdmin(object):
         """
         self._kvI.create(VERSION_KEY, str(VERSION))
 
+    ##### convenience ##########################################################
+    def _cssGet(self, key, default=None):
+        "Returns key value or default if key does not exist"
+        if self._kvI.exists(key):
+            return self._kvI.get(key)
+        return default
+
+    def _cssChildren(self, key, default=None):
+        "Returns list of children or default if key does not exist"
+        if self._kvI.exists(key):
+            return self._kvI.getChildren(key)
+        return default
+
     ##### Locking related ##########################################################
     def _getDbLock(self, dbName):
-            return self._kvI.getLockObject("/DBS/%s" % dbName, self._uniqueId())
+        return self._kvI.getLockObject("/DBS/%s" % dbName, self._uniqueId())
 
     def _uniqueId(self):
         self._uniqueLockId += 1

--- a/admin/tests/test_chunkMapping.py
+++ b/admin/tests/test_chunkMapping.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+
+# LSST Data Management System
+# Copyright 2014 AURA/LSST.
+# 
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the LSST License Statement and 
+# the GNU General Public License along with this program.  If not, 
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+"""
+This is a unit test for chunkMapping module.
+
+@author  Andy Salnikov, SLAC
+
+"""
+
+import os
+import tempfile
+import unittest
+import StringIO
+
+from lsst.qserv.admin.chunkMapping import ChunkMapping
+import lsst.qserv.admin.qservAdmin as qservAdmin
+
+
+def _makeAdmin(data=None):
+    """
+    Create QservAdmin instance with some pre-defined data.
+    """
+    if data is None:
+        # read from /dev/null
+        connection = '/dev/null'
+    else:
+        # make temp file and save data in it
+        file = tempfile.NamedTemporaryFile(delete=False)
+        connection = file.name
+        file.write(data)
+        file.close()
+
+    # make an instance
+    config = dict(technology='mem', connection=connection)
+    admin = qservAdmin.QservAdmin(config=config)
+
+    # remove tmp file
+    if connection != '/dev/null':
+        os.unlink(connection)
+
+    return admin
+
+
+class TestConfigParser(unittest.TestCase):
+
+    def testRR(self):
+        """ Testing round-robin without CSS backend """
+
+        workers = ['worker1', 'worker2']
+        database = 'TESTDB'
+        table = 'TABLE'
+        mapper = ChunkMapping(workers, database, table)
+
+        # current implementation works in round-robin mode
+        wmap = [mapper.worker(w) for w in range(10)]
+        for i, worker in enumerate(wmap):
+            expect = workers[i % len(workers)]
+            self.assertEqual(worker, expect)
+
+
+    def testRepeat(self):
+        """ Testing repeatability without CSS backend """
+
+        workers = ['worker1', 'worker2']
+        database = 'TESTDB'
+        table = 'TABLE'
+        mapper = ChunkMapping(workers, database, table)
+
+        # repeat the same thing twice, must get identical output
+        wmap1 = [mapper.worker(w) for w in range(10)]
+        wmap2 = [mapper.worker(w) for w in range(10)]
+        self.assertEqual(wmap1, wmap2)
+
+
+    def testCss1(self):
+        """ Test for reading data from CSS """
+
+        # instantiate kvI with come initial data
+        initData = """\
+/\t\\N
+/css_meta\t\\N
+/css_meta/version\t{version}
+/DBS\t\\N
+/DBS/{db}\t\\N
+/DBS/{db}/TABLES\t\\N
+/DBS/{db}/TABLES/{table}\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1.json\t{{"nodeName": "worker333"}}
+/DBS/{db}/TABLES/{table}/CHUNKS/765\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1.json\t{{"nodeName": "worker765"}}
+"""
+
+        workers = ['worker1', 'worker2']
+        database = 'TESTDB'
+        table = 'TABLE'
+
+        initData = initData.format(version=qservAdmin.VERSION, db=database, table=table)
+        admin = _makeAdmin(initData)
+
+        mapper = ChunkMapping(workers, database, table, admin)
+
+        # check that pre-defined chunks work
+        worker = mapper.worker(333)
+        self.assertEqual(worker, 'worker333')
+        worker = mapper.worker(765)
+        self.assertEqual(worker, 'worker765')
+
+        # chunks that are not in CSS should return workers from the list
+        worker = mapper.worker(1)
+        self.assertEqual(worker, 'worker1')
+        worker = mapper.worker(2)
+        self.assertEqual(worker, 'worker2')
+
+    def testCss2(self):
+        """ Test for reading data from CSS, use chunks map from different table """
+
+        # instantiate kvI with come initial data
+        initData = """\
+/\t\\N
+/css_meta\t\\N
+/css_meta/version\t{version}
+/DBS\t\\N
+/DBS/{db}\t\\N
+/DBS/{db}/TABLES\t\\N
+/DBS/{db}/TABLES/{table}\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1.json\t{{"nodeName": "worker333"}}
+/DBS/{db}/TABLES/{table}/CHUNKS/765\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1.json\t{{"nodeName": "worker765"}}
+"""
+
+        workers = ['worker1', 'worker2']
+        database = 'TESTDB'
+        table = 'TABLE'
+
+        initData = initData.format(version=qservAdmin.VERSION, db=database, table="TBL123")
+        admin = _makeAdmin(initData)
+
+        mapper = ChunkMapping(workers, database, table, admin)
+
+        # check that pre-defined chunks work
+        worker = mapper.worker(333)
+        self.assertEqual(worker, 'worker333')
+        worker = mapper.worker(765)
+        self.assertEqual(worker, 'worker765')
+
+        # chunks that are not in CSS should return workers from the list
+        worker = mapper.worker(1)
+        self.assertEqual(worker, 'worker1')
+        worker = mapper.worker(2)
+        self.assertEqual(worker, 'worker2')
+
+    def testCss3(self):
+        """ Test for saving data to CSS """
+
+        # instantiate kvI with come initial data
+        initData = """\
+/\t\\N
+/css_meta\t\\N
+/css_meta/version\t{version}
+/DBS\t\\N
+/DBS/{db}\t\\N
+/DBS/{db}/TABLES\t\\N
+/DBS/{db}/TABLES/{table}\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS\t\\N
+"""
+
+        workers = ['worker1', 'worker2']
+        database = 'TESTDB'
+        table = 'TABLE'
+
+        initData = initData.format(version=qservAdmin.VERSION, db=database, table=table)
+        admin = _makeAdmin(initData)
+
+        mapper = ChunkMapping(workers, database, table, admin)
+
+        # chunks that are not in CSS should return workers from the list
+        worker = mapper.worker(1)
+        self.assertEqual(worker, 'worker1')
+        worker = mapper.worker(2)
+        self.assertEqual(worker, 'worker2')
+
+        # save stuff to CSS
+        mapper.save()
+
+        # save all CSS to file
+        dest = StringIO.StringIO()
+        admin.dumpEverything(dest)
+        data = dest.getvalue()
+
+        # build another CSS instance from saved data
+        admin = _makeAdmin(data)
+
+        # new mapper, use different worker set to avboid confusion
+        workers = ['worker1000', 'worker2000']
+        mapper = ChunkMapping(workers, database, table, admin)
+
+        # get workers for chunks from css
+        worker = mapper.worker(1)
+        self.assertEqual(worker, 'worker1')
+        worker = mapper.worker(2)
+        self.assertEqual(worker, 'worker2')
+        worker = mapper.worker(3)
+        self.assertEqual(worker, 'worker1000')
+        worker = mapper.worker(4)
+        self.assertEqual(worker, 'worker2000')
+
+####################################################################################
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/modules/css/KvInterfaceImplMem.cc
+++ b/core/modules/css/KvInterfaceImplMem.cc
@@ -101,6 +101,15 @@ KvInterfaceImplMem::create(string const& key, string const& value) {
     if (exists(key)) {
         throw KeyExistsError(key);
     }
+    // create all parents
+    string parent = key;
+    for (string::size_type p = parent.rfind('/'); p != string::npos; p = parent.rfind('/')) {
+        parent = parent.substr(0, p);
+        if (parent.empty()) break;
+        if (_kvMap.find(parent) != _kvMap.end()) break;
+        _kvMap.insert(std::make_pair(parent, std::string()));
+    }
+    // store the key with value
     _kvMap[key] = value;
 }
 
@@ -141,13 +150,14 @@ KvInterfaceImplMem::getChildren(string const& key) {
     if ( ! exists(key) ) {
         throw NoSuchKey(key);
     }
+    const std::string pfx(key == "/" ? key : key + "/");
     vector<string> retV;
     map<string, string>::const_iterator itrM;
     for (itrM=_kvMap.begin() ; itrM!=_kvMap.end() ; itrM++) {
         string fullKey = itrM->first;
         LOGF_INFO("fullKey: %1%" % fullKey);
-        if (boost::starts_with(fullKey, key+"/")) {
-            string theChild = fullKey.substr(key.length()+1);
+        if (boost::starts_with(fullKey, pfx)) {
+            string theChild = fullKey.substr(pfx.length());
             if (!theChild.empty() && (theChild.find("/") == string::npos)) {
                 LOGF_INFO("child: %1%" % theChild);
                 retV.push_back(theChild);

--- a/core/modules/css/python/kvInterface.py
+++ b/core/modules/css/python/kvInterface.py
@@ -657,7 +657,11 @@ class KvInterfaceMem(KvInterface):
         """
         Returns entire contents.
         """
-        self._printNode("/", fileH)
+        contents = self._printNode("/")
+        if fileH:
+            fileH.write(contents)
+        else:
+            print contents
 
     def getLockObject(self, k, id):
         """


### PR DESCRIPTION
This makes an initial implementation of the data loader with support for
multiple worker nodes (DM-1653). data-loader.py gets new option -W which
can be used multiple times to specify one or more worker host name.
Currently there is no way to specify different mysql port number for
different workers, all worker database servers are supposed to listen on
the same port. Mapping of chunks to hosts is currently done in a
round-robin mode, and of course different tables use the same chunk
mapping (see admin/chunkMapping module).
