### PR TITLE
Implement empty chunk cache reset (DM-4383)

### DIFF
--- a/admin/templates/configuration/etc/qserv-wmgr.cnf
+++ b/admin/templates/configuration/etc/qserv-wmgr.cnf
@@ -34,9 +34,16 @@ DB_PASSWD = ''
 DB_USER_PRIV = '{{MYSQLD_USER}}'
 DB_PASSWD_PRIV = '{{MYSQLD_PASS}}'
 
+# parameters for mysql-proxy connection, these are only useful
+# for czar wmgr instance
+PROXY_HOST = '127.0.0.1'
+PROXY_PORT = {{MYSQL_PROXY_PORT}}
+PROXY_USER = '{{QSERV_USER}}'
+PROXY_PASSWD = ''
+
 # CSS-related parameters
 # CSS_CONFIG is a dictionary as accepted by CssAccess.createFromConfig() method,
-# all values in a dictionary must bestrings even if represent numbers
+# all values in a dictionary must be strings even if they represent numbers
 USE_CSS = True
 CSS_CONFIG = {
     'technology': 'mysql',

--- a/core/modules/ccontrol/UserQueryFactory.cc
+++ b/core/modules/ccontrol/UserQueryFactory.cc
@@ -38,6 +38,7 @@
 #include "ccontrol/ConfigError.h"
 #include "ccontrol/ConfigMap.h"
 #include "ccontrol/UserQueryDrop.h"
+#include "ccontrol/UserQueryFlushChunksCache.h"
 #include "ccontrol/UserQueryInvalid.h"
 #include "ccontrol/UserQuerySelect.h"
 #include "ccontrol/UserQueryType.h"
@@ -148,6 +149,11 @@ UserQueryFactory::newUserQuery(std::string const& query,
                                                   _impl->resultDbConn.get(), resultTable,
                                                   _impl->queryMetadata, _impl->qMetaCzarId);
         LOGF(_log, LOG_LVL_DEBUG, "make UserQueryDrop: db=%s" % dbName);
+        return uq;
+    } else if (UserQueryType::isFlushChunksCache(query, dbName)) {
+        auto uq = std::make_shared<UserQueryFlushChunksCache>(_impl->css, dbName,
+                                                              _impl->resultDbConn.get(), resultTable);
+        LOGF(_log, LOG_LVL_DEBUG, "make UserQueryFlushChunksCache: %s" % dbName);
         return uq;
     } else {
         // something that we don't recognize

--- a/core/modules/ccontrol/UserQueryFlushChunksCache.cc
+++ b/core/modules/ccontrol/UserQueryFlushChunksCache.cc
@@ -1,0 +1,104 @@
+/*
+ * LSST Data Management System
+ * Copyright 2015 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Class header
+#include "ccontrol/UserQueryFlushChunksCache.h"
+
+// System headers
+
+// LSST headers
+#include "lsst/log/Log.h"
+
+// Qserv headers
+#include "css/CssAccess.h"
+#include "css/EmptyChunks.h"
+#include "qdisp/MessageStore.h"
+#include "sql/SqlConnection.h"
+#include "sql/SqlErrorObject.h"
+
+namespace {
+
+LOG_LOGGER getLogger() {
+    static LOG_LOGGER logger = LOG_GET("lsst.qserv.ccontrol.UserQueryFlushChunksCache");
+    return logger;
+}
+
+}
+
+namespace lsst {
+namespace qserv {
+namespace ccontrol {
+
+// Constructor
+UserQueryFlushChunksCache::UserQueryFlushChunksCache(std::shared_ptr<css::CssAccess> const& css,
+                                                     std::string const& dbName,
+                                                     sql::SqlConnection* resultDbConn,
+                                                     std::string const& resultTable)
+    : _css(css), _dbName(dbName), _resultDbConn(resultDbConn),
+      _resultTable(resultTable),  _qState(UNKNOWN),
+      _messageStore(std::make_shared<qdisp::MessageStore>()) {
+}
+
+std::string UserQueryFlushChunksCache::getError() const {
+    return std::string();
+}
+
+// Attempt to kill in progress.
+void UserQueryFlushChunksCache::kill() {
+}
+
+// Submit or execute the query.
+void UserQueryFlushChunksCache::submit() {
+
+    LOGF(getLogger(), LOG_LVL_INFO, "going to flush empty chunks - db: %s" % _dbName);
+
+    // create result table first, exact schema does not matter but mysql
+    // needs at least one column in table DDL
+    LOGF(getLogger(), LOG_LVL_DEBUG, "creating result table: %s" % _resultTable);
+    std::string sql = "CREATE TABLE " + _resultTable + " (CODE INT)";
+    sql::SqlErrorObject sqlErr;
+    if (not _resultDbConn->runQuery(sql, sqlErr)) {
+        // There is no way to return success if we cannot create result table so just stop here
+        std::string message = "Failed to create result table: " + sqlErr.errMsg();
+        _messageStore->addMessage(-1, 1005, message, MessageSeverity::MSG_ERROR);
+        _qState = ERROR;
+        return;
+    }
+
+    // reset empty chunk cache , this does not throw
+    _css->getEmptyChunks().clearCache(_dbName);
+
+    _qState = SUCCESS;
+}
+
+// Block until a submit()'ed query completes.
+QueryState UserQueryFlushChunksCache::join() {
+    // everything should be done in submit()
+    return _qState;
+}
+
+// Release resources.
+void UserQueryFlushChunksCache::discard() {
+    // no resources
+}
+
+}}} // lsst::qserv::ccontrol

--- a/core/modules/ccontrol/UserQueryFlushChunksCache.h
+++ b/core/modules/ccontrol/UserQueryFlushChunksCache.h
@@ -1,0 +1,113 @@
+/*
+ * LSST Data Management System
+ * Copyright 2015 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_QSERV_CCONTROL_USERQUERYFLUSHCHUNKSCACHE_H
+#define LSST_QSERV_CCONTROL_USERQUERYFLUSHCHUNKSCACHE_H
+
+// System headers
+#include <memory>
+
+// Third-party headers
+
+// Qserv headers
+#include "ccontrol/UserQuery.h"
+
+// Forward decl
+namespace lsst {
+namespace qserv {
+namespace css {
+class CssAccess;
+}
+namespace sql {
+class SqlConnection;
+}}}
+
+namespace lsst {
+namespace qserv {
+namespace ccontrol {
+
+/// @addtogroup ccontrol
+
+/**
+ *  @ingroup ccontrol
+ *
+ *  @brief Implementation of UserQuery for FLUSH QSERV_CHUNKS_CACHE.
+ */
+
+class UserQueryFlushChunksCache : public UserQuery {
+public:
+
+    /**
+     *  @param css:           CSS interface
+     *  @param dbName:        Name of the database where table is
+     *  @param resultDbConn:  Connection to results database
+     *  @param resultTable:   Name of the table for query results
+     */
+    UserQueryFlushChunksCache(std::shared_ptr<css::CssAccess> const& css,
+                              std::string const& dbName,
+                              sql::SqlConnection* resultDbConn,
+                              std::string const& resultTable);
+
+    UserQueryFlushChunksCache(UserQueryFlushChunksCache const&) = delete;
+    UserQueryFlushChunksCache& operator=(UserQueryFlushChunksCache const&) = delete;
+
+    // Accessors
+
+    /// @return a non-empty string describing the current error state
+    /// Returns an empty string if no errors have been detected.
+    virtual std::string getError() const override;
+
+    /// Begin execution of the query over all ChunkSpecs added so far.
+    virtual void submit() override;
+
+    /// Wait until the query has completed execution.
+    /// @return the final execution state.
+    virtual QueryState join() override;
+
+    /// Stop a query in progress (for immediate shutdowns)
+    virtual void kill() override;
+
+    /// Release resources related to user query
+    virtual void discard() override;
+
+    // Delegate objects
+    virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
+        return _messageStore; }
+
+    /// @return ORDER BY part of SELECT statement to be executed by proxy
+    virtual std::string getProxyOrderBy() override { return std::string(); }
+
+protected:
+
+private:
+
+    std::shared_ptr<css::CssAccess> const _css;
+    std::string const _dbName;
+    sql::SqlConnection* _resultDbConn;
+    std::string const _resultTable;
+    QueryState _qState;
+    std::shared_ptr<qdisp::MessageStore> _messageStore;
+
+};
+
+}}} // namespace lsst::qserv::ccontrol
+
+#endif // LSST_QSERV_CCONTROL_USERQUERYFLUSHCHUNKSCACHE_H

