### PR TITLE
Add some missing virtual destructors

### DIFF
--- a/core/modules/global/ResourceUnit.h
+++ b/core/modules/global/ResourceUnit.h
@@ -102,6 +102,7 @@ private:
 
 class ResourceUnit::Checker {
 public:
+    virtual ~Checker() {};
     virtual bool operator()(ResourceUnit const& ru) = 0;
 };
 

--- a/core/modules/mysql/RowBuffer.h
+++ b/core/modules/mysql/RowBuffer.h
@@ -69,6 +69,8 @@ class RowBuffer {
 public:
     typedef boost::shared_ptr<RowBuffer> Ptr;
 
+    virtual ~RowBuffer() {};
+
     /// Fetch a number of bytes into a buffer. Return the number of bytes
     /// fetched. Returning less than bufLen does NOT indicate EOF.
     virtual unsigned fetch(char* buffer, unsigned bufLen) = 0;

--- a/core/modules/wbase/SendChannel.h
+++ b/core/modules/wbase/SendChannel.h
@@ -48,6 +48,8 @@ public:
     typedef boost::shared_ptr<ReleaseFunc> ReleaseFuncPtr;
     typedef long long Size;
 
+    virtual ~SendChannel() {};
+
     /// Send a buffer
     virtual bool send(char const* buf, int bufLen) = 0;
 


### PR DESCRIPTION
(@andy-slac, @wangd: I think we should probably fix these?  If you guys agree, I'll open a ticket, attach this cl and push it in?)

The compiler was flagging with warnings at a few places where we
had class hierarchies without virtual destructors.  Added empty
virtual destructor the the base classes in each of these cases
for safety.