### PR TITLE
Support human-friendly Thread ID in logging messages (DM-4756)

### DIFF
--- a/admin/templates/configuration/etc/log4cxx.czar.properties
+++ b/admin/templates/configuration/etc/log4cxx.czar.properties
@@ -11,7 +11,7 @@ log4j.rootLogger=DEBUG, CONSOLE
 # message on stderr
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [%t] %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
 
 log4j.appender.FILE=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.FILE.File={{QSERV_LOG_DIR}}/qserv-czar.log
@@ -20,7 +20,7 @@ log4j.appender.FILE.DatePattern="'.'yyyy-MM-dd"
 log4j.appender.FILE.MaxBackupIndex=30
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 # Follow RFC3339 data format (see http://tools.ietf.org/html/rfc3339)
-log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} [%t] %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
 
 # Tune log at the module level
 log4j.logger.lsst.qserv.qproc=DEBUG

--- a/admin/templates/configuration/etc/log4cxx.worker.properties
+++ b/admin/templates/configuration/etc/log4cxx.worker.properties
@@ -7,4 +7,4 @@ log4j.rootLogger=DEBUG, XRDLOG
 # Appender for xrootd log file
 log4j.appender.XRDLOG=org.apache.log4j.XrootdAppender
 log4j.appender.XRDLOG.layout=org.apache.log4j.PatternLayout
-log4j.appender.XRDLOG.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [%t] %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.XRDLOG.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n

--- a/core/modules/xrdsvc/SsiService.cc
+++ b/core/modules/xrdsvc/SsiService.cc
@@ -58,6 +58,13 @@ class XrdPosixCallBack; // Forward.
 
 namespace {
 LOG_LOGGER _log = LOG_GET("lsst.qserv.xrdsvc.SsiService");
+
+// add LWP to MDC in log messages
+void initMDC() {
+    LOG_MDC("LWP", std::to_string(lsst::log::lwpID()));
+}
+int dummyInitMDC = LOG_MDC_INIT(initMDC);
+
 }
 
 namespace lsst {


### PR DESCRIPTION
Needs the same branch from log package to work. Uses new log facility
(LOG_MDC_INIT macro) to add LWP to MDC in mesages in czar and workers.
Logging format string was changed for czar and workers to display LWP
instead of Thread ID.