### PR TITLE
DM-3584: Port Qserv to OS/x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ qserv_client_info.log
 .project
 RemoteSystemTempFiles/
 \#*\#
+_build.log
+_build.sh
+_build.tags
+

--- a/core/modules/SConscript
+++ b/core/modules/SConscript
@@ -98,7 +98,7 @@ shProducts = { "xrdoss" : {'mods' : """global mysql sql util wconfig
 
 # external libs for shmods
 shmodLibs = {
-  'css': ['log', 'boost_system', 'boost_thread', 'mysqlclient_r']
+  'css': ['log', 'log4cxx', 'boost_system', 'boost_thread', 'mysqlclient_r']
 }
 
 # extra modules to include into shmod

--- a/core/modules/mysql/MySqlConnection.cc
+++ b/core/modules/mysql/MySqlConnection.cc
@@ -29,6 +29,7 @@
 #include "mysql/MySqlConnection.h"
 
 // Third-party headers
+#include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"
 #include "boost/thread/tss.hpp"
 
@@ -144,7 +145,7 @@ MySqlConnection::cancel() {
     }
     // KILL QUERY only, not KILL CONNECTION.
     int threadId = mysql_thread_id(_mysql);
-    std::string killSql = "KILL QUERY " + boost::lexical_cast<int>(threadId);
+    std::string killSql = boost::str(boost::format("KILL QUERY ") % threadId);
     rc = mysql_real_query(killMysql, killSql.c_str(), killSql.size());
     mysql_close(killMysql);
     if(rc) {

--- a/core/modules/mysql/MySqlConnection.h
+++ b/core/modules/mysql/MySqlConnection.h
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <memory>
 #include <mutex>
+#include <string>
 
 // Third-party headers
 #include "boost/utility.hpp"

--- a/core/modules/proto/ProtoHeaderWrap.cc
+++ b/core/modules/proto/ProtoHeaderWrap.cc
@@ -43,7 +43,7 @@ const size_t ProtoHeaderWrap::PROTOBUFFER_DESIRED_LIMIT = 2000000;
 const size_t ProtoHeaderWrap::PROTOBUFFER_HARD_LIMIT = 64000000;
 
 std::string ProtoHeaderWrap::wrap(std::string& protoHeaderString) {
-    unsigned char phSize = static_cast<unsigned char>(protoHeaderString.size());
+    char phSize = static_cast<char>(protoHeaderString.size());
     std::string msgBuf{phSize};
     msgBuf += protoHeaderString;
     while (msgBuf.size() < PROTO_HEADER_SIZE) {

--- a/core/modules/qana/QueryMapping.h
+++ b/core/modules/qana/QueryMapping.h
@@ -32,6 +32,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 
 // Forward declarations
 namespace lsst {

--- a/core/modules/query/Constraint.cc
+++ b/core/modules/query/Constraint.cc
@@ -32,6 +32,7 @@
 #include "query/Constraint.h"
 
 // System headers
+#include <iostream>
 #include <iterator>
 
 namespace lsst {

--- a/core/modules/query/Constraint.h
+++ b/core/modules/query/Constraint.h
@@ -31,6 +31,7 @@
   */
 
 // System headers
+#include <iosfwd>
 #include <string>
 #include <vector>
 

--- a/core/modules/tests/testIter.cc
+++ b/core/modules/tests/testIter.cc
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <map>
 #include <string>
+#include <fcntl.h>
 
 // Third-party headers
 

--- a/core/modules/xrdsvc/ChannelStream.h
+++ b/core/modules/xrdsvc/ChannelStream.h
@@ -27,6 +27,7 @@
 #include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <string>
 
 // Third-party headers
 #include "XrdSsi/XrdSsiErrInfo.hh" // required by XrdSsiStream


### PR DESCRIPTION
These patches allow Qserv to be built on OS X with clang.