### PR TITLE
DM-2729: Fix a few more g++ 4.9.2 compatos

### DIFF
--- a/core/modules/SConscript
+++ b/core/modules/SConscript
@@ -44,6 +44,9 @@ if not env.GetOption('clean'):
 
     env.Append(CPPFLAGS=["-D_FILE_OFFSET_BITS=64", "-fPIC", "-std=c++0x",
                          "-Wno-unused-local-typedefs"])
+
+    env.Append(LINKFLAGS=["-pthread"])
+
     state.log.debug("Scons env:\n" + env.Dump())
 
 # all modules

--- a/core/modules/util/DynamicWorkQueue.cc
+++ b/core/modules/util/DynamicWorkQueue.cc
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <stdexcept>
 #include <sys/time.h>
+#include <thread>
 
 // Third-party headers
 #include <boost/scoped_ptr.hpp>

--- a/core/modules/util/DynamicWorkQueue.h
+++ b/core/modules/util/DynamicWorkQueue.h
@@ -25,10 +25,10 @@
 #define LSST_QSERV_CCONTROL_DYNAMICWORKQUEUE_H
 
 // System headers
+#include <condition_variable>
 #include <map>
 #include <mutex>
 #include <set>
-#include <thread>
 
 namespace lsst {
 namespace qserv {

--- a/core/modules/util/Thread.h
+++ b/core/modules/util/Thread.h
@@ -26,46 +26,16 @@
 
 // System headers
 #include <cassert>
+#include <condition_variable>
+#include <mutex>
 #include <set>
 
 // Third-party headers
 #include "XrdSys/XrdSysPthread.hh"
 
-#ifdef DO_NOT_USE_BOOST
-#else
-#include <mutex>
-#include <thread>
-#endif
-
 namespace lsst {
 namespace qserv {
 namespace util {
-
-#ifdef DO_NOT_USE_BOOST
-/// xrootd-dependent unique_lock
-class UniqueLock { // scoped lock.
-public:
-    explicit UniqueLock(XrdSysMutex& m) : _m(m) {
-	_m.Lock();
-    }
-    ~UniqueLock() { _m.UnLock(); }
-private:
-    XrdSysMutex& _m;
-};
-
-/// An xrootd-dependent semaphore wrapper
-class Semaphore {
-public:
-    explicit Semaphore(int count=0) : _sema(count) {}
-    inline void proberen() { _sema.Wait(); }
-    inline void verhogen() { _sema.Post(); }
-    inline void get() { proberen(); }
-    inline void release() { verhogen(); }
-private:
-    XrdSysSemaphore _sema;
-};
-
-#else
 
 class Semaphore {
 public:
@@ -103,7 +73,6 @@ private:
     int _count;
 };
 
-#endif
 
 /// An xrootd-dependent thread library that
 /// roughly follows std::thread semantics.

--- a/core/modules/util/WorkQueue.cc
+++ b/core/modules/util/WorkQueue.cc
@@ -32,7 +32,7 @@
 // System headers
 #include <iostream>
 #include <sstream>
-
+#include <thread>
 
 namespace lsst {
 namespace qserv {

--- a/core/modules/util/WorkQueue.h
+++ b/core/modules/util/WorkQueue.h
@@ -24,10 +24,10 @@
 #define LSST_QSERV_UTIL_WORKQUEUE_H
 
 // System headers
+#include <condition_variable>
 #include <deque>
 #include <memory>
 #include <mutex>
-#include <thread>
 
 namespace lsst {
 namespace qserv {

--- a/core/modules/wbase/Base.h
+++ b/core/modules/wbase/Base.h
@@ -109,13 +109,9 @@ private:
     typedef std::deque<Fragment> FragmentDeque;
     FragmentDeque _buffers;
     StringBufferOffset _totalSize;
-#if DO_NOT_USE_BOOST
-    XrdSysMutex _mutex;
-#else
     std::mutex _mutex;
-#endif
     std::stringstream _ss;
-    };
+};
 
 class StringBuffer2 {
 public:
@@ -130,11 +126,7 @@ public:
     void reset();
 private:
     void _setSize(unsigned size);
-#if DO_NOT_USE_BOOST
-    XrdSysMutex _mutex;
-#else
     std::mutex _mutex;
-#endif
     char* _buffer;
     unsigned _bufferSize;
     unsigned _bytesWritten;
@@ -142,10 +134,6 @@ private:
 
 }}} // namespace lsst::qserv::wbase
 
-#if DO_NOT_USE_BOOST
-typedef lsst::qserv::worker::PosFormat Pformat;
-#else
 typedef boost::format Pformat;
-#endif
 
 #endif // LSST_QSERV_WBASE_BASE_H

--- a/core/modules/wconfig/Config.cc
+++ b/core/modules/wconfig/Config.cc
@@ -30,6 +30,7 @@
 // System headers
 #include <cassert>
 #include <sstream>
+#include <unistd.h>
 
 // Qserv headers
 #include "mysql/MySqlConfig.h"

--- a/core/modules/xrdsvc/ChannelStream.h
+++ b/core/modules/xrdsvc/ChannelStream.h
@@ -24,9 +24,9 @@
 #define LSST_QSERV_XRDSVC_CHANNELSTREAM_H
 
 // System headers
+#include <condition_variable>
 #include <deque>
 #include <mutex>
-#include <thread>
 
 // Third-party headers
 #include "XrdSsi/XrdSsiErrInfo.hh" // required by XrdSsiStream


### PR DESCRIPTION
- Fix some poor #include hygiene (include <condition_variable>
explicitly instead of <thread>, include <unistd.h> when necessary).

- g++ 4.9.2 requires "-pthread" linker option explicitly when using
std::thread

- Clean up some outdated '#ifdef DO_NOT_USE_BOOST' in Base.{cc,h}