### PR TITLE
Support deletion of nodes from CSS (DM-2411).

### DIFF
--- a/admin/bin/qserv-admin.py
+++ b/admin/bin/qserv-admin.py
@@ -109,6 +109,7 @@ class CommandParser(object):
         self._initLogging()
         self._funcMap = {
             'CREATE':  self._parseCreate,
+            'DELETE':  self._parseDelete,
             'DROP':    self._parseDrop,
             'DUMP':    self._parseDump,
             'EXIT':    self._justExit,
@@ -128,6 +129,7 @@ class CommandParser(object):
     CREATE TABLE <dbName>.<tableName> LIKE <dbName2>.<tableName2>;
     CREATE NODE <nodeName> <key=value ...>;  # keys: type, host, runDir, mysqlConn, state
     UPDATE NODE <nodeName> state=value;  # value: ACTIVE, INACTIVE
+    DELETE NODE <nodeName>;
     DROP DATABASE <dbName>;
     DROP EVERYTHING;
     DUMP EVERYTHING [<outFile>];
@@ -293,6 +295,21 @@ class CommandParser(object):
                                       "DROP TABLE")
         elif t == 'EVERYTHING':
             self._impl.dropEverything()
+        else:
+            raise QservAdminException(QservAdminException.BAD_CMD)
+
+    def _parseDelete(self, tokens):
+        """
+        Subparser - handles all DELETE requests.
+        Throws KvException, QservAdminException.
+        """
+        t = tokens[0].upper()
+        l = len(tokens)
+        if t == 'NODE':
+            if l != 2:
+                raise QservAdminException(QservAdminException.BAD_CMD,
+                                    "unexpected number of arguments")
+            self._impl.deleteNode(tokens[1])
         else:
             raise QservAdminException(QservAdminException.BAD_CMD)
 

--- a/admin/python/lsst/qserv/admin/qservAdminException.py
+++ b/admin/python/lsst/qserv/admin/qservAdminException.py
@@ -46,5 +46,6 @@ QservAdminException = produceExceptionClass('QservAdminException', [
     (3055, "VERSION_MISSING",   "CSS schema/data version does not exist."),
     (3060, "NODE_EXISTS",       "Node already exists."),
     (3065, "NODE_DOES_NOT_EXIST", "Node does not exist."),
+    (3070, "NODE_DELETE_FAILURE", "Node cannot be deleted because it is used by one or more chunks."),
     (9998, "NOT_IMPLEMENTED",   "Feature not implemented yet."),
     (9999, "INTERNAL",          "Internal error.")])

--- a/core/modules/css/python/kvInterface.py
+++ b/core/modules/css/python/kvInterface.py
@@ -251,7 +251,7 @@ class KvInterface(object):
             children = self.getChildren(p)
             if p == "/": p = "" # Prevent // in concatenated path.
             for child in children:
-                self.visitPrefix(p + "/" + child, nodeFunc, acceptFunc)
+                self.visitPostfix(p + "/" + child, nodeFunc, acceptFunc)
             nodeFunc(p)
         except NoNodeError:
             self._logger.warning("Caught NoNodeError, someone deleted node just now")
@@ -649,7 +649,7 @@ class KvInterfaceMem(KvInterface):
         @raise     Raise KvException if the key doesn't exist.
         """
         if recursive:
-            self.visitPostfix(k, lambda p: self._kvi.deleteKey(k))
+            self.visitPostfix(k, lambda p: self._kvi.deleteKey(p))
         else:
             self._kvi.deleteKey(k)
 


### PR DESCRIPTION
Extended QservAdmin interface to allow deletion of existing nodes. Node
can only be deleted if there are no chunks in CSS assigned to this node.
Also added protection (lock) for simultaneous updates of /NODES data.
qserv-admin script adds new command DELETE NODE ... which uses this new
method. Added unit test for deletion too.
