### PR TITLE
Fix Dockerfile producing Qserv build

### DIFF
--- a/admin/tools/docker/tagged/Dockerfile.tpl
+++ b/admin/tools/docker/tagged/Dockerfile.tpl
@@ -7,12 +7,10 @@ RUN apt-get update && apt-get -y install byobu git vim gdb lsof
 
 USER qserv 
 
-WORKDIR /home/qserv
+ENV QSERV_SRC_DIR /home/qserv/src/qserv
 
-RUN mkdir src && cd src && git clone -b {{GIT_TAG_OPT}} --single-branch https://github.com/LSST/qserv
-WORKDIR /home/qserv/src/qserv
-RUN bash -c ". /qserv/stack/loadLSST.bash && setup -r . -t qserv-dev && eupspkg -er build"
 # Force execution of lines below by changing timestamp
-RUN git pull # Build performed on {{TIMESTAMP}}
+RUN git clone -b {{GIT_TAG_OPT}} --single-branch https://github.com/LSST/qserv $QSERV_SRC_DIR # Build performed on {{TIMESTAMP}}
+WORKDIR $QSERV_SRC_DIR
 RUN bash -c ". /qserv/stack/loadLSST.bash && setup -r . -t qserv-dev && eupspkg -er install"
 RUN bash -c ". /qserv/stack/loadLSST.bash && setup -r . -t qserv-dev && eupspkg -er decl -t qserv-dev"


### PR DESCRIPTION
- git pull removed (weak if initial clone build fails)
- eupspkg -er build removed
  (strange docker behaviour on PREFIX/lib/python)