--- a/core/modules/ccontrol/UserQueryType.cc
+++ b/core/modules/ccontrol/UserQueryType.cc
@@ -54,6 +54,12 @@ boost::regex _dropTableRe(R"(^drop\s+table\s+((["`]?)(\w+)\2[.])?(["`]?)(\w+)\4\
 boost::regex _selectRe(R"(^select\s+.+$)",
                        boost::regex::ECMAScript | boost::regex::icase | boost::regex::optimize);
 
+// regex for FLUSH QSERV_CHUNKS_CACHE [FOR database]
+// Note that parens around whole string are not part of the regex but raw string literal
+// db name will be in group 3.
+boost::regex _flushEmptyRe(R"(^flush\s+qserv_chunks_cache(\s+for\s+(["`]?)(\w+)\2)?\s*;?\s*$)",
+                           boost::regex::ECMAScript | boost::regex::icase | boost::regex::optimize);
+
 }
 
 namespace lsst {
@@ -95,6 +101,19 @@ UserQueryType::isSelect(std::string const& query) {
     bool match = boost::regex_match(query, sm, _selectRe);
     if (match) {
         LOGF(_log, LOG_LVL_DEBUG, "isSelect: match");
+    }
+    return match;
+}
+
+/// Returns true if query is FLUSH QSERV_CHUNKS_CACHE [FOR database]
+bool
+UserQueryType::isFlushChunksCache(std::string const& query, std::string& dbName) {
+    LOGF(_log, LOG_LVL_DEBUG, "isFlushChunksCache: %s" % query);
+    boost::smatch sm;
+    bool match = boost::regex_match(query, sm, _flushEmptyRe);
+    if (match) {
+        dbName = sm.str(3);
+        LOGF(_log, LOG_LVL_DEBUG, "isFlushChunksCache: match: %s" % dbName);
     }
     return match;
 }

--- a/core/modules/ccontrol/UserQueryType.h
+++ b/core/modules/ccontrol/UserQueryType.h
@@ -54,6 +54,9 @@ public:
     /// Returns true if query is SELECT
     static bool isSelect(std::string const& query);
 
+    /// Returns true if query is FLUSH QSERV_CHUNKS_CACHE [FOR database]
+    static bool isFlushChunksCache(std::string const& query, std::string& dbName);
+
 };
 
 }}} // namespace lsst::qserv::ccontrol

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -126,8 +126,40 @@ BOOST_AUTO_TEST_CASE(testUserQueryType) {
         BOOST_CHECK(not UserQueryType::isDropDb(test, db));
     }
 
+    struct {
+        const char* query;
+        const char* db;
+    } flush_empty_ok[] = {
+        {"FLUSH QSERV_CHUNKS_CACHE", ""},
+        {"FLUSH QSERV_CHUNKS_CACHE\t ", ""},
+        {"FLUSH QSERV_CHUNKS_CACHE;", ""},
+        {"FLUSH QSERV_CHUNKS_CACHE ; ", ""},
+        {"FLUSH QSERV_CHUNKS_CACHE FOR DB", "DB"},
+        {"FLUSH QSERV_CHUNKS_CACHE FOR `DB`", "DB"},
+        {"FLUSH QSERV_CHUNKS_CACHE FOR \"DB\"", "DB"},
+        {"FLUSH QSERV_CHUNKS_CACHE FOR DB ; ", "DB"},
+        {"flush qserv_chunks_cache for `d_b`", "d_b"},
+        {"flush\nqserv_chunks_CACHE\tfor \t d_b", "d_b"},
+    };
+    for (auto test: flush_empty_ok) {
+        std::string db;
+        BOOST_CHECK(UserQueryType::isFlushChunksCache(test.query, db));
+        BOOST_CHECK_EQUAL(db, test.db);
+    }
+
+    const char* flush_empty_fail[] = {
+        "FLUSH QSERV CHUNKS CACHE",
+        "UNFLUSH QSERV_CHUNKS_CACHE",
+        "FLUSH QSERV_CHUNKS_CACHE DB",
+        "FLUSH QSERV_CHUNKS_CACHE FOR",
+        "FLUSH QSERV_CHUNKS_CACHE FROM DB",
+        "FLUSH QSERV_CHUNKS_CACHE FOR DB.TABLE",
+    };
+    for (auto test: flush_empty_fail) {
+        std::string db;
+        BOOST_CHECK(not UserQueryType::isFlushChunksCache(test, db));
+    }
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-
-

--- a/core/modules/css/EmptyChunks.h
+++ b/core/modules/css/EmptyChunks.h
@@ -65,11 +65,17 @@ public:
     /// @return true if db/chunk is empty
     bool isEmpty(std::string const& db, int chunk) const;
 
+    /// Clear cache for empty chunk list so that on next call to above methods
+    /// empty chunk list is re-populated. If database name is empty then cache
+    // for all databases is cleared.
+    void clearCache(std::string const& db=std::string()) const;
+
+private:
+
     // Convenience types
     typedef std::shared_ptr<IntSet> IntSetPtr;
     typedef std::shared_ptr<IntSet const> IntSetConstPtr;
 
-private:
     typedef std::map<std::string, IntSetPtr> IntSetMap;
     std::string _path; ///< Search path for empty chunks files
     std::string _fallbackFile; ///< Fallback path for empty chunks

--- a/core/modules/css/testEmptyChunks.cc
+++ b/core/modules/css/testEmptyChunks.cc
@@ -108,7 +108,7 @@ BOOST_FIXTURE_TEST_SUITE(Suite, Fixture)
 
 BOOST_AUTO_TEST_CASE(Basic) {
     EmptyChunks ec(dummyFile._path, dummyFile._fallback);
-    EmptyChunks::IntSetConstPtr s = ec.getEmpty("TestOne");
+    auto s = ec.getEmpty("TestOne");
     BOOST_CHECK(s->find(3) != s->end());
     BOOST_CHECK(s->find(103) == s->end());
     BOOST_CHECK(s->find(1001) == s->end());

--- a/core/modules/proxy/mysqlProxy.lua
+++ b/core/modules/proxy/mysqlProxy.lua
@@ -245,7 +245,7 @@ function queryType()
     ---------------------------------------------------------------------------
 
     local isIgnored = function(qU)
-        -- SET is already in isLocal() so this laways returns false for now
+        -- SET is already in isLocal() so this always returns false for now
         if string.find(qU, "^SET ") then
             return true
         end
@@ -257,7 +257,7 @@ function queryType()
     local isNotSupported = function(qU)
         if string.find(qU, "^EXPLAIN ") or
            string.find(qU, "^GRANT ") or
-           string.find(qU, "^FLUSH ") then
+           (string.find(qU, "^FLUSH ") and not string.find(qU, "^FLUSH QSERV")) then
             err.set(ERR_NOT_SUPPORTED,
                     "Sorry, this type of queries is not supported in DC3b.")
             return true

--- a/core/modules/wmgr/python/client.py
+++ b/core/modules/wmgr/python/client.py
@@ -530,6 +530,23 @@ class WmgrClient(object):
                                    headers={'Content-Type': stream.content_type})
         return self._getKey(result, 'count')
 
+
+    def resetChunksCache(self, dbName):
+        """
+        Reset chunk cache (a.k.a. empty chunks list) for specified database name.
+
+        @param dbName:     Database name
+        @raise ClientException: in case of problems
+        """
+
+        _log.debug('reset chunk cache: %s', dbName)
+
+        # resource URL
+        resource = dbName + '/chunks/cache'
+
+        result = self._requestJSON('dbs', resource, method='PUT')
+
+
     def services(self):
         """
         Return the list of service names.


### PR DESCRIPTION
Adding special SQL syntax for czar to reset empty chunk cache
(`FLUSH QSERV_CHUNKS_CACHE [FOR database]`). Wmgr also gets
a special method to reset chunks cache which uses above SQL.