### PR TITLE
Simplify handling of packed keys (DM-4138)

### DIFF
--- a/admin/tests/test_chunkMapping.py
+++ b/admin/tests/test_chunkMapping.py
@@ -91,10 +91,12 @@ class TestChunkMapping(unittest.TestCase):
 /DBS/{db}/TABLES/{table}/CHUNKS\t\\N
 /DBS/{db}/TABLES/{table}/CHUNKS/333\t\\N
 /DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS\t\\N
-/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1.json\t{{"nodeName": "worker333"}}
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1/.packed.json\t{{"nodeName": "worker333"}}
 /DBS/{db}/TABLES/{table}/CHUNKS/765\t\\N
 /DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS\t\\N
-/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1.json\t{{"nodeName": "worker765"}}
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1/.packed.json\t{{"nodeName": "worker765"}}
 """
 
         workers = ['worker1', 'worker2']
@@ -133,10 +135,12 @@ class TestChunkMapping(unittest.TestCase):
 /DBS/{db}/TABLES/{table}/CHUNKS\t\\N
 /DBS/{db}/TABLES/{table}/CHUNKS/333\t\\N
 /DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS\t\\N
-/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1.json\t{{"nodeName": "worker333"}}
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/333/REPLICAS/1/.packed.json\t{{"nodeName": "worker333"}}
 /DBS/{db}/TABLES/{table}/CHUNKS/765\t\\N
 /DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS\t\\N
-/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1.json\t{{"nodeName": "worker765"}}
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1\t\\N
+/DBS/{db}/TABLES/{table}/CHUNKS/765/REPLICAS/1/.packed.json\t{{"nodeName": "worker765"}}
 """
 
         workers = ['worker1', 'worker2']

--- a/admin/tests/test_cssNodes.py
+++ b/admin/tests/test_cssNodes.py
@@ -57,9 +57,9 @@ class TestCssNodes(unittest.TestCase):
 /css_meta/version\t{version}
 /NODES\t\\N
 /NODES/worker-1\tACTIVE
-/NODES/worker-1.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
+/NODES/worker-1/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
 /NODES/worker-2\tINACTIVE
-/NODES/worker-2.json\t{{"type": "worker", "host": "worker.domain", "port": 5013}}
+/NODES/worker-2/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5013}}
 """
 
         initData = initData.format(version=css.VERSION)
@@ -129,9 +129,9 @@ class TestCssNodes(unittest.TestCase):
 /css_meta/version\t{version}
 /NODES\t\\N
 /NODES/worker-1\tACTIVE
-/NODES/worker-1.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
+/NODES/worker-1/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
 /NODES/worker-2\tINACTIVE
-/NODES/worker-2.json\t{{"type": "worker", "host": "worker.domain", "port": 5013}}
+/NODES/worker-2/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5013}}
 """
 
         initData = initData.format(version=css.VERSION)
@@ -200,16 +200,17 @@ class TestCssNodes(unittest.TestCase):
 /DBS/TEST\t\\N
 /DBS/TEST/TABLES\t\\N
 /DBS/TEST/TABLES/TEST\t\\N
-/DBS/TEST/TABLES/TEST.json\t{{}}
+/DBS/TEST/TABLES/TEST/.packed.json\t{{}}
 /DBS/TEST/TABLES/TEST/CHUNKS\t\\N
 /DBS/TEST/TABLES/TEST/CHUNKS/1\t\\N
 /DBS/TEST/TABLES/TEST/CHUNKS/1/REPLICAS\t\\N
-/DBS/TEST/TABLES/TEST/CHUNKS/1/REPLICAS/001.json\t{{"nodeName": "worker-2"}}
+/DBS/TEST/TABLES/TEST/CHUNKS/1/REPLICAS/001\t\\N
+/DBS/TEST/TABLES/TEST/CHUNKS/1/REPLICAS/001/.packed.json\t{{"nodeName": "worker-2"}}
 /NODES\t\\N
 /NODES/worker-1\tACTIVE
-/NODES/worker-1.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
+/NODES/worker-1/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
 /NODES/worker-2\tINACTIVE
-/NODES/worker-2.json\t{{"type": "worker", "host": "worker.domain", "port": 5013}}
+/NODES/worker-2/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5013}}
 """
 
         initData = initData.format(version=css.VERSION)
@@ -286,9 +287,9 @@ class TestCssNodes(unittest.TestCase):
 /css_meta/version\t{version}
 /NODES\t\\N
 /NODES/worker-1\tACTIVE
-/NODES/worker-1.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
+/NODES/worker-1/.packed.json\t{{"type": "worker", "host": "worker.domain", "port": 5012}}
 /NODES/worker-2\tINACTIVE
-/NODES/worker-2.json\t{{"type": "backup", "host": "worker.domain", "port": 5013}}
+/NODES/worker-2/.packed.json\t{{"type": "backup", "host": "worker.domain", "port": 5013}}
 """
 
         initData = initData.format(version=css.VERSION)

