### PR TITLE
Fix some minor gcc 5.2 & clang warns

### DIFF
--- a/core/modules/ccontrol/UserQueryFactory.cc
+++ b/core/modules/ccontrol/UserQueryFactory.cc
@@ -76,7 +76,7 @@ public:
     std::shared_ptr<qproc::SecondaryIndex> secondaryIndex;
     std::shared_ptr<qmeta::QMeta> queryMetadata;
     std::unique_ptr<sql::SqlConnection> resultDbConn;
-    qmeta::CzarId qMetaCzarId;   ///< Czar ID in QMeta database
+    qmeta::CzarId qMetaCzarId = {0};   ///< Czar ID in QMeta database
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/core/modules/xrdsvc/SsiSession.cc
+++ b/core/modules/xrdsvc/SsiSession.cc
@@ -69,10 +69,8 @@ void SsiSession::ProcessRequest(XrdSsiRequest* req, unsigned short timeout) {
 
     auto replyChannel = std::make_shared<ReplyChannel>(*this);
 
-    auto errorFunc = [this, &req, &replyChannel](std::string const& errStr, bool sendStr=true ) {
-        if (sendStr) {
-            replyChannel->sendError(errStr, EINVAL);
-        }
+    auto errorFunc = [this, &req, &replyChannel](std::string const& errStr) {
+        replyChannel->sendError(errStr, EINVAL);
         BindRequest(req, this);
         ReleaseRequestBuffer();
     };
@@ -90,7 +88,7 @@ void SsiSession::ProcessRequest(XrdSsiRequest* req, unsigned short timeout) {
         std::ostringstream os;
         os << "WARNING: unowned chunk query detected:" << ru.path();
         LOGF_WARN(os.str());
-        errorFunc(os.str(), false);
+        errorFunc(os.str());
         return;
     }
 


### PR DESCRIPTION
Pretty trivial: qMetaCzarId was missing init, and default args for lambdas are verboten...