### PR TITLE
Implement unique query-id generation (DM-5314)

### DIFF
--- a/core/modules/ccontrol/UserQuery.h
+++ b/core/modules/ccontrol/UserQuery.h
@@ -79,6 +79,9 @@ public:
     // Delegate objects
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() = 0;
 
+    /// @return Name of the result table for this query, can be empty
+    virtual std::string getResultTableName() = 0;
+
     /// @return ORDER BY part of SELECT statement to be executed by proxy
     virtual std::string getProxyOrderBy() = 0;
 

--- a/core/modules/ccontrol/UserQueryDrop.h
+++ b/core/modules/ccontrol/UserQueryDrop.h
@@ -62,7 +62,6 @@ public:
      *  @param tableName:     Name of the table to drop, if empty then drop
      *                        entire database
      *  @param resultDbConn:  Connection to results database
-     *  @param resultTable:   Name of the table for query results
      *  @param queryMetadata: QMeta interface
      *  @param qMetaCzarId:   Czar ID in QMeta database
      */
@@ -70,7 +69,6 @@ public:
                   std::string const& dbName,
                   std::string const& tableName,
                   sql::SqlConnection* resultDbConn,
-                  std::string const& resultTable,
                   std::shared_ptr<qmeta::QMeta> const& queryMetadata,
                   qmeta::CzarId qMetaCzarId);
 
@@ -100,6 +98,9 @@ public:
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
 
+    /// @return Name of the result table for this query, can be empty
+    virtual std::string getResultTableName() override { return std::string(); }
+
     /// @return ORDER BY part of SELECT statement to be executed by proxy
     virtual std::string getProxyOrderBy() override { return std::string(); }
 
@@ -112,7 +113,6 @@ private:
     std::string const _dbName;
     std::string const _tableName;
     sql::SqlConnection* _resultDbConn;
-    std::string const _resultTable;
     std::shared_ptr<qmeta::QMeta> _queryMetadata;
     qmeta::CzarId const _qMetaCzarId;   ///< Czar ID in QMeta database
     QueryState _qState;

--- a/core/modules/ccontrol/UserQueryFactory.h
+++ b/core/modules/ccontrol/UserQueryFactory.h
@@ -58,13 +58,9 @@ public:
 
     /// @param query:       Query text
     /// @param defaultDb:   Default database name, may be empty
-    /// @param resultTable: Name of the table to store results
-    /// @param userQueryId: Unique ID for new query
     /// @return new UserQuery object
     UserQuery::Ptr newUserQuery(std::string const& query,
-                                std::string const& defaultDb,
-                                std::string const& resultTable,
-                                uint64_t userQueryId);
+                                std::string const& defaultDb);
 
 private:
     class Impl;

--- a/core/modules/ccontrol/UserQueryFlushChunksCache.h
+++ b/core/modules/ccontrol/UserQueryFlushChunksCache.h
@@ -59,12 +59,10 @@ public:
      *  @param css:           CSS interface
      *  @param dbName:        Name of the database where table is
      *  @param resultDbConn:  Connection to results database
-     *  @param resultTable:   Name of the table for query results
      */
     UserQueryFlushChunksCache(std::shared_ptr<css::CssAccess> const& css,
                               std::string const& dbName,
-                              sql::SqlConnection* resultDbConn,
-                              std::string const& resultTable);
+                              sql::SqlConnection* resultDbConn);
 
     UserQueryFlushChunksCache(UserQueryFlushChunksCache const&) = delete;
     UserQueryFlushChunksCache& operator=(UserQueryFlushChunksCache const&) = delete;
@@ -92,6 +90,9 @@ public:
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
 
+    /// @return Name of the result table for this query, can be empty
+    virtual std::string getResultTableName() override { return std::string(); }
+
     /// @return ORDER BY part of SELECT statement to be executed by proxy
     virtual std::string getProxyOrderBy() override { return std::string(); }
 
@@ -102,7 +103,6 @@ private:
     std::shared_ptr<css::CssAccess> const _css;
     std::string const _dbName;
     sql::SqlConnection* _resultDbConn;
-    std::string const _resultTable;
     QueryState _qState;
     std::shared_ptr<qdisp::MessageStore> _messageStore;
 

--- a/core/modules/ccontrol/UserQueryInvalid.h
+++ b/core/modules/ccontrol/UserQueryInvalid.h
@@ -76,6 +76,9 @@ public:
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
 
+    /// @return Name of the result table for this query, can be empty
+    virtual std::string getResultTableName() override { return std::string(); }
+
     /// @return ORDER BY part of SELECT statement to be executed by proxy
     virtual std::string getProxyOrderBy() override { return std::string(); }
 

--- a/core/modules/ccontrol/UserQuerySelect.h
+++ b/core/modules/ccontrol/UserQuerySelect.h
@@ -82,7 +82,6 @@ public:
                     std::shared_ptr<qproc::SecondaryIndex> const& secondaryIndex,
                     std::shared_ptr<qmeta::QMeta> const& queryMetadata,
                     qmeta::CzarId czarId,
-                    uint64_t userQueryId,
                     std::string const& errorExtra);
 
     UserQuerySelect(UserQuerySelect const&) = delete;
