### PR TITLE
Set 'qserv master' param at container execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ language: c++
 
 before_install:
   - docker pull qserv/qserv:dev
-  - cp ./admin/tools/docker/deployment/travis/env.sh .
+  - cp ./admin/tools/docker/deployment/travis/env.sh ./admin/tools/docker/deployment/localhost/env.sh
 
 script:
   - ./admin/tools/docker/3_build-git-image.sh -L -T travis -S "$PWD"
-  - ./admin/tools/docker/4_build-configured-images.sh -L -i travis master.localdomain
+  - ./admin/tools/docker/4_build-configured-images.sh -L -i travis
   - ./admin/tools/docker/deployment/localhost/run-multinode-tests.sh

--- a/admin/tools/docker/4_build-configured-images.sh
+++ b/admin/tools/docker/4_build-configured-images.sh
@@ -31,7 +31,7 @@ PUSH_TO_HUB="true"
 
 usage() {
     cat << EOD
-Usage: $(basename "$0") [options] host
+Usage: $(basename "$0") [options]
 
 Available options:
   -h          this message
@@ -40,7 +40,6 @@ Available options:
 
 Create docker images containing Qserv master and worker instances,
 use an existing Qserv Docker image as input.
-Qserv master fqdn or ip adress must be provided as unique argument.
 
 EOD
 }
@@ -56,12 +55,10 @@ while getopts hi:L c ; do
 done
 shift "$((OPTIND-1))"
 
