### PR TITLE
tickets/DM-5753: XCode 7.3 is broken

### DIFF
--- a/site_scons/site_tools/compiler.py
+++ b/site_scons/site_tools/compiler.py
@@ -94,7 +94,7 @@ def generate(env):
 
         env['LDMODULESUFFIX'] = ".so"
         if not re.search(r"-install_name", str(env['SHLINKFLAGS'])):
-            env.Append(SHLINKFLAGS=["-Wl,-install_name", "-Wl,${TARGET.file}"])
+            env.Append(SHLINKFLAGS=["-install_name", "@rpath/${TARGET.file}"])
 
     elif platform == 'linux2':
         # Linux with any compiler

--- a/site_scons/site_tools/compiler.py
+++ b/site_scons/site_tools/compiler.py
@@ -86,6 +86,9 @@ def generate(env):
         env.Append(CCFLAGS=['-pedantic', '-Wall', '-Wno-variadic-macros'])
         env.Append(CXXFLAGS=['-std=c++11'])
 
+        # Required for XCode 7.3 @rpath linker issues
+        env['LIBDIRSUFFIX'] = "/"
+
         # copied from sconsUtils
         env.Append(SHLINKFLAGS=["-undefined", "suppress", "-flat_namespace", "-headerpad_max_install_names"])
 


### PR DESCRIPTION
Provides a workaround on OSX for the bug linking indirect libraries on OS X. Since I was messing with that code there is a second commit that cleans up the `-install_name` option and also switches that to use `@rpath` (which seems to be the recommended thing to do on OS X).