### PR TITLE
Create (secondary) index only for director table (DM-1720).

### DIFF
--- a/admin/bin/qserv-data-loader.py
+++ b/admin/bin/qserv-data-loader.py
@@ -161,9 +161,10 @@ class Loader(object):
                            help='Path name for "empty chunks" file, if not specified then this file is '
                            'not produced.')
         group.add_argument('-i', '--index-db', dest='indexDb', default='qservMeta', metavar='DB_NAME',
-                           help='Name of the database which keeps czar-side object index, '
-                           'def: %(default)s. Set to empty string to avoid building index. '
-                           'If name is not empty then database must already exist.')
+                           help='Name of the database which keeps czar-side object index, def: '
+                           '%(default)s. Index is generated only for director table which is specified '
+                           'with dirTable option in configuration file. Set to empty string to avoid '
+                           'building index. If name is not empty then database must already exist.')
         group.add_argument('-e', '--delete-tables', dest='deleteTables', default=False, action='store_true',
                            help='If specified then existing tables in database will be deleted if '
                            'they exist, this includes both data and metadata.')

--- a/admin/python/lsst/qserv/admin/dataLoader.py
+++ b/admin/python/lsst/qserv/admin/dataLoader.py
@@ -80,7 +80,8 @@ class DataLoader(object):
                              create chunk tables.
         @param cssConn:      Connection string for CSS service.
         @param cssClear:     If true then CSS info for a table will be deleted first.
-        @param indexDb:      Name of  database for object indices.
+        @param indexDb:      Name of  database for object indices, index is generated for director
+                             table when it is partitioned, use empty string to disable index.
         @param emptyChunks:  Path name for "empty chunks" file, may be None.
         @param deleteTables: If True then existing tables in database will be deleted.
         @param loggerName:   Logger name used for logging all messages from loader.
@@ -121,7 +122,7 @@ class DataLoader(object):
 
         # Logic is slightly complicated here, so pre-calculate options that we need below:
         # 1. If self.skipPart and self.oneTable are both true then we skip partitioning
-        #    even for partitioned tables abnd load original data. So if self.skipPart and
+        #    even for partitioned tables and load original data. So if self.skipPart and
         #    self.oneTable are both true then we say table is not partitioned
         # 2. Partitioning is done only for partitioned table, if self.skipPart is true then
         #    pre-partitioned data must exist already and we skip calling partitioner
@@ -734,8 +735,8 @@ class DataLoader(object):
         Generate object index in czar meta database.
         """
 
-        # only makes sense for true partitioned tables
-        if not self.partitioned or not self.indexDb:
+        # only makes sense for director table
+        if not self.partitioned or not self.partOptions.isDirector(table) or not self.indexDb:
             return
 
         metaTable = self.indexDb + '.' + database + '__' + table


### PR DESCRIPTION
Chunk/subchunk index is only needed for director table, data loader
script now ignores index table option for all other tables. Director
table name is determined by dirTable configuration option.