### PR TITLE
Tickets/DM-4931: Use Apple CommonCrypto rather than OpenSSL

### DIFF
--- a/core/modules/proto/TaskMsgDigest.cc
+++ b/core/modules/proto/TaskMsgDigest.cc
@@ -27,6 +27,10 @@
 // System headers
 #ifdef __SUNPRO_CC
 #include <sys/md5.h>
+#elif __APPLE__
+#define COMMON_DIGEST_FOR_OPENSSL
+#include <CommonCrypto/CommonDigest.h>
+#define MD5 CC_MD5
 #else // Linux?
 #include <openssl/md5.h>
 #endif

--- a/core/modules/util/StringHash.cc
+++ b/core/modules/util/StringHash.cc
@@ -30,8 +30,37 @@
 #include <sstream>
 
 // Third-party headers
+#ifdef __APPLE__
+#define COMMON_DIGEST_FOR_OPENSSL
+#include <CommonCrypto/CommonDigest.h>
+
+// On OS X MD5() is CC_MD5() the size argument CC_LONG is a uint32_t
+// and the data argument is a const void *.
+
+// unsigned char *   MD5(const unsigned char *, size_t, unsigned char *);
+// vs
+// unsigned char *CC_MD5(const          void *, CC_LONG,unsigned char *);
+
+unsigned char * MD5(const unsigned char * data,
+                    size_t len,
+                    unsigned char * md) {
+  return CC_MD5(data, len, md);
+}
+unsigned char * SHA1(const unsigned char * data,
+                    size_t len,
+                    unsigned char * md) {
+  return CC_SHA1(data, len, md);
+}
+unsigned char * SHA256(const unsigned char * data,
+                    size_t len,
+                    unsigned char * md) {
+  return CC_SHA256(data, len, md);
+}
+
+#else
 #include <openssl/md5.h>
 #include <openssl/sha.h>
+#endif
 
 namespace {
 template <unsigned char *dFunc(const unsigned char *,

--- a/core/modules/wbase/Base.cc
+++ b/core/modules/wbase/Base.cc
@@ -36,7 +36,6 @@
 #include <fstream>
 #include <glob.h>
 #include <iostream>
-#include <openssl/md5.h>
 #include <sstream>
 #include <string.h> // memcpy
 #include <unistd.h>


### PR DESCRIPTION
These patches switch the digest creation code from OpenSSL to Apple CommonCrypto on Apple systems. The changes to `StringHash.cc` do not seem to be optimal so I would welcome advice on how to get this to work with the templating rather than writing a forwarding function. The issue is that the API for the Apple versions of `MD5` and `SHA256` seem to have a slightly different signature to the OpenSSL variants.