-if [ $# -ne 1 ] ; then
+if [ $# -ne 0 ] ; then
     usage
     exit 2
 fi
-
-MASTER=$1
 
 DIR=$(cd "$(dirname "$0")"; pwd -P)
 DOCKERDIR="$DIR/configured"
@@ -72,10 +69,9 @@ DOCKERFILE="$DOCKERDIR/Dockerfile"
 cp "$DOCKERDIR/Dockerfile.tpl" "$DOCKERFILE"
 sed -i 's%{{NODE_TYPE_OPT}}%-m%g' "$DOCKERFILE"
 sed -i "s%{{DOCKER_IMAGE_OPT}}%$DOCKER_IMAGE%g" "$DOCKERFILE"
-sed -i "s%{{MASTER_FQDN_OPT}}%${MASTER}%g" "$DOCKERFILE"
 sed -i 's%{{COMMENT_ON_WORKER_OPT}}%%g' "$DOCKERFILE"
 
-TAG="${DOCKER_IMAGE}_master_${MASTER}"
+TAG="${DOCKER_IMAGE}_master"
 printf "Building master image %s from %s\n" "$TAG" "$DOCKERDIR"
 docker build --tag="$TAG" "$DOCKERDIR"
 printf "Image %s built successfully\n" "$TAG"
@@ -91,10 +87,9 @@ fi
 cp "$DOCKERDIR/Dockerfile.tpl" "$DOCKERFILE"
 sed -i 's%{{NODE_TYPE_OPT}}%%g' "$DOCKERFILE"
 sed -i "s%{{DOCKER_IMAGE_OPT}}%$DOCKER_IMAGE%g" "$DOCKERFILE"
-sed -i "s%{{MASTER_FQDN_OPT}}%${MASTER}%g" "$DOCKERFILE"
 sed -i 's%{{COMMENT_ON_WORKER_OPT}}%# %g' "$DOCKERFILE"
 
-TAG="${DOCKER_IMAGE}_worker_${MASTER}"
+TAG="${DOCKER_IMAGE}_worker"
 printf "Building worker image %s from %s\n" "$TAG" "$DOCKERDIR"
 docker build --tag="$TAG" "$DOCKERDIR"
 printf "Image %s built successfully\n" "$TAG"

--- a/admin/tools/docker/configured/Dockerfile.tpl
+++ b/admin/tools/docker/configured/Dockerfile.tpl
@@ -15,11 +15,11 @@ EXPOSE 5012 1094
 
 COPY scripts/*.sh scripts/
 
-RUN bash -c ". /qserv/stack/loadLSST.bash && setup qserv -t qserv-dev && /qserv/scripts/configure.sh {{NODE_TYPE_OPT}} {{MASTER_FQDN_OPT}}"
+RUN bash -c ". /qserv/stack/loadLSST.bash && setup qserv -t qserv-dev && /qserv/scripts/configure.sh {{NODE_TYPE_OPT}}"
 
 # WARNING: Unsafe because it is pushed in Docker Hub
 # TODO: use consul to manage secret
-COPY wmgr.secret /qserv/run/etc/
+COPY wmgr.secret /qserv/run/etc/wmgr.secret.example
 
 # This script does not exit
 CMD /qserv/scripts/start.sh

--- a/admin/tools/docker/configured/scripts/configure.sh
+++ b/admin/tools/docker/configured/scripts/configure.sh
@@ -30,14 +30,14 @@ set -e
 usage() {
   cat << EOD
 
-Usage: `basename $0` [options] host
+Usage: `basename $0` [options]
 
   Available options:
     -h          this message
     -m          configure Qserv master, instead of worker by default
 
-  Configure a Qserv worker/master in a docker image. Qserv master fqdn
-  must be provided.
+  Configure a Qserv worker/master in a docker image,
+  except Qserv master hostname parameter, set later at container execution.
 EOD
 }
 
@@ -53,12 +53,10 @@ while getopts hm c ; do
 done
 shift `expr $OPTIND - 1`
 
-if [ $# -ne 1 ] ; then
+if [ $# -ne 0 ] ; then
     usage
     exit 2
 fi
-
-MASTER=$1
 
 DIR=$(cd "$(dirname "$0")"; pwd -P)
 . $DIR/params.sh
@@ -71,7 +69,7 @@ qserv-configure.py --init --force \
 # Customize meta configuration file
 sed -i "s/node_type = mono/node_type = $NODE_TYPE/" \
     $QSERV_RUN_DIR/qserv-meta.conf
-sed -i "s/master = 127.0.0.1/master = $MASTER/" \
+sed -i "s/master = 127.0.0.1/master = <DOCKER_ENV_QSERV_MASTER>/" \
     $QSERV_RUN_DIR/qserv-meta.conf
 
 qserv-configure.py --qserv-run-dir $QSERV_RUN_DIR --force

--- a/admin/tools/docker/deployment/in2p3/env.example.sh
+++ b/admin/tools/docker/deployment/in2p3/env.example.sh
@@ -1,13 +1,8 @@
 # Rename this file to env.sh and edit configuration parameters
 # env.sh is sourced by other scripts from the directory
 
-# Nodes names
-# ===========
-
-MASTER=ccqserv100.in2p3.fr
-WORKERS=$(echo ccqserv1{01..24}.in2p3.fr)
-#MASTER=ccqserv125.in2p3.fr
-#WORKERS=$(echo ccqserv1{26..49}.in2p3.fr)
+# shmux path
+PATH=$PATH:/opt/shmux/bin/
 
 # Image names
 # ===========
@@ -18,20 +13,49 @@ WORKERS=$(echo ccqserv1{01..24}.in2p3.fr)
 # example: tickets_DM-5402
 BRANCH=dev
 
-MASTER_IMAGE="qserv/qserv:${BRANCH}_master_$MASTER"  # Do not edit
-WORKER_IMAGE="qserv/qserv:${BRANCH}_worker_$MASTER"  # Do not edit
-
 # `docker run` settings
 # =====================
 
 # Data directory location on docker host, optional
-HOST_DATA_DIR=/qserv/data               
+HOST_DATA_DIR=/qserv/data
 
 # Log directory location on docker host, optional
 HOST_LOG_DIR=/qserv/log
 
-CONTAINER_NAME=qserv                                 # Do not edit
 
-# shmux access
-export PATH="$PATH:/opt/shmux/bin"
+# Nodes names
+# ===========
+
+# Format for all node names
+HOSTNAME_FORMAT="ccqserv%g.in2p3.fr"
+
+# Master id
+MASTER_ID=100
+
+# Workers range
+WORKER_FIRST_ID=101
+WORKER_LAST_ID=124
+
+# Master id
+# MASTER_ID=125
+
+# Workers range
+# WORKER_FIRST_ID=126
+# WORKER_LAST_ID=149
+
+# Disjoint sequences of host names can
+# be set directly using variables below
+MASTER=$(printf "$HOSTNAME_FORMAT" "$MASTER_ID")    # Master hostname. Do not edit
+WORKERS=$(seq --format "$HOSTNAME_FORMAT" \
+    --separator=' ' "$WORKER_FIRST_ID" \
+    "$WORKER_LAST_ID")                              # Worker hostnames list. Do not edit
+
+
+# Advanced configuration
+# ======================
+
+CONTAINER_NAME=qserv                                # Do not edit
+
+MASTER_IMAGE="qserv/qserv:${BRANCH}_master"         # Do not edit
+WORKER_IMAGE="qserv/qserv:${BRANCH}_worker"         # Do not edit
 

--- a/admin/tools/docker/deployment/in2p3/run-test-queries.sh
+++ b/admin/tools/docker/deployment/in2p3/run-test-queries.sh
@@ -10,7 +10,7 @@ DIR=$(cd "$(dirname "$0")"; pwd -P)
 
 . /qserv/stack/loadLSST.bash
 
-setup mysqlclient
+setup mariadbclient
 time mysql --host "$MASTER" --port 4040 --user qsmaster LSST -e "SELECT ra, decl FROM Object WHERE deepSourceId = 2322920177142607;"
 
 setup mysqlpython

--- a/admin/tools/docker/deployment/localhost/env.example.sh
+++ b/admin/tools/docker/deployment/localhost/env.example.sh
@@ -17,8 +17,7 @@ do
 done
 
 # Set images names
-DOCKER_ORG=qserv
-MASTER_IMAGE="$DOCKER_ORG/qserv:${VERSION}_master_$MASTER"
-WORKER_IMAGE="$DOCKER_ORG/qserv:${VERSION}_worker_$MASTER"
+MASTER_IMAGE="qserv/qserv:${VERSION}_master"
+WORKER_IMAGE="qserv/qserv:${VERSION}_worker"
 
 

--- a/admin/tools/docker/deployment/parallel/env.example.sh
+++ b/admin/tools/docker/deployment/parallel/env.example.sh
@@ -1,12 +1,6 @@
 # Rename this file to env.sh and edit configuration parameters
 # env.sh is sourced by other scripts from the directory
 
-# Nodes names
-# ===========
-
-MASTER=qserv00.domain.org
-WORKERS=$(echo qserv0{1..3}.domain.org)
-
 # Image names
 # ===========
 
@@ -15,9 +9,6 @@ WORKERS=$(echo qserv0{1..3}.domain.org)
 #   2. a git tag
 # example: tickets_DM-5402
 BRANCH=dev
-
-MASTER_IMAGE="qserv/qserv:${BRANCH}_master_$MASTER"  # Do not edit
-WORKER_IMAGE="qserv/qserv:${BRANCH}_worker_$MASTER"  # Do not edit
 
 # `docker run` settings
 # =====================
@@ -28,4 +19,32 @@ WORKER_IMAGE="qserv/qserv:${BRANCH}_worker_$MASTER"  # Do not edit
 # Log directory location on docker host, optional
 # HOST_LOG_DIR=/qserv/log
 
-CONTAINER_NAME=qserv                                 # Do not edit
+
+# Nodes names
+# ===========
+
+# Format for all node names
+HOSTNAME_FORMAT="qserv%g.domain.org"
+
+# Master id
+MASTER_ID=1
+
+# Workers range
+WORKER_FIRST_ID=2
+WORKER_LAST_ID=3
+
+# Disjoint sequences of host names can
+# be set directly using variables below
+MASTER=$(printf "$HOSTNAME_FORMAT" "$MASTER_ID")    # Master hostname. Do not edit
+WORKERS=$(seq --format "$HOSTNAME_FORMAT" \
+    --separator=' ' "$WORKER_FIRST_ID" \
+    "$WORKER_LAST_ID")                              # Worker hostnames list. Do not edit
+
+
+# Advanced configuration
+# ======================
+
+CONTAINER_NAME=qserv                                # Do not edit
+
+MASTER_IMAGE="qserv/qserv:${BRANCH}_master"         # Do not edit
+WORKER_IMAGE="qserv/qserv:${BRANCH}_worker"         # Do not edit

--- a/admin/tools/docker/deployment/parallel/run.sh
+++ b/admin/tools/docker/deployment/parallel/run.sh
@@ -43,7 +43,9 @@ echo
 echo "Launch Qserv containers on master"
 echo "================================="
 echo
-shmux -Bm -c "docker run --detach=true \
+shmux -Bm -c "
+docker run --detach=true \
+    -e "QSERV_MASTER=$MASTER" \
     $DATA_VOLUME_OPT \
     $LOG_VOLUME_OPT \
     --name $CONTAINER_NAME --net=host \
@@ -54,6 +56,7 @@ echo "Launch Qserv containers on worker"
 echo "================================="
 echo
 shmux -Bm -S all -c "docker run --detach=true \
+    -e "QSERV_MASTER=$MASTER" \
     $DATA_VOLUME_OPT \
     $LOG_VOLUME_OPT \
     --name $CONTAINER_NAME --net=host \

--- a/admin/tools/docker/deployment/travis/env.sh
+++ b/admin/tools/docker/deployment/travis/env.sh
@@ -17,5 +17,5 @@ do
 done
 
 # Set images names
-MASTER_IMAGE="${VERSION}_master_${MASTER}"
-WORKER_IMAGE="${VERSION}_worker_${MASTER}"
+MASTER_IMAGE="${VERSION}_master"
+WORKER_IMAGE="${VERSION}_worker"

--- a/admin/tools/docker/latest/Dockerfile
+++ b/admin/tools/docker/latest/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /qserv
 # other files changes in scripts/
 COPY scripts/install-stack.sh scripts/install-stack.sh
 
-# Hack to enable diagnose of stack install failure
-RUN /bin/bash /qserv/scripts/install-stack.sh 2>&1 /qserv/STACK_INSTALL.out || echo 'INSTALL FAILED' > /qserv/STACK_INSTALL.err
+RUN /bin/bash /qserv/scripts/install-stack.sh 2>&1 /qserv/STACK_INSTALL.out
 
 COPY scripts/*.sh scripts/

--- a/doc/source/install/docker.rst
+++ b/doc/source/install/docker.rst
@@ -54,7 +54,7 @@ Create Qserv master and worker images from a given Qserv version:
    # Code need to be pushed on github
    # eups tag named qserv-dev will be used to setup Qserv version
    cd ${SRC_DIR}/qserv/admin/tools/docker
-   4_build-configured-image.sh -i <docker-image-name> <master-node-fqdn>
+   4_build-configured-image.sh -i <docker-image-name>
 
 *********
 Use cases
@@ -93,7 +93,7 @@ Host might be a development machine or a continuous integration server.
 
    ./change-uid.sh
 
-Build, configure and run Qserv from source in qserv:dev-uid container using
+Build, configure and run Qserv from source in qserv:work-uid container using
 source and run directory located on a development machine.
 
 .. code-block:: bash
@@ -103,7 +103,7 @@ source and run directory located on a development machine.
    -v /home/qserv/src/qserv:/home/dev/src/qserv \
    -v /home/qserv/qserv-run/:/home/dev/qserv-run \
    -u dev \
-   fjammes/qserv:dev-uid \
+   fjammes/qserv:work-uid \
    /bin/sh -c "/home/dev/scripts/build.sh && /qserv/scripts/mono-node-test.sh"
 
 ***************


### PR DESCRIPTION
- remove 'qserv master' parameter from dockerfile
- update configuration files at container start
  using QSERV_MASTER env variable
- update Travis scripts
- make env.example.sh pure-shell compliant
- update documentation