### PR TITLE
Include <unistd.h> for gcc 4.9.2

### DIFF
--- a/core/modules/qdisp/TransactionSpec.cc
+++ b/core/modules/qdisp/TransactionSpec.cc
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <fstream>
 #include <sys/mman.h>
+#include <unistd.h>
 
 namespace {
 int seekMagic(int start, char* buffer, int term) {

--- a/core/modules/util/MmapFile.cc
+++ b/core/modules/util/MmapFile.cc
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <iostream>
 #include <sys/mman.h>
+#include <unistd.h>
 
 namespace lsst {
 namespace qserv {

--- a/core/modules/wbase/SendChannel.cc
+++ b/core/modules/wbase/SendChannel.cc
@@ -25,6 +25,7 @@
 // System headers
 #include <iostream>
 #include <sstream>
+#include <unistd.h>
 #include <vector>
 
 // Third-party headers


### PR DESCRIPTION
Build under gcc 4.9.2 was complaining about undefined close(),
read(), etc. in a few places.