### PR TITLE
Tickets/DM-5030: Allow Qserv tests to pass on OS X El Capitan

### DIFF
--- a/ups/qserv.table
+++ b/ups/qserv.table
@@ -21,5 +21,7 @@ setupRequired(swig)
 setupRequired(xrootd)
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
+envPrepend(DYLD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
+envPrepend(LSST_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)


### PR DESCRIPTION
Minimum patch required to get Qserv to finally build on OS X El Capitan.

The `build/` directory in path was the only wrinkle. In theory we could make more extensive changes to how libraries and binaries are built with `@rpath` support but this seemed like a quick way to get things to work. I'm not sure if I can get the value of `build_dir` from the Scons environment rather than hard-coding it in as `build`.