### PR TITLE
Adding test suite for SqlTransaction class (DM-3090)

### DIFF
--- a/core/modules/qmeta/QMetaTransaction.cc
+++ b/core/modules/qmeta/QMetaTransaction.cc
@@ -57,8 +57,7 @@ QMetaTransaction::~QMetaTransaction() {
     // instead of just destroying SqlTransaction instance we call abort and see
     // if error happens. We cannot throw here but we can print a message.
     if (_trans.isActive()) {
-        _trans.abort(_errObj);
-        if (_errObj.isSet()) {
+        if (not _trans.abort(_errObj)) {
             LOGF(_logger, LOG_LVL_ERROR, "Failed to abort transaction: mysql error: (%1%) %2%" %
                  _errObj.errNo() % _errObj.errMsg());
         }
@@ -68,8 +67,7 @@ QMetaTransaction::~QMetaTransaction() {
 /// Explicitly commit transaction, throws SqlError for errors.
 void
 QMetaTransaction::commit() {
-    _trans.commit(_errObj);
-    if (_errObj.isSet()) {
+    if (not _trans.commit(_errObj)) {
         LOGF(_logger, LOG_LVL_ERROR, "Failed to commit transaction: mysql error: (%1%) %2%" %
              _errObj.errNo() % _errObj.errMsg());
         throw SqlError(ERR_LOC, _errObj);
@@ -79,8 +77,7 @@ QMetaTransaction::commit() {
 /// Explicitly abort transaction, throws SqlError for errors.
 void
 QMetaTransaction::abort() {
-    _trans.abort(_errObj);
-    if (_errObj.isSet()) {
+    if (not _trans.abort(_errObj)) {
         LOGF(_logger, LOG_LVL_ERROR, "Failed to abort transaction: mysql error: (%1%) %2%" %
              _errObj.errNo() % _errObj.errMsg());
         throw SqlError(ERR_LOC, _errObj);

--- a/core/modules/sql/SConscript.test
+++ b/core/modules/sql/SConscript.test
@@ -20,4 +20,8 @@ p = env.Program(['testSqlConnection.cc'] + deps,
                 LIBS=findLibs(extDeps))
 programs.append(p)
 
+p = env.Program(['testSqlTransaction.cc'] + deps,
+                LIBS=findLibs(extDeps))
+programs.append(p)
+
 Return('programs')

--- a/core/modules/sql/SqlTransaction.cc
+++ b/core/modules/sql/SqlTransaction.cc
@@ -49,17 +49,17 @@ SqlTransaction::~SqlTransaction() {
 }
 
 // Explicitly commit transaction
-void
-SqlTransaction::commit(SqlErrorObject& errObj) {
+bool SqlTransaction::commit(SqlErrorObject& errObj) {
     _conn.runQuery("COMMIT", errObj);
     _doCleanup = false;
+    return not errObj.isSet();
 }
 
 // Explicitly abort transaction
-void
-SqlTransaction::abort(SqlErrorObject& errObj) {
+bool SqlTransaction::abort(SqlErrorObject& errObj) {
     _conn.runQuery("ROLLBACK", errObj);
     _doCleanup = false;
+    return not errObj.isSet();
 }
 
 }}} // namespace lsst::qserv::sql

--- a/core/modules/sql/SqlTransaction.h
+++ b/core/modules/sql/SqlTransaction.h
@@ -79,11 +79,11 @@ public:
     /// Destructor aborts transaction if it has not been committed
     ~SqlTransaction();
 
-    /// Explicitly commit transaction
-    void commit(SqlErrorObject& errObj);
+    /// Explicitly commit transaction. Return false if operation fails.
+    bool commit(SqlErrorObject& errObj);
 
-    /// Explicitly abort transaction
-    void abort(SqlErrorObject& errObj);
+    /// Explicitly abort transaction. Return false if operation fails.
+    bool abort(SqlErrorObject& errObj);
 
     /// Returns true if transaction is active (no explicit commit/abort was called).
     bool isActive() const { return _doCleanup; }

--- a/core/modules/sql/testSqlTransaction.cc
+++ b/core/modules/sql/testSqlTransaction.cc
@@ -1,0 +1,259 @@
+/*
+ * LSST Data Management System
+ * Copyright 2015 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Class header
+#include "SqlTransaction.h"
+
+// System headers
+#include <iostream>
+#include <string>
+#include <unistd.h> // for getpass
+
+// Third-party headers
+
+// Qserv headers
+#include "sql/SqlConnection.h"
+#include "sql/SqlErrorObject.h"
+#include "sql/SqlResults.h"
+
+// Local headers
+
+// Boost unit test header
+#define BOOST_TEST_MODULE SqlTransaction_1
+#include "boost/test/included/unit_test.hpp"
+
+using lsst::qserv::mysql::MySqlConfig;
+using namespace lsst::qserv::sql;
+
+#define DB_NAME "testSqlTransX675sdrt"
+#define TABLE_NAME "TEST123"
+#define FULL_TABLE_NAME DB_NAME "." TABLE_NAME
+
+namespace {
+
+
+struct TestDBGuard {
+    TestDBGuard() {
+        sqlConfig.hostname = "";
+        sqlConfig.port = 0;
+        sqlConfig.username = "root";
+        sqlConfig.password = getpass("Enter mysql root password: ");
+        std::cout << "Enter mysql socket: ";
+        std::cin >> sqlConfig.socket;
+        sqlConfig.dbName = DB_NAME;
+
+        // need config without database name
+        MySqlConfig sqlConfigLocal = sqlConfig;
+        sqlConfigLocal.dbName = "";
+        SqlConnection sqlConn(sqlConfigLocal);
+
+        SqlErrorObject errObj;
+
+        // create database
+        sqlConn.createDb(DB_NAME, errObj);
+    }
+
+    ~TestDBGuard() {
+        SqlConnection sqlConn(sqlConfig);
+        SqlErrorObject errObj;
+        sqlConn.dropDb(sqlConfig.dbName, errObj);
+    }
+
+    MySqlConfig sqlConfig;
+};
+
+}
+
+struct PerTestFixture {
+    PerTestFixture() : sqlConn(testDB.sqlConfig) {
+
+        // create table (must be InnoDB)
+        std::string query = "CREATE TABLE " FULL_TABLE_NAME " (X INT, Y INT) ENGINE=InnoDB";
+        SqlErrorObject errObj;
+        sqlConn.runQuery(query, errObj);
+    }
+    ~PerTestFixture() {
+        // drop table
+        std::string query = "DROP TABLE " FULL_TABLE_NAME;
+        SqlErrorObject errObj;
+        sqlConn.runQuery(query, errObj);
+    }
+
+    static TestDBGuard testDB;
+    SqlConnection sqlConn;
+};
+
+TestDBGuard PerTestFixture::testDB;
+
+BOOST_FIXTURE_TEST_SUITE(SqlTransactionTestSuite, PerTestFixture)
+
+BOOST_AUTO_TEST_CASE(riiaTest) {
+
+    // do transactions riia-style, they automatically abort
+
+    for (int i = 0; i != 3; ++ i){
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string i_str = boost::lexical_cast<std::string>(i);
+        std::string j_str = boost::lexical_cast<std::string>(i*100);
+        std::string query = "INSERT INTO " FULL_TABLE_NAME " (X, Y) VALUES(" + i_str + ", " + j_str + ")";
+        BOOST_CHECK(sqlConn.runQuery(query, errObj));
+
+        BOOST_CHECK(trans.isActive());
+    }
+
+    {
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string query = "SELECT COUNT(*) FROM " FULL_TABLE_NAME;
+        SqlResults sqlRes;
+        BOOST_CHECK(sqlConn.runQuery(query, sqlRes, errObj));
+        std::vector<std::string> rows;
+        BOOST_CHECK(sqlRes.extractFirstColumn(rows, errObj));
+        BOOST_CHECK_EQUAL(rows.size(), 1U);
+        BOOST_CHECK_EQUAL(rows[0], "0");
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(commitTest) {
+
+    // explicit commit
+
+    for (int i = 0; i != 3; ++ i){
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string i_str = boost::lexical_cast<std::string>(i);
+        std::string j_str = boost::lexical_cast<std::string>(i*100);
+        std::string query = "INSERT INTO " FULL_TABLE_NAME " (X, Y) VALUES(" + i_str + ", " + j_str + ")";
+        BOOST_CHECK(sqlConn.runQuery(query, errObj));
+
+        BOOST_CHECK(trans.isActive());
+        BOOST_CHECK(trans.commit(errObj));
+        BOOST_CHECK(not trans.isActive());
+    }
+
+    {
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string query = "SELECT COUNT(*) FROM " FULL_TABLE_NAME;
+        SqlResults sqlRes;
+        BOOST_CHECK(sqlConn.runQuery(query, sqlRes, errObj));
+        std::vector<std::string> rows;
+        BOOST_CHECK(sqlRes.extractFirstColumn(rows, errObj));
+        BOOST_CHECK_EQUAL(rows.size(), 1U);
+        BOOST_CHECK_EQUAL(rows[0], "3");
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(abortTest) {
+
+    // explicit abort
+
+    for (int i = 0; i != 3; ++ i){
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string i_str = boost::lexical_cast<std::string>(i);
+        std::string j_str = boost::lexical_cast<std::string>(i*100);
+        std::string query = "INSERT INTO " FULL_TABLE_NAME " (X, Y) VALUES(" + i_str + ", " + j_str + ")";
+        BOOST_CHECK(sqlConn.runQuery(query, errObj));
+
+        BOOST_CHECK(trans.isActive());
+        BOOST_CHECK(trans.abort(errObj));
+        BOOST_CHECK(not trans.isActive());
+    }
+
+    {
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string query = "SELECT COUNT(*) FROM " FULL_TABLE_NAME;
+        SqlResults sqlRes;
+        BOOST_CHECK(sqlConn.runQuery(query, sqlRes, errObj));
+        std::vector<std::string> rows;
+        BOOST_CHECK(sqlRes.extractFirstColumn(rows, errObj));
+        BOOST_CHECK_EQUAL(rows.size(), 1U);
+        BOOST_CHECK_EQUAL(rows[0], "0");
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(mixedTest) {
+
+    // explicit abort/commit
+
+    for (int i = 0; i != 10; ++ i){
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string i_str = boost::lexical_cast<std::string>(i);
+        std::string j_str = boost::lexical_cast<std::string>(i*100);
+        std::string query = "INSERT INTO " FULL_TABLE_NAME " (X, Y) VALUES(" + i_str + ", " + j_str + ")";
+        BOOST_CHECK(sqlConn.runQuery(query, errObj));
+
+        BOOST_CHECK(trans.isActive());
+        if (i % 2) {
+            BOOST_CHECK(trans.commit(errObj));
+        } else {
+            BOOST_CHECK(trans.abort(errObj));
+        }
+        BOOST_CHECK(not trans.isActive());
+    }
+
+    {
+        SqlErrorObject errObj;
+
+        SqlTransaction trans(sqlConn, errObj);
+        BOOST_CHECK(not errObj.isSet());
+
+        std::string query = "SELECT COUNT(*) FROM " FULL_TABLE_NAME;
+        SqlResults sqlRes;
+        BOOST_CHECK(sqlConn.runQuery(query, sqlRes, errObj));
+        std::vector<std::string> rows;
+        BOOST_CHECK(sqlRes.extractFirstColumn(rows, errObj));
+        BOOST_CHECK_EQUAL(rows.size(), 1U);
+        BOOST_CHECK_EQUAL(rows[0], "5");
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is not really a unit test as it needs database instance up and
running.

Small change to SqlTransaction class itself, abort() and commit() now
return bool value which is true if operation succeeds, this matches
better other interfaces in this package.