### PR TITLE
Improve strictness to reject queries with garbage after a valid query.

### DIFF
--- a/core/modules/parser/ParseException.cc
+++ b/core/modules/parser/ParseException.cc
@@ -47,5 +47,17 @@ ParseException::ParseException(char const* msg, antlr::RefAST subTree)
 ParseException::ParseException(std::string const& msg, antlr::RefAST subTree)
     : std::runtime_error(msg + ":" + walkSiblingString(subTree))
 {}
+ParseException::ParseException(std::string const& msg,
+                               antlr::RecognitionException const&)
+    : std::runtime_error(msg)
+{}
+ParseException::ParseException(std::string const& msg,
+                               antlr::ANTLRException const&)
+    : std::runtime_error(msg)
+{}
+
+ParseException::ParseException(Bug const& b)
+    : std::runtime_error(std::string("Bug during parse:") + b.what()) {
+}
 
 }}} // namespace lsst::qserv::parser

--- a/core/modules/parser/ParseException.h
+++ b/core/modules/parser/ParseException.h
@@ -35,6 +35,15 @@
 // Third-party headers
 #include <antlr/AST.hpp>
 
+// Qserv headers
+#include "global/Bug.h"
+
+// Forward
+namespace antlr {
+class ANTLRException;
+class RecognitionException;
+}
+
 namespace lsst {
 namespace qserv {
 namespace parser {
@@ -46,6 +55,11 @@ class ParseException : public std::runtime_error {
 public:
     ParseException(char const* msg, antlr::RefAST subTree);
     ParseException(std::string const& msg, antlr::RefAST subTree);
+    /// Lexer errors don't have a subtree to reference.
+    ParseException(std::string const& msg, antlr::RecognitionException const&);
+    /// ANTLR errors have almost nothing inside
+    ParseException(std::string const& msg, antlr::ANTLRException const&);
+    explicit ParseException(Bug const& b);
 protected:
     explicit ParseException(std::string const& msg)
         : std::runtime_error(msg) {}

--- a/core/modules/parser/SqlSQL2.g
+++ b/core/modules/parser/SqlSQL2.g
@@ -309,6 +309,11 @@ boost::shared_ptr<VoidTwoRefFunc> _qservFctSpecHandler;
 // ---------------
 // Top-level rules
 // ---------------
+// Qserv-supported statement, requires end of file, no statement chaining
+qserv_stmt : 
+      select_stmt (SEMICOLON)* EOF
+    ;
+
 //{ Rule #--- <sql_stmt> is a proxy rule for all types of sql statements
 sql_stmt : 
 	  sql_data_stmt 


### PR DESCRIPTION
Extend the grammar to include a production for supported qserv queries, and
modify the code to use this production instead of a generic sql statement.
Extend ParseException to be constructed with more ANTLR exceptions