### PR TITLE
Fix MySQL connection close handling

### DIFF
--- a/core/modules/mysql/MySqlConnection.cc
+++ b/core/modules/mysql/MySqlConnection.cc
@@ -94,14 +94,21 @@ MySqlConnection::~MySqlConnection() {
             while((row = mysql_fetch_row(_mysql_res))); // Drain results.
             _mysql_res = nullptr;
         }
-        mysql_close(_mysql);
+        closeMySqlConn();
     }
+}
+
+void
+MySqlConnection::closeMySqlConn() {
+    // Close mysql connection and set deallocated pointer to null
+    mysql_close(_mysql);
+    _mysql = nullptr;
 }
 
 bool
 MySqlConnection::connect() {
     // Cleanup garbage
-    if (_mysql) { mysql_close(_mysql); }
+    if (_mysql) { closeMySqlConn(); }
     _isConnected = false;
     // Make myself a thread
     _mysql = _connectHelper();

--- a/core/modules/mysql/MySqlConnection.h
+++ b/core/modules/mysql/MySqlConnection.h
@@ -55,6 +55,7 @@ public:
 
     ~MySqlConnection();
 
+    void closeMySqlConn();
     bool connect();
 
     bool connected() const { return _isConnected; }

--- a/core/modules/sql/SqlConnection.cc
+++ b/core/modules/sql/SqlConnection.cc
@@ -126,14 +126,18 @@ SqlConnection::~SqlConnection() {
 
 bool
 SqlConnection::connectToDb(SqlErrorObject& errObj) {
-    assert(_connection.get());
-    if (_connection->connected()) return true;
+    if (_connection->connected()) {
+        int rc = mysql_ping(_connection->getMySql());
+        if (rc == 0) return true;
+        _connection->closeMySqlConn();
+    }
+
     if (!_connection->connect()) {
         _setErrorObject(errObj);
         return false;
-    } else {
-        return true;
     }
+
+    return true;
 }
 
 bool


### PR DESCRIPTION
If the MySQL pointer was allocated by `mysql_init()`, and you plan to reuse the connection descriptor, then it is important to set it to `NULL` after `mysql_close()`, otherwise the next init will think it's already allocated, then the next call for `mysql_real_connect()` will cause a SEGFAULT. This is what was observed and I've added a new function to handle closing this connection properly. 