### PR TITLE
Add createTable() method to WorkerMgmt class.

### DIFF
--- a/admin/python/lsst/qserv/admin/qservAdminException.py
+++ b/admin/python/lsst/qserv/admin/qservAdminException.py
@@ -39,6 +39,7 @@ QservAdminException = produceExceptionClass('QservAdminException', [
     (3025, "MISSING_PARAM",     "Missing parameter."),
     (3030, "TB_EXISTS",         "Table already exists."),
     (3035, "TB_DOES_NOT_EXIST", "Table does not exist."),
+    (3036, "TB_SCHEMA_MISSING", "Table schema is missing from CSS."),
     (3040, "WRONG_PARAM",       "Unrecognized parameter."),
     (3045, "WRONG_PARAM_VAL",   "Unrecognized value for parameter."),
     (3050, "VERSION_MISMATCH",  "CSS schema/data version does not match current SW version."),


### PR DESCRIPTION
This new method follows the same pattern as createDb() method added
earlier. It takes the arguments which select a subset of worker nodes,
arguments that define mysql connection options (these are likely to be
replaced in the future) and database/table names. Schema description
must be defined in CSS prior to calling this method.