@@ -110,6 +109,9 @@ public:
     // Delegate objects
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
+
+    /// @return Name of the result table for this query, can be empty
+    virtual std::string getResultTableName() override { return _resultTable; }
 
     /// @return ORDER BY part of SELECT statement to be executed by proxy
     virtual std::string getProxyOrderBy() override;
@@ -140,9 +142,9 @@ private:
     bool _killed;
     bool _submitted;                ///< True after submit() is completed
     std::mutex _killMutex;
-    uint64_t _userQueryId;          ///< Unique query identifier
     int _sequence;                  ///< Sequence number for subtask ids
     std::string _errorExtra;        ///< Additional error information
+    std::string _resultTable;       ///< Result table name
 };
 
 }}} // namespace lsst::qserv:ccontrol

--- a/core/modules/czar/Czar.cc
+++ b/core/modules/czar/Czar.cc
@@ -113,7 +113,6 @@ Czar::submitQuery(std::string const& query,
 
     // make table names
     auto userQueryIdStr = std::to_string(userQueryId);
-    std::string const resultName = _resultConfig.dbName + ".result_" + userQueryIdStr;
     std::string const lockName = _resultConfig.dbName + ".message_" + userQueryIdStr;
 
     SubmitResult result;
@@ -133,7 +132,7 @@ Czar::submitQuery(std::string const& query,
     ccontrol::UserQuery::Ptr uq;
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        uq = _uqFactory->newUserQuery(query, defDb, resultName, userQueryId);
+        uq = _uqFactory->newUserQuery(query, defDb);
     }
 
     // check for errors
@@ -186,7 +185,9 @@ Czar::submitQuery(std::string const& query,
     }
 
     // return all info to caller
-    result.resultTable = resultName;
+    if (not uq->getResultTableName().empty()) {
+        result.resultTable = _resultConfig.dbName + "." + uq->getResultTableName();
+    }
     result.messageTable = lockName;
     result.orderBy = uq->getProxyOrderBy();
     LOGS(_log, LOG_LVL_DEBUG, "returning result to proxy: resultTable="

--- a/core/modules/proxy/mysqlProxy.lua
+++ b/core/modules/proxy/mysqlProxy.lua
@@ -413,16 +413,23 @@ function queryProcessing()
         proxy.queries:append(1, string.char(proxy.COM_QUERY) .. q1,
                              {resultset_is_needed = true})
 
-        local q2 = "SELECT * FROM " .. self.resultTableName .. " " .. self.orderByClause
+        -- if no result table then do something that returns empty result set
+        local q2 = "SELECT NULL FROM DUAL LIMIT 0"
+        if self.resultTableName ~= "" then
+            q2 = "SELECT * FROM " .. self.resultTableName .. " " .. self.orderByClause
+        end
         proxy.queries:append(2, string.char(proxy.COM_QUERY) .. q2,
                              {resultset_is_needed = true})
+
         local q3 = "DROP TABLE " .. self.msgTableName
         proxy.queries:append(3, string.char(proxy.COM_QUERY) .. q3,
                              {resultset_is_needed = true})
 
-        local q4 = "DROP TABLE " .. self.resultTableName
-        proxy.queries:append(4, string.char(proxy.COM_QUERY) .. q4,
-                             {resultset_is_needed = true})
+        if self.resultTableName ~= "" then
+            local q4 = "DROP TABLE " .. self.resultTableName
+            proxy.queries:append(4, string.char(proxy.COM_QUERY) .. q4,
+                                 {resultset_is_needed = true})
+        end
 
         return SUCCESS
     end

--- a/core/modules/qproc/QuerySession.cc
+++ b/core/modules/qproc/QuerySession.cc
@@ -195,10 +195,6 @@ void QuerySession::setDummy() {
     _chunks.push_back(ChunkSpec(DUMMY_CHUNK, v));
 }
 
-void QuerySession::setResultTable(std::string const& resultTable) {
-    _resultTable = resultTable;
-}
-
 std::string const& QuerySession::getDominantDb() const {
     return _context->dominantDb; // parsed query's dominant db (via TablePlugin)
 }

--- a/core/modules/qproc/QuerySession.h
+++ b/core/modules/qproc/QuerySession.h
@@ -100,12 +100,6 @@ public:
 
     query::SelectStmtPtrVector const& getStmtParallel() const { return _stmtParallel; }
 
-    // Resulttable concept will be obsolete after we implement query result
-    // marshalling/transfer (at which point, table dump and restore will also be
-    // obsolete).
-    void setResultTable(std::string const& resultTable);
-    std::string const& getResultTable() const { return _resultTable; }
-
     /** @brief Return the ORDER BY clause to run on mysql-proxy at result retrieval.
      *
      *  Indeed, MySQL results order is undefined with simple "SELECT *" clause.


### PR DESCRIPTION
Query ID is now generated by QMeta when registering new query and it is
globally unique. This query ID is not used for the message table name
which is still generated from the same "user query ID", the reason is
that message table should be created before the rest of the system kicks
in and message table must exist even if we don't register (or fail to
register) query in QMeta.

As a small optimization czar now avoids creation of the result table
when it is not used (for some non-SELECT queries). Proxy Lua logic is
updated to handle empty result table name.