### PR TITLE
Fix worker side sub-chunk reference counting.

### DIFF
--- a/core/modules/wdb/ChunkResource.cc
+++ b/core/modules/wdb/ChunkResource.cc
@@ -325,8 +325,8 @@ public:
                 if(si->second == 0) {
                     discardable.push_back(ScTable(db, _chunkId,
                                                   ti->first,
-                                                  si->second));
-                    mapDiscardable.push_back(si->second);
+                                                  si->first));
+                    mapDiscardable.push_back(si->first);
                 } else if(si->second < 0) {
                     throw Bug("ChunkResource ChunkEntry::flush: Invalid negative use count when flushing subchunks");
                 }


### PR DESCRIPTION
The code for tracking sub-chunks in use by a worker was passing
sub-chunk reference counts where sub-chunk IDs are expected
(both are of type int). Because sub-chunk tables are supposed to
be deleted when their reference counts reach 0, the effect is that
sub-chunk 0 is repeatedly dropped, and eventually an assertion gets
triggered when sub-chunk 0 is missing but expected to be present.