### PR TITLE
Include sciSQL in master node configuration

### DIFF
--- a/admin/bin/qserv-configure.py
+++ b/admin/bin/qserv-configure.py
@@ -364,11 +364,8 @@ class Configurator(object):
                 if config['qserv']['node_type'] in ['master']:
                     _LOG.info(
                         "Master instance: not configuring " +
-                        "%s and %s",
-                        configure.SCISQL,
-                        configure.WORKER
+                        "{0}".format(configure.WORKER)
                     )
-                    component_cfg_steps.remove(configure.SCISQL)
                     component_cfg_steps.remove(configure.WORKER)
                 elif config['qserv']['node_type'] in ['worker']:
                     _LOG.info(

--- a/admin/python/lsst/qserv/admin/configure.py
+++ b/admin/python/lsst/qserv/admin/configure.py
@@ -200,13 +200,10 @@ def _get_template_params():
 
         testdata_dir = os.getenv('QSERV_TESTDATA_DIR', "NOT-AVAILABLE # please set environment variable QSERV_TESTDATA_DIR if needed")
 
-        if config['qserv']['node_type'] in ['mono', 'worker']:
-            scisql_dir = os.environ.get('SCISQL_DIR')
-            if scisql_dir is None:
-                _LOG.fatal("Mono-node or worker install : sciSQL is missing, please install it and set SCISQL_DIR environment variable.")
-                sys.exit(1)
-        else:
-            scisql_dir = "NOT-AVAILABLE # please set environment variable SCISQL_DIR if needed"
+        scisql_dir = os.environ.get('SCISQL_DIR')
+        if scisql_dir is None:
+            _LOG.fatal("sciSQL install : sciSQL is missing, please install it and set SCISQL_DIR environment variable.")
+            sys.exit(1)
 
         python_bin_list = which("python")
         if python_bin_list:

--- a/doc/source/HOW-TO/cluster-configuration.rst
+++ b/doc/source/HOW-TO/cluster-configuration.rst
@@ -39,6 +39,7 @@ Configure master and worker nodes
    *Note: secret file is read when qserv-wmgr client starts*
 
    :code:`scp <qserv-run directory>/etc/wmgr.secret <worker1 hostName>:<qserv-run directory>/etc/wmgr.secret`
+
    :code:`scp <qserv-run directory>/etc/wmgr.secret <worker2 hostName>:<qserv-run directory>/etc/wmgr.secret`
 
 4. Start services on master and every worker:
@@ -49,7 +50,7 @@ Configure master and worker nodes
 
    :code:`mysql -S <qserv-run directory>/var/lib/mysql/mysql.sock -uroot -p`
 
-   .. code-block::
+   .. code-block:: sql
 
      GRANT USAGE ON *.* TO 'qsmaster'@'<master hostName>';
      GRANT SELECT ON `mysql`.* TO 'qsmaster'@'<master hostName>';
@@ -60,7 +61,7 @@ Configure master and worker nodes
 
    :code:`qserv-admin.py`
 
-   .. code-block::
+   .. code-block:: none
 
      CREATE NODE worker1 type=worker port=5012 host=<worker1 hostName>;
      CREATE NODE worker2 type=worker port=5012 host=<worker2 hostName>;
@@ -70,6 +71,12 @@ Run Integration Test
 
 .. code-block:: bash
 
-  qserv-check-integration.py --case=01 --load -M --mode=qserv
-  qserv-check-integration.py --case=02 --load -M --mode=qserv
+  qserv-test-integration.py
+
+Or for individual test cases:
+
+.. code-block:: bash
+
+  qserv-check-integration.py --case=01 --load
+  qserv-check-integration.py --case=02 --load
   ...


### PR DESCRIPTION
Running mysql tests in multi-node integration tests require adding scisql to the master node configuration.