### PR TITLE
Fix parenthesization in rendered IR tree (DM-737)

### DIFF
--- a/core/modules/global/sqltoken.cc
+++ b/core/modules/global/sqltoken.cc
@@ -53,8 +53,8 @@ struct InsensitiveCompare {
 /// implementations. Possibilities: hashing, lookup tables.
 struct CompareMap {
     CompareMap() {
-        const char* sepWords[] = {"select", "from", "where", "by", "limit"};
-        const int swSize=5;
+        const char* sepWords[] = {"select", "from", "where", "by", "limit", "and", "or"};
+        const int swSize=7;
         _sepWords.insert(sepWords, sepWords + swSize);
     }
     inline bool isSeparatingWord(std::string const& w) {

--- a/core/modules/query/BoolTerm.cc
+++ b/core/modules/query/BoolTerm.cc
@@ -87,26 +87,34 @@ namespace {
     template <typename Plist>
     inline void renderList(QueryTemplate& qt,
                            Plist const& lst,
+                           BoolTerm::OpPrecedence listOpPrecedence,
                            std::string const& sep) {
         int count=0;
         typename Plist::const_iterator i;
         for(i = lst.begin(); i != lst.end(); ++i) {
             if(!sep.empty() && ++count > 1) { qt.append(sep); }
             if(!*i) { throw std::logic_error("Bad list term"); }
+            BoolTerm *asBoolTerm = dynamic_cast<BoolTerm*>(&**i);
+            BoolTerm::OpPrecedence termOpPrecedence = asBoolTerm
+                ? asBoolTerm->getOpPrecedence()
+                : BoolTerm::OTHER_PRECEDENCE;
+            bool parensNeeded = listOpPrecedence > termOpPrecedence;
+            if (parensNeeded) { qt.append("("); }
             (**i).renderTo(qt);
+            if (parensNeeded) { qt.append(")"); }
         }
     }
 }
 
 void OrTerm::renderTo(QueryTemplate& qt) const {
-    renderList(qt, _terms, "OR");
+    renderList(qt, _terms, getOpPrecedence(), "OR");
 }
 void AndTerm::renderTo(QueryTemplate& qt) const {
-    renderList(qt, _terms, "AND");
+    renderList(qt, _terms, getOpPrecedence(), "AND");
 }
 void BoolFactor::renderTo(QueryTemplate& qt) const {
     std::string s;
-    renderList(qt, _terms, s);
+    renderList(qt, _terms, getOpPrecedence(), s);
 }
 void UnknownTerm::renderTo(QueryTemplate& qt) const {
     qt.append("unknown");

--- a/core/modules/query/BoolTerm.h
+++ b/core/modules/query/BoolTerm.h
@@ -80,6 +80,15 @@ public:
     virtual ~BoolTerm() {}
     virtual char const* getName() const { return "BoolTerm"; }
 
+    enum OpPrecedence {
+        OTHER_PRECEDENCE   = 3,  // terms joined stronger than AND -- no parens needed
+        AND_PRECEDENCE     = 2,  // terms joined by AND
+        OR_PRECEDENCE      = 1,  // terms joined by OR
+        UNKNOWN_PRECEDENCE = 0   // terms joined by ??? -- always add parens
+    };
+
+    virtual OpPrecedence getOpPrecedence() const { return UNKNOWN_PRECEDENCE; }
+
     virtual void findValueExprs(ValueExprList& list) {}
     virtual void findColumnRefs(ColumnRef::List& list) {}
 
@@ -109,6 +118,7 @@ public:
     typedef boost::shared_ptr<OrTerm> Ptr;
 
     virtual char const* getName() const { return "OrTerm"; }
+    virtual OpPrecedence getOpPrecedence() const { return OR_PRECEDENCE; }
 
     virtual void findValueExprs(ValueExprList& list) {
         typedef BoolTerm::PtrList::iterator Iter;
@@ -142,6 +152,7 @@ public:
     typedef boost::shared_ptr<AndTerm> Ptr;
 
     virtual char const* getName() const { return "AndTerm"; }
+    virtual OpPrecedence getOpPrecedence() const { return AND_PRECEDENCE; }
 
     virtual void findValueExprs(ValueExprList& list) {
         typedef BoolTerm::PtrList::iterator Iter;
@@ -174,6 +185,7 @@ class BoolFactor : public BoolTerm {
 public:
     typedef boost::shared_ptr<BoolFactor> Ptr;
     virtual char const* getName() const { return "BoolFactor"; }
+    virtual OpPrecedence getOpPrecedence() const { return OTHER_PRECEDENCE; }
 
     virtual void findValueExprs(ValueExprList& list) {
         typedef BfTerm::PtrList::iterator Iter;

--- a/core/modules/query/testRepr.cc
+++ b/core/modules/query/testRepr.cc
@@ -26,27 +26,38 @@
   *
   */
 
+// System headers
+#include <sstream>
+
+// Third-party headers
+#include "boost/make_shared.hpp"
+
 // Qserv headers
+#include "query/BoolTerm.h"
+#include "query/ColumnRef.h"
+#include "query/Predicate.h"
 #include "query/QueryContext.h"
 #include "query/SelectStmt.h"
+#include "query/SqlSQL2Tokens.h"
 #include "query/TestFactory.h"
+#include "query/ValueExpr.h"
+#include "query/ValueFactor.h"
+#include "query/WhereClause.h"
 
 // Boost unit test header
 #define BOOST_TEST_MODULE QueryRepr_1
 #include "boost/test/included/unit_test.hpp"
 
-namespace test = boost::test_tools;
+namespace lsst {
+namespace qserv {
+namespace query {
 
-using lsst::qserv::query::QueryContext;
-using lsst::qserv::query::SelectStmt;
-using lsst::qserv::query::TestFactory;
+namespace test = boost::test_tools;
 
 struct TestFixture {
     TestFixture(void) {}
-
     ~TestFixture(void) {}
 };
-
 
 BOOST_FIXTURE_TEST_SUITE(Suite, TestFixture)
 
@@ -56,7 +67,167 @@ BOOST_AUTO_TEST_CASE(Factory) {
     QueryContext::Ptr context = tf.newContext();
 }
 
+// Helper function to construct a BoolTerm tree from a specification
+// string and then render it down.  The input specifiation is RPN,
+// and the tree is constructed via a push down list.  The aim here
+// was to keep the specification parser as simple as possible...
+
+const std::string RenderedBoolTermFromRPN(const char **rpn)
+{
+    BoolTerm::PtrList pdl;
+    int opcount;
+
+    for(const char **t=rpn; *t; ++t) {
+        if (sscanf(*t, "%d", &opcount)==1) {
+            ;
+        } else if (!strcmp(*t, "AND")) {
+            AndTerm::Ptr andt = boost::make_shared<AndTerm>();
+            for(int i=0; i<opcount; ++i) {
+                andt->_terms.push_back(pdl.front());
+                pdl.pop_front();
+            }
+            pdl.push_front(andt);
+        } else if (!strcmp(*t, "OR")) {
+            OrTerm::Ptr ort = boost::make_shared<OrTerm>();
+            for(int i=0; i<opcount; ++i) {
+                ort->_terms.push_back(pdl.front());
+                pdl.pop_front();
+            }
+            pdl.push_front(ort);
+        } else {
+            PassTerm::Ptr pt = boost::make_shared<PassTerm>();
+            pt->_text = *t;
+            BoolFactor::Ptr bf = boost::make_shared<BoolFactor>();
+            bf->_terms.push_back(pt);
+            pdl.push_front(bf);
+        }
+    }
+
+    std::ostringstream str;
+    str << *(pdl.front());
+    return str.str();
+}
+
+BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
+
+    // AND
+    // +-- AND
+    // |   +-- A
+    // |   +-- B
+    // +-- C
+    const char *test0[] = {"C", "B", "A", "2", "AND", "2", "AND", NULL};
+    BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test0), "A AND B AND C");
+
+    // AND
+    // +-- OR
+    // |   +-- A
+    // |   +-- B
+    // +-- C
+    const char *test1[] = {"C", "B", "A", "2", "OR", "2", "AND", NULL};
+    BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test1), "(A OR B) AND C");
+
+    // OR
+    // +-- AND
+    // |   +-- A
+    // |   +-- B
+    // +-- C
+    const char *test2[] = {"C", "B", "A", "2", "AND", "2", "OR", NULL};
+    BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test2), "A AND B OR C");
+
+    // OR
+    // +-- OR
+    // |   +-- A
+    // |   +-- B
+    // +-- C
+    const char *test3[] = {"C", "B", "A", "2", "OR", "2", "OR", NULL};
+    BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test3), "A OR B OR C");
+
+    // AND
+    // +-- A
+    // +-- OR
+    // |   +-- B
+    // |   +-- C
+    // |   +-- D
+    // +-- E
+    const char *test4[] = {"E", "D", "C", "B", "3", "OR", "A", "3", "AND", NULL};
+    BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test4), "A AND (B OR C OR D) AND E");
+
+    // OR
+    // +-- A
+    // +-- AND
+    // |   +-- B
+    // |   +-- C
+    // |   +-- D
+    // +-- E
+    const char *test5[] = {"E", "D", "C", "B", "3", "AND", "A", "3", "OR", NULL};
+    BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test5), "A OR B AND C AND D OR E");
+
+}
+
+BOOST_AUTO_TEST_CASE(DM_737_REGRESSION) {
+
+    // Construct "refObjectId IS NULL OR flags<>2"
+    ColumnRef::Ptr cr0 = ColumnRef::newShared("", "", "refObjectId");
+    boost::shared_ptr<ValueFactor> vf0 = ValueFactor::newColumnRefFactor(cr0);
+    boost::shared_ptr<ValueExpr> ve0 = ValueExpr::newSimple(vf0);
+    NullPredicate::Ptr np0 = boost::make_shared<NullPredicate>();
+    np0->value = ve0;
+    BoolFactor::Ptr bf0 = boost::make_shared<BoolFactor>();
+    bf0->_terms.push_back(np0);
+    ColumnRef::Ptr cr1 = ColumnRef::newShared("", "", "flags");
+    boost::shared_ptr<ValueFactor> vf1 = ValueFactor::newColumnRefFactor(cr1);
+    boost::shared_ptr<ValueExpr> ve1 = ValueExpr::newSimple(vf1);
+    boost::shared_ptr<ValueFactor> vf2 = ValueFactor::newConstFactor("2");
+    boost::shared_ptr<ValueExpr> ve2 = ValueExpr::newSimple(vf2);
+    CompPredicate::Ptr cp0 = boost::make_shared<CompPredicate>();
+    cp0->left = ve1;
+    cp0->op = SqlSQL2Tokens::NOT_EQUALS_OP;
+    cp0->right = ve2;
+    BoolFactor::Ptr bf1 = boost::make_shared<BoolFactor>();
+    bf1->_terms.push_back(cp0);
+    OrTerm::Ptr ot0 = boost::make_shared<OrTerm>();
+    ot0->_terms.push_back(bf0);
+    ot0->_terms.push_back(bf1);
+
+    // Construct "WHERE foo!=bar AND baz<3.14159"
+    ColumnRef::Ptr cr2 = ColumnRef::newShared("", "", "foo");
+    boost::shared_ptr<ValueFactor> vf3 = ValueFactor::newColumnRefFactor(cr2);
+    boost::shared_ptr<ValueExpr> ve3 = ValueExpr::newSimple(vf3);
+    ColumnRef::Ptr cr3 = ColumnRef::newShared("", "", "bar");
+    boost::shared_ptr<ValueFactor> vf4 = ValueFactor::newColumnRefFactor(cr3);
+    boost::shared_ptr<ValueExpr> ve4 = ValueExpr::newSimple(vf4);
+    CompPredicate::Ptr cp1 = boost::make_shared<CompPredicate>();
+    cp1->left = ve3;
+    cp1->op = SqlSQL2Tokens::NOT_EQUALS_OP_ALT;
+    cp1->right = ve4;
+    BoolFactor::Ptr bf2 = boost::make_shared<BoolFactor>();
+    bf2->_terms.push_back(cp1);
+    ColumnRef::Ptr cr4 = ColumnRef::newShared("", "", "baz");
+    boost::shared_ptr<ValueFactor> vf5 = ValueFactor::newColumnRefFactor(cr4);
+    boost::shared_ptr<ValueExpr> ve5 = ValueExpr::newSimple(vf5);
+    boost::shared_ptr<ValueFactor> vf6 = ValueFactor::newConstFactor("3.14159");
+    boost::shared_ptr<ValueExpr> ve6 = ValueExpr::newSimple(vf6);
+    CompPredicate::Ptr cp2 = boost::make_shared<CompPredicate>();
+    cp2->left = ve5;
+    cp2->op = SqlSQL2Tokens::LESS_THAN_OP;
+    cp2->right = ve6;
+    BoolFactor::Ptr bf3 = boost::make_shared<BoolFactor>();
+    bf3->_terms.push_back(cp2);
+    AndTerm::Ptr at0 = boost::make_shared<AndTerm>();
+    at0->_terms.push_back(bf2);
+    at0->_terms.push_back(bf3);
+    boost::shared_ptr<WhereClause> wc0 = boost::make_shared<WhereClause>();
+    wc0->prependAndTerm(at0);
+
+    // Prepend the OR clause onto the WHERE as an additional AND term,
+    // render result, and check.  Should have parens around OR clause.
+    boost::shared_ptr<WhereClause> wc1 = wc0->clone();
+    wc1->prependAndTerm(ot0);
+    std::ostringstream str0;
+    str0 << *wc1;
+    BOOST_CHECK_EQUAL(str0.str(), "WHERE (refObjectId IS NULL OR flags<>2) AND foo!=bar AND baz<3.14159");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
-
-
+}}} // lsst::qserv::query


### PR DESCRIPTION
This fixes parethesization in rendering of BoolTerm trees.  A
BoolTerm::OpPrecedence enum was added, and the various subclasses
of BoolTerm were assigned relative precedence based on their operators
per the SQL92 standard.  The term list render helper
template function was extended to add parentheses when rendering a
contained term iff the operator of the contained term is of lower
precedence than that of the containing term.

A regression test for the reported test case, and some additional
unit test for parenthesis rendering were also added.