### PR TITLE
Use InnoDB engine for secondary index table (DM-2617)

### DIFF
--- a/admin/python/lsst/qserv/admin/dataLoader.py
+++ b/admin/python/lsst/qserv/admin/dataLoader.py
@@ -895,8 +895,9 @@ class DataLoader(object):
                 idxColType = row[1]
                 break
 
-        # make a table
+        # make a table, InnoDB engine is required for scalability
         q = "CREATE TABLE {table} ({column} {type} NOT NULL PRIMARY KEY, chunkId INT, subChunkId INT)"
+        q += " ENGINE = INNODB"
         q = q.format(table=metaTable, column=idxCol, type=idxColType)
         self._log.debug('query: %s', q)
         czarCursor.execute(q)
@@ -942,6 +943,7 @@ class DataLoader(object):
 
             wCursor.close()
 
+        self.mysql.commit()
         czarCursor.close()
 
     def _makeIndexSingleNode(self, database, table, metaTable, idxCol):
@@ -958,4 +960,5 @@ class DataLoader(object):
             self._log.debug('query: %s', q)
             cursor.execute(q)
 
+        self.mysql.commit()
         cursor.close()

--- a/admin/templates/configuration/etc/my.cnf
+++ b/admin/templates/configuration/etc/my.cnf
@@ -12,6 +12,11 @@ symbolic-links=0
 tmp_table_size=4G
 max_heap_table_size=4G
 
+# enable InnoDB support via plugin
+ignore-builtin-innodb
+plugin-load=innodb=ha_innodb_plugin.so
+innodb_file_per_table=1
+
 #
 # Advanced logging
 #


### PR DESCRIPTION
This is a trivial fix to change engine type for secondary index table
from default (myisam) to InnoDB. By default in our configuration mysqld
is started without InnoDB support so it always makes myisam table even
if explicit encine type provided. I updated mysqld config to enable
innodb plugin so that now it makes innodb tables. Also I enabled
innodb_file_per_table in config as global tablespace is hard to manage.