### PR TITLE
Tickets/dm 4529

### DIFF
--- a/core/modules/qmeta/qmetaLib.i
+++ b/core/modules/qmeta/qmetaLib.i
@@ -17,18 +17,18 @@ Access to the qmeta classes
 
 %include typemaps.i
 %include cstring.i
+%include stdint.i
 %include "std_map.i"
 %include "std_shared_ptr.i"
 %include "std_string.i"
 %include "std_vector.i"
 
-// we need few types from stdint.h but SWIG provides incorrect typedef
-// for 64-bit types in its stdint.i so we cannot use that, need some manual defs
+// swig is missing typedefs for <cstdint>
 namespace std {
-typedef int                     int32_t;
-typedef long int                int64_t;
-typedef unsigned int            uint32_t;
-typedef unsigned long int       uint64_t;
+typedef ::int32_t  int32_t;
+typedef ::int64_t  int64_t;
+typedef ::uint32_t uint32_t;
+typedef ::uint64_t uint64_t;
 }
 
 // Instantiate types

--- a/core/modules/util/EventThread.cc
+++ b/core/modules/util/EventThread.cc
@@ -109,7 +109,7 @@ PoolEventThread::Ptr ThreadPool::release(PoolEventThread *thrd) {
 }
 
 /// Change the size of the thread pool.
-void ThreadPool::resize(uint targetThrdCount) {
+void ThreadPool::resize(unsigned int targetThrdCount) {
     {
         std::lock_guard<std::mutex> lock(_countMutex);
         _targetThrdCount = targetThrdCount;

--- a/core/modules/util/EventThread.h
+++ b/core/modules/util/EventThread.h
@@ -153,7 +153,8 @@ protected:
 class ThreadPool : public std::enable_shared_from_this<ThreadPool> {
 public:
     using Ptr = std::shared_ptr<ThreadPool>;
-    static ThreadPool::Ptr newThreadPool(uint thrdCount, CommandQueue::Ptr const& q) {
+    static ThreadPool::Ptr newThreadPool(unsigned int thrdCount,
+                                         CommandQueue::Ptr const& q) {
         Ptr thp{new ThreadPool{thrdCount, q}}; // private constructor
         thp->_resize();
         return thp;
@@ -161,22 +162,22 @@ public:
     virtual ~ThreadPool();
 
     CommandQueue::Ptr getQueue() {return _q;}
-    uint getTargetThrdCount() {
+    unsigned int getTargetThrdCount() {
         std::lock_guard<std::mutex> lock(_countMutex);
         return _targetThrdCount;
     }
-    uint size() {
+    unsigned int size() {
         std::lock_guard<std::mutex> lock(_poolMutex);
         return _pool.size();
     }
 
     void waitForResize(int millisecs);
     void endAll() { resize(0); }
-    void resize(uint targetThrdCount);
+    void resize(unsigned int targetThrdCount);
     PoolEventThread::Ptr release(PoolEventThread *thread);
 
 protected:
-    ThreadPool(uint thrdCount, CommandQueue::Ptr const& q) : _targetThrdCount{thrdCount}, _q{q} {
+    ThreadPool(unsigned int thrdCount, CommandQueue::Ptr const& q) : _targetThrdCount{thrdCount}, _q{q} {
         if (_q == nullptr) {
             _q = std::make_shared<CommandQueue>();
         }
@@ -185,7 +186,7 @@ protected:
 
     std::mutex _poolMutex; ///< Protects _pool
     std::vector<std::shared_ptr<PoolEventThread>> _pool; ///< All the threads in our pool.
-    uint _targetThrdCount{0}; ///< How many threads we want to have.
+    unsigned int _targetThrdCount{0}; ///< How many threads we want to have.
     std::mutex _countMutex; ///< protects _targetThrdCount
     std::condition_variable _countCV; ///< Notifies about changes to _pool size, uses _countMutex.
     CommandQueue::Ptr _q; ///< The queue used by all threads in the _pool.

--- a/core/modules/wbase/SendChannel.cc
+++ b/core/modules/wbase/SendChannel.cc
@@ -23,6 +23,7 @@
 #include "wbase/SendChannel.h"
 
 // System headers
+#include <functional>
 #include <iostream>
 #include <sstream>
 #include <unistd.h>

--- a/core/modules/wbase/SendChannel.h
+++ b/core/modules/wbase/SendChannel.h
@@ -25,6 +25,7 @@
 #define LSST_QSERV_WBASE_SENDCHANNEL_H
 
 // System headers
+#include <functional>
 #include <memory>
 #include <string>
 #include <stdexcept>

--- a/core/modules/wsched/ChunkState.cc
+++ b/core/modules/wsched/ChunkState.cc
@@ -24,6 +24,7 @@
 #include "wsched/ChunkState.h"
 
 // System headers
+#include <iostream>
 #include <iterator>
 
 namespace lsst {

--- a/site_scons/site_tools/compiler.py
+++ b/site_scons/site_tools/compiler.py
@@ -114,6 +114,12 @@ def generate(env):
 
         env.Append(LINKFLAGS=["-pthread"])
 
+        # SWIG handling of stdint.h types is broken by default and
+        # needs special flag to workaround inconsistent typedefs.
+        # This currently only applies to Linux, looks like clang/OSX
+        # works as expected
+        env['SWIGCOM'] = '$SWIG -DSWIGWORDSIZE64 -o $TARGET ${_SWIGOUTDIR} ${_SWIGINCFLAGS} $SWIGFLAGS $SOURCES'
+
     else:
 
         raise SCons.Errors.StopError('Unsupported platform or toolchain: %s/%s' % (platform, toolchain))


### PR DESCRIPTION
Four files were modified to address MacOSX clang70 compiler errors:
-- `core/modules/util/EventThread.h,cc`: `uint` ==> `unsigned int`
-- `core/modules/wbase/SendChannel.h,cc`: Add `#include <functional>`
-- `core/modules/wsched/ChunkState.cc`: Add `#include <iostream>`
-- `build/qmeta/qmetaLib_wrap.cc`:  Use `::uint*` (global namespace) for typedefs into `std::`