--- a/admin/tests/test_cssVersion.py
+++ b/admin/tests/test_cssVersion.py
@@ -88,7 +88,7 @@ class TestCssVersion(unittest.TestCase):
         initData = """\
 /DBS\t\\N
 /DBS/TESTDB\tREADY
-/DBS/TESTDB.json\t\\N
+/DBS/TESTDB/.packed.json\t\\N
 /css_meta\t\\N
 /css_meta/version\t""" + str(css.VERSION)
         css_inst = _makeCss(initData)

--- a/admin/tests/test_nodeAdmin.py
+++ b/admin/tests/test_nodeAdmin.py
@@ -73,7 +73,7 @@ class TestWorkerAdmin(unittest.TestCase):
 /css_meta/version\t{version}
 /NODES\t\\N
 /NODES/worker\t\\N
-/NODES/worker.json\t{{"type": "worker", "host": "localhost", "port": 5012}}
+/NODES/worker/.packed.json\t{{"type": "worker", "host": "localhost", "port": 5012}}
 """
         initData = initData.format(version=css.VERSION)
         css_inst = _makeCss(initData)

--- a/core/modules/css/testCssAccess.cc
+++ b/core/modules/css/testCssAccess.cc
@@ -77,18 +77,18 @@ shared_ptr<KvInterface> initKVI() {
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234", ""));
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS", ""));
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS/0000000001", ""));
-    kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS/0000000001.json", R"({"nodeName": "worker1"})"));
+    kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS/0000000001/.packed.json", R"({"nodeName": "worker1"})"));
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS/0000000002", ""));
-    kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS/0000000002.json", R"({"nodeName": "worker2"})"));
+    kv.push_back(make_pair(p + "/Exposure/CHUNKS/1234/REPLICAS/0000000002/.packed.json", R"({"nodeName": "worker2"})"));
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/5678", ""));
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/5678/REPLICAS", ""));
     kv.push_back(make_pair(p + "/Exposure/CHUNKS/5678/REPLICAS/0000000001", ""));
-    kv.push_back(make_pair(p + "/Exposure/CHUNKS/5678/REPLICAS/0000000001.json", R"({"nodeName": "worker1"})"));
+    kv.push_back(make_pair(p + "/Exposure/CHUNKS/5678/REPLICAS/0000000001/.packed.json", R"({"nodeName": "worker1"})"));
 
     p = "/DBS/dbB/TABLES";
     kv.push_back(make_pair(p, ""));
     kv.push_back(make_pair(p + "/Exposure", KEY_STATUS_READY));
-    kv.push_back(make_pair(p + "/Exposure.json", R"X({"schema": "(FLOAT X)"})X"));
+    kv.push_back(make_pair(p + "/Exposure/.packed.json", R"X({"schema": "(FLOAT X)"})X"));
     kv.push_back(make_pair(p + "/MyObject", KEY_STATUS_READY));
     kv.push_back(make_pair(p + "/MyObject/partitioning", ""));
     kv.push_back(make_pair(p + "/MyObject/partitioning/lonColName", "ra_PS"));
@@ -109,7 +109,8 @@ shared_ptr<KvInterface> initKVI() {
     kv.push_back(make_pair(p + "/RefMatch/match/dirColName2", "sourceId"));
     kv.push_back(make_pair(p + "/RefMatch/match/flagColName", "flag"));
     kv.push_back(make_pair(p + "/RefMatch2", KEY_STATUS_READY));
-    kv.push_back(make_pair(p + "/RefMatch2/match.json",
+    kv.push_back(make_pair(p + "/RefMatch2/match", ""));
+    kv.push_back(make_pair(p + "/RefMatch2/match/.packed.json",
                            R"({"dirTable1": "Object", "dirColName1": "objectId", "dirTable2": "Source", "dirColName2": "sourceId", "flagColName": "flag"})"));
     kv.push_back(make_pair(p + "/TempTable1", KEY_STATUS_IGNORE));
     kv.push_back(make_pair(p + "/TempTable2", "PENDING_CREATE:12345"));
@@ -118,7 +119,7 @@ shared_ptr<KvInterface> initKVI() {
     kv.push_back(make_pair(p, ""));
     kv.push_back(make_pair(p + "/node1", "ACTIVE"));
     kv.push_back(make_pair(p + "/node2", "INACTIVE"));
-    kv.push_back(make_pair(p + "/node2.json", R"({"type": "worker", "host": "worker2", "port": 5012})"));
+    kv.push_back(make_pair(p + "/node2/.packed.json", R"({"type": "worker", "host": "worker2", "port": 5012})"));
     kv.push_back(make_pair(p + "/node3", "ACTIVE"));
     kv.push_back(make_pair(p + "/node3/type", "worker"));
     kv.push_back(make_pair(p + "/node3/host", "worker3"));

--- a/doc/source/devel/css.rst
+++ b/doc/source/devel/css.rst
@@ -2,48 +2,67 @@
 CSS metadata layout
 ###################
 
-The Central State System (CSS) maintains information about the data
-stored in Qserv. Currently, this consists of the data schema: the
-names of databases and what tables they contain, the partitioning
-parameters used by the database, etc.
+The Central State System (CSS) maintains information about the data stored in
+Qserv. Currently, this consists of the data schema: the names of databases and
+what tables they contain, the partitioning parameters used by the database, etc.
 
 **************
 Implementation
 **************
 
 CSS content is stored in a hierarchical key-value structure, with keys
-structured much like filename paths.
-In standard Qserv installations, CSS data is kept in a Zookeeeper
-cluster, although parts of qserv may be tested with CSS content stored
-in a more feature-light form, e.g., a file.
+structured much like filename paths. In standard Qserv installations, CSS data
+is kept in a MySQL database, although parts of qserv may be tested with CSS
+content stored in a more feature-light form, e.g., a file.
 
 ***********
 Packed keys
 ***********
 
-In order to reduce the number of key-value updates when manipulating
-CSS content, some portions of the content tree are stored packed in
-JSON format. This is signified by a ".json" in the key name. The
-presence of ".json" in a key name indicates that its contents should
-be interpreted as children of the key. For example, suppose CSS
-content includes (specified in python dict syntax):
+In order to reduce the number of key-value updates when manipulating CSS
+content, some portions of the content tree are stored packed in JSON format.
+This is signified by presence of ".packed.json" key. The content of this key is
+a structure (JSON object) which contains some of the keys appearing at the same
+level as ".packed.json" key. For example, suppose CSS content includes
+(specified in python dict syntax):
 
 .. code-block:: python
 
     { "/foo/bar" : "12345",
-      "/foo/bar.json" : '{"a":"aa", "b":"bb"}'}
+      "/foo/bar/baz" : "regular data",
+      "/foo/bar/.packed.json" : '{"a":"aa", "b":"bb"}' }
 
-The key "/foo/bar.json" is unpacked, thus the above content will be
+The key "/foo/bar/.packed.json" is unpacked, thus the above content will be
 interpreted as:
 
 .. code-block:: python
 
     { "/foo/bar" : "12345",
-      "/foo/bar/a" : "aa",
-      "/foo/bar/b" : "bb" }
+      "/foo/bar/baz" : "regular data",
+      "/foo/bar/a"   : "aa",
+      "/foo/bar/b"   : "bb" }
 
-Note that the presence of "/foo/bar.json" does not prevent the
-presence of "/foo/bar". In this version, the value for the parent
-"/foo/bar" may not be stored in "/foo/bar.json", and so the
-JSON-encoded string in "/foo/bar.json" must contain a key-value
-structure (this may change in the future).
+Note that the presence of "/foo/bar/.packed.json" does not prevent the presence
+of "/foo/bar/baz". It is not specified what happens if the same key appears in
+both regular CSS structure and in packed key value like in this structure:
+
+.. code-block:: python
+
+    # it is unspecified which value /foo/bar/a has when unpacked
+    { "/foo/bar" : "12345",
+      "/foo/bar/a" : "regular key data",
+      "/foo/bar/.packed.json" : '{"a":"aa", "b":"bb"}' }
+
+The values in JSON object can be simple types like strings or numbers, complex
+objects are not supported there. All values in JSON object are transformed to
+strings when unpacked, so the packed object ``"{"key": 1}"`` is treated
+identically to ``"{"key": "1"}"``.
+
+*************
+CSS interface
+*************
+
+CSS key-value storage is hidden completely behind CSS interface
+(``css/CssAccess`` class). This interface defines all logical operations on
+databases, tables, nodes, etc. and translates those operations into key-value
+structure manipulatons, including packing and upacking of the keys.


### PR DESCRIPTION
Packed keys now have unique names (.packed.json) and they appear on the
same level in CSS tree as the keys the replace. This simplifies
CssAccess code which handles packing/unpacking.