### PR TITLE
Fix libxrdoss to allow cmsd server startup

### DIFF
--- a/core/modules/SConscript
+++ b/core/modules/SConscript
@@ -56,11 +56,10 @@ allModules = """ccontrol css czar global log mysql obsolete
 # Products
 def pyDistRelative(env, module):
     return os.path.join(env['python_relative_prefix'],"lsst","qserv",module)
-shProducts = { "xrdoss" : {'mods' : """wlog mysql obsolete sql util
-                                       wbase wconfig
-                                       xrdoss wpublish""".split(),
-                           'libs' : """boost_regex boost_signals boost_thread log log4cxx
-                                       mysqlclient_r ssl crypto XrdSsi""".split(),
+shProducts = { "xrdoss" : {'mods' : """global mysql obsolete sql util wconfig
+                                       wpublish xrdoss""".split(),
+                           'libs' : """boost_regex boost_thread crypto log
+                                       log4cxx mysqlclient_r ssl XrdSsi""".split(),
                            'distDir' : 'lib'
                            },
 

--- a/core/modules/xrdoss/QservOss.cc
+++ b/core/modules/xrdoss/QservOss.cc
@@ -41,12 +41,18 @@
 
 // Third-party headers
 #include "boost/make_shared.hpp"
+#include "XrdSys/XrdSysError.hh"
 #include "XrdSys/XrdSysLogger.hh"
 
 // Qserv headers
 #include "obsolete/QservPath.h"
 #include "wpublish/ChunkInventory.h"
 #include "xrdsvc/XrdName.h"
+
+namespace XrdSsi
+{
+    extern XrdSysError Log;
+}
 
 
 namespace {
@@ -289,6 +295,7 @@ XrdOssGetStorageSystem(XrdOss       *native_oss,
                        const char   *config_fn,
                        const char   *parms)
 {
+    XrdSsi::Log.logger(Logger);
     lsst::qserv::xrdoss::QservOss* oss =
         lsst::qserv::xrdoss::QservOss::getInstance();
     lsst::qserv::xrdsvc::XrdName x;
@@ -303,3 +310,7 @@ XrdOssGetStorageSystem(XrdOss       *native_oss,
 }
 } // extern C
 
+// As recommended by XrdOss/XrdOss.h, declare the version.
+#include "XrdVersion.hh"
+// Compiler complains if we terminate with a ';'
+XrdVERSIONINFO(XrdOssGetStorageSystem,QservOssGeneric)

--- a/core/modules/xrdoss/SConscript.test
+++ b/core/modules/xrdoss/SConscript.test
@@ -11,7 +11,7 @@ import itertools
 
 programs = []
 unbuntuDeps = ["pthread"]
-extDeps = unbuntuDeps + "boost_regex boost_system boost_thread mysqlclient_r protobuf ssl crypto log log4cxx XrdClient XrdUtils".split()
+extDeps = unbuntuDeps + "boost_regex boost_system boost_thread mysqlclient_r protobuf ssl crypto log log4cxx XrdClient XrdSsi XrdUtils".split()
 
 modDeps = 'mysql obsolete sql wbase wconfig wpublish util'.split() # deps on other modules
 deps = itertools.chain(*map(lambda m: defaultTgts[m], modDeps))


### PR DESCRIPTION
- Link missing shared libs in libxrdoss build procedure
  Some shared libraries were missing at runtime.

- Add version declaration for QservOss for XrdOssGetStorageSystem

- Fix logger initialization in QservOss