### PR TITLE
Remove dependency on MySQLdb module (DM-3949)

### DIFF
--- a/core/modules/wmgr/python/config.py
+++ b/core/modules/wmgr/python/config.py
@@ -38,7 +38,6 @@ import tempfile
 from .errors import ExceptionResponse
 from lsst.db.engineFactory import getEngineFromArgs
 from lsst.qserv import css
-import MySQLdb as sql
 
 #----------------------------------
 # Local non-exported definitions --
@@ -105,10 +104,9 @@ class Config(object):
         if self.dbPort: kwargs['port'] = self.dbPort
         if self.dbSocket: kwargs['query'] = {"unix_socket": self.dbSocket}
         if self.dbUser: kwargs['username'] = self.dbUser
-        _log.debug('creating new connection %s', kwargs)
+        _log.debug('creating new connection (password not shown) %s', kwargs)
         if self.dbPasswd: kwargs['password'] = self.dbPasswd
-        inst = getEngineFromArgs(**kwargs)
-        return inst
+        return getEngineFromArgs(**kwargs)
 
     def privDbEngine(self):
         """ Return database engine for priviledged account """
@@ -117,26 +115,19 @@ class Config(object):
         if self.dbPort: kwargs['port'] = self.dbPort
         if self.dbSocket: kwargs['query'] = {"unix_socket": self.dbSocket}
         if self.dbUserPriv: kwargs['username'] = self.dbUserPriv
-        _log.debug('creating new connection %s', kwargs)
+        _log.debug('creating new connection (password not shown) %s', kwargs)
         if self.dbPasswdPriv: kwargs['password'] = self.dbPasswdPriv
-        inst = getEngineFromArgs(**kwargs)
-        return inst
+        return getEngineFromArgs(**kwargs)
 
-    def proxyConn(self):
-        """
-        Return mysql connection object for proxy.
-
-        Sqlalchemy drivers have trouble with qserv, so we have to limit
-        ourself to direct mysqldb.
-        """
+    def proxyDbEngine(self):
+        """ Return database engine for proxy """
         kwargs = {}
         if self.proxyHost: kwargs['host'] = self.proxyHost
         if self.proxyPort: kwargs['port'] = self.proxyPort
-        if self.proxyUser: kwargs['user'] = self.proxyUser
-        _log.debug('creating new connection %s', kwargs)
-        if self.proxyPasswd: kwargs['passwd'] = self.proxyPasswd
-        conn = sql.connect(**kwargs)
-        return conn
+        if self.proxyUser: kwargs['username'] = self.proxyUser
+        _log.debug('creating new connection (password not shown) %s', kwargs)
+        if self.proxyPasswd: kwargs['password'] = self.proxyPasswd
+        return getEngineFromArgs(**kwargs)
 
     def cssAccess(self):
         """

--- a/core/modules/wmgr/python/dbMgr.py
+++ b/core/modules/wmgr/python/dbMgr.py
@@ -944,16 +944,11 @@ def resetChunksCache(dbName):
     # validate params
     _validateDbName(dbName)
 
-    try:
-        dbConn = Config.instance().proxyConn()
-    except Exception as exc:
-        _log.error('Failed to connect to proxy: %s', exc)
-        raise ExceptionResponse(500, "ConnectFailed", "Failed to connect to qserv (mysql-proxy)", str(exc))
+    dbConn = Config.instance().proxyDbEngine().connect()
 
     try:
-        cursor = dbConn.cursor()
         query = "FLUSH QSERV_CHUNKS_CACHE FOR {}".format(dbName)
-        cursor.execute(query)
+        dbConn.execute(query)
     except Exception as exc:
         _log.error('exception executing FLUSH QSERV_CHUNKS_CACHE: %s', exc)
         raise ExceptionResponse(500, "FLushFailed", "FLUSH QSERV_CHUNKS_CACHE failed for database %s" % dbName,


### PR DESCRIPTION
Updated wmgr code to use sqlalchemy instead of MySQLdb module.

Same is done for tests/MySqlUdf.py, plus updated that test script for
most recent scisql function names and signatures.

core/examples/obsolete/loader.py still has an import for MySQLdb, we
keep that obsolete script just in case someone wants to look at it but
we do not use it anywhere.

Note that I did not remove mysqlpython from ups table file as we still
depend on MySQLdb as a driver for sqlalchemy. We may switch to some
other driver in the future, then we can replace this dependency.