### PR TITLE
Fixing discovery of mysql package by scons (DM-5125)

### DIFF
--- a/site_scons/state.py
+++ b/site_scons/state.py
@@ -136,7 +136,7 @@ def _setEnvWithDependencies():
                       PathVariable.PathIsFile)),
         (PathVariable('XROOTD_DIR', 'xrootd install dir', _findPrefixFromBin('XROOTD_DIR', "xrootd"),
                       PathVariable.PathIsDir)),
-        (PathVariable('MYSQL_DIR', 'mysql install dir', _findPrefixFromBin('MYSQL_DIR', "mysqld_safe"),
+        (PathVariable('MYSQL_DIR', 'mysql install dir', _findPrefixFromBin('MYSQL_DIR', "mysqld"),
                       PathVariable.PathIsDir)),
         (PathVariable('MYSQLPROXY_DIR', 'mysqlproxy install dir',
                       _findPrefixFromBin('MYSQLPROXY_DIR', "mysql-proxy"),


### PR DESCRIPTION
Make scons search for mysqld instead of mysqld_safe, latter may exist in
a location which has client-only installation.