### PR TITLE
Change qserv_testdata repository location

### DIFF
--- a/doc/source/devel/quick-start-devel.rst
+++ b/doc/source/devel/quick-start-devel.rst
@@ -82,7 +82,7 @@ If you want to modify tests datasets, please clone Qserv test data repository :
 
    cd ~/src/
    # authenticated access (require a ssh key) :
-   git clone ssh://git@git.lsstcorp.org/LSST/DMS/testdata/qserv_testdata.git
+   git clone ssh://git@github.com/LSST/qserv_testdata
 
 In order to test it with your Qserv version :
 


### PR DESCRIPTION
Quick start guide for developers still points qserv_testdata to the old repo, it needs to be changed to the new github location.