### PR TITLE
Add missing include file for lexical_cast

### DIFF
--- a/core/modules/qdisp/testQDisp.cc
+++ b/core/modules/qdisp/testQDisp.cc
@@ -25,6 +25,9 @@
 #include <string>
 #include <unistd.h>
 
+// Third-party headers
+#include "boost/lexical_cast.hpp"
+
 // Boost unit test header
 #define BOOST_TEST_MODULE Qdisp_1
 #include "boost/test/included/unit_test.hpp"

--- a/core/modules/sql/testSqlTransaction.cc
+++ b/core/modules/sql/testSqlTransaction.cc
@@ -29,6 +29,7 @@
 #include <unistd.h> // for getpass
 
 // Third-party headers
+#include "boost/lexical_cast.hpp"
 
 // Qserv headers
 #include "sql/SqlConnection.h"


### PR DESCRIPTION
Needed for Boost 1.60 compatibility.