### PR TITLE
Provision Openstack infrastructure for Qserv

### DIFF
--- a/admin/tools/provision/.gitignore
+++ b/admin/tools/provision/.gitignore
@@ -1,0 +1,1 @@
+/ssh_config

--- a/admin/tools/provision/LSST-openrc.sh
+++ b/admin/tools/provision/LSST-openrc.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# To use an OpenStack cloud you need to authenticate against the Identity
+# service named keystone, which returns a **Token** and **Service Catalog**.
+# The catalog contains the endpoints for all services the user/tenant has
+# access to - such as Compute, Image Service, Identity, Object Storage, Block
+# Storage, and Networking (code-named nova, glance, keystone, swift,
+# cinder, and neutron).
+#
+# *NOTE*: Using the 2.0 *Identity API* does not necessarily mean any other
+# OpenStack API is version 2.0. For example, your cloud provider may implement
+# Image API v1.1, Block Storage API v2, and Compute API v2.0. OS_AUTH_URL is
+# only for the Identity API served through keystone.
+export OS_AUTH_URL=http://nebula.ncsa.illinois.edu:5000/v2.0
+
+# With the addition of Keystone we have standardized on the term **tenant**
+# as the entity that owns the resources.
+export OS_TENANT_ID=8c1ba1e0b84d486fbe7a665c30030113
+export OS_TENANT_NAME="LSST"
+export OS_PROJECT_NAME="LSST"
+
+# In addition to the owning entity (tenant), OpenStack stores the entity
+# performing the action as the **user**.
+export OS_USERNAME="lsst-aaoualid"
+
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack Password: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+
+# If your configuration has multiple regions, we set that information here.
+# OS_REGION_NAME is optional and only valid in certain environments.
+export OS_REGION_NAME="RegionOne"
+# Don't leave a blank variable, unset it if it was empty
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi

--- a/admin/tools/provision/LSST-openrc.sh.example
+++ b/admin/tools/provision/LSST-openrc.sh.example
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# To use an OpenStack cloud you need to authenticate against the Identity
+# service named keystone, which returns a **Token** and **Service Catalog**.
+# The catalog contains the endpoints for all services the user/tenant has
+# access to - such as Compute, Image Service, Identity, Object Storage, Block
+# Storage, and Networking (code-named nova, glance, keystone, swift,
+# cinder, and neutron).
+#
+# *NOTE*: Using the 2.0 *Identity API* does not necessarily mean any other
+# OpenStack API is version 2.0. For example, your cloud provider may implement
+# Image API v1.1, Block Storage API v2, and Compute API v2.0. OS_AUTH_URL is
+# only for the Identity API served through keystone.
+export OS_AUTH_URL=http://nebula.ncsa.illinois.edu:5000/v2.0
+
+# With the addition of Keystone we have standardized on the term **tenant**
+# as the entity that owns the resources.
+export OS_TENANT_ID=8c1ba1e0b84d486fbe7a665c30030113
+export OS_TENANT_NAME="LSST"
+export OS_PROJECT_NAME="LSST"
+
+# In addition to the owning entity (tenant), OpenStack stores the entity
+# performing the action as the **user**.
+export OS_USERNAME="lsst-aaoualid"
+
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack Password: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+
+# If your configuration has multiple regions, we set that information here.
+# OS_REGION_NAME is optional and only valid in certain environments.
+export OS_REGION_NAME="RegionOne"
+# Don't leave a blank variable, unset it if it was empty
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi

--- a/admin/tools/provision/README.rst
+++ b/admin/tools/provision/README.rst
@@ -1,0 +1,57 @@
+**************************************
+Provision Qserv using Docker+Openstack
+**************************************
+
+Pre-requisite
+-------------
+
+* Install system dependencies
+
+.. code-block:: bash
+
+   sudo apt-get install python-dev python-pip
+
+   # Install the OpenStack client
+   sudo pip install python-openstackclient
+
+   # Install the nova client
+   sudo pip install python-novaclient
+
+* Download Openstack RC file: http://docs.openstack.org/user-guide/common/cli_set_environment_variables_using_openstack_rc.html
+
+* Install shmux to run multi node tests
+see http://web.taranis.org/shmux/
+
+
+Provision Qserv & run multinode tests
+-------------------------------------
+   
+* Clone Qserv repository and set Openstack environment and parameters:
+
+.. code-block:: bash
+
+   SRC_DIR=${HOME}/src
+   mkdir ${SRC_DIR}
+   cd ${SRC_DIR}
+   git clone https://github.com/lsst/qserv.git
+   cd qserv/admin/tools/provision
+
+   # Source Openstack RC file
+   # This is an example for NCSA 
+   . ./LSST-openrc.sh
+
+   # Update the configuration file which contains instance parameters
+   # Add special tuning if needed
+   mv ncsa.conf.example ncsa.conf
+
+Update :program:`test.sh` top parameters to set the configuration files above, the snapshot name and the number of servers to boot.
+
+* Create customized image, provision openstack cluster and run Qserv multinodes tests:
+
+.. warning::
+   Make sure that run-multinode-test doesn't fail in order to save ~/.ssh/config
+   your old ~/.ssh/config is in ~/.ssh/config.backup
+
+.. code-block:: bash
+
+   ./test.sh

--- a/admin/tools/provision/README.rst
+++ b/admin/tools/provision/README.rst
@@ -20,7 +20,7 @@ Pre-requisite
 * Download Openstack RC file: http://docs.openstack.org/user-guide/common/cli_set_environment_variables_using_openstack_rc.html
 
 * Install shmux to run multi node tests
-  * see http://web.taranis.org/shmux/
+   see http://web.taranis.org/shmux/
 
 
 Provision Qserv & run multinode tests

--- a/admin/tools/provision/README.rst
+++ b/admin/tools/provision/README.rst
@@ -20,7 +20,7 @@ Pre-requisite
 * Download Openstack RC file: http://docs.openstack.org/user-guide/common/cli_set_environment_variables_using_openstack_rc.html
 
 * Install shmux to run multi node tests
-see http://web.taranis.org/shmux/
+  * see http://web.taranis.org/shmux/
 
 
 Provision Qserv & run multinode tests

--- a/admin/tools/provision/cloudmanager.py
+++ b/admin/tools/provision/cloudmanager.py
@@ -102,7 +102,6 @@ class CloudManager(object):
 
         with open(config_file_name, 'r') as config_file:
             config.readfp(config_file)
-        config_file.close()
 
         self._creds = get_nova_creds()
         logging.debug("Openstack user: %s", self._creds['username'])

--- a/admin/tools/provision/cloudmanager.py
+++ b/admin/tools/provision/cloudmanager.py
@@ -265,14 +265,18 @@ class CloudManager(object):
         for instance in instances:
             cmd = ['ssh', '-t', '-F', './ssh_config', instance.name, 'true']
             success = False
-            occurence = 0
-            while not success and occurence<10:
+            nb_try = 0
+            while not success:
                 try:
-                    time.sleep(2)
                     check_output(cmd)
                     success = True
                 except CalledProcessError as exc:
-                    logging.warn("Waiting for ssh to be avalaible on %s: %s", instance.name, exc.output)
+                    logging.warn("Waiting for ssh to be available on %s: %s", instance.name, exc.output)
+                    nb_try += 1
+                    if nb_try > 10:
+                        logging.fatal("No available ssh on %s OpenStack clean up is required", instance.name)
+                        sys.exit(1)
+                    time.sleep(2)
             logging.debug("ssh available on %s", instance.name)
 
     def update_etc_hosts(self, instances):

--- a/admin/tools/provision/cloudmanager.py
+++ b/admin/tools/provision/cloudmanager.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python
+
+"""
+Tools to ease Openstack infrastructure configuration
+and provisioning
+
+@author  Oualid Achbal, IN2P3
+
+"""
+
+# -------------------------------
+#  Imports of standard modules --
+# -------------------------------
+import ConfigParser
+import logging
+import os
+import re
+from subprocess import CalledProcessError, check_output
+import sys
+import time
+import warnings
+
+# ----------------------------
+# Imports for other modules --
+# ----------------------------
+from novaclient import client
+import novaclient.exceptions
+
+# -----------------------
+# Exported definitions --
+# -----------------------
+
+BASE_IMAGE_KEY='base_image_name'
+SNAPSHOT_IMAGE_KEY='snapshot_name'
+
+def get_nova_creds():
+    """
+    Extract the login information from the environment
+    """
+    creds = {}
+    creds['version'] = 2
+    creds['username'] = os.environ['OS_USERNAME']
+    creds['api_key'] = os.environ['OS_PASSWORD']
+    creds['auth_url'] = os.environ['OS_AUTH_URL']
+    creds['project_id'] = os.environ['OS_TENANT_NAME']
+    creds['insecure'] = True
+    return creds
+
+def add_parser_args(parser):
+    """
+    Configure the parser
+    """
+    parser.add_argument('-v', '--verbose', dest='verbose', default=[], action='append_const',
+                        const=None, help='More verbose output, can use several times.')
+    parser.add_argument('--verbose-all', dest='verboseAll', default=False, action='store_true',
+                        help='Apply verbosity to all loggers, by default only loader level is set.')
+    # parser = lsst.qserv.admin.logger.add_logfile_opt(parser)
+    group = parser.add_argument_group('Cloud configuration options',
+                                       'Options defining parameters to access remote cloud-platform')
+
+    group.add_argument('-f', '--config', dest='configFile',
+                        required=True, metavar='PATH',
+                        help='Add cloud config file which contains instance characteristics')
+
+    return parser
+
+def config_logger(loggerName, verbose, verboseAll):
+    """
+    Configure the logger
+    """
+    verbosity = len(verbose)
+    levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    if not verboseAll:
+        # suppress INFO/DEBUG regular messages from other loggers
+        # Disable requests and urllib3 package logger and warnings
+        logging.getLogger("requests").setLevel(logging.ERROR)
+        logging.getLogger("urllib3").setLevel(logging.ERROR)
+
+    logging.basicConfig(format='%(asctime)s %(levelname)-8s %(name)-15s'
+                               ' %(message)s',
+                        level=levels.get(verbosity, logging.DEBUG))
+
+    warnings.filterwarnings("ignore")
+
+
+class CloudManager(object):
+    """Application class for common definitions for creation of snapshot and provision qserv"""
+
+    def __init__(self, config_file_name, used_image_key=BASE_IMAGE_KEY, add_ssh_key=False):
+        """
+        Constructor parse all arguments
+
+        @param config_file_name define the configuration file containing cloud parameters
+        @param used_image_key base image or snapshot
+        @param add_ssh_key Add ssh key only while launching instances in provision qserv.
+        """
+
+        logging.debug("Use configuration file: {}".format(config_file_name))
+
+        config = ConfigParser.ConfigParser({'net-id': None,
+                                            'ssh_security_group': None})
+
+        with open(config_file_name, 'r') as config_file:
+            config.readfp(config_file)
+        config_file.close()
+
+        self._creds = get_nova_creds()
+        logging.debug("Openstack user: {}".format(self._creds['username']))
+        self._safe_username = self._creds['username'].replace('.', '')
+        self.nova = client.Client(**self._creds)
+
+        base_image_name = config.get('openstack', used_image_key)
+        self.snapshot_name = config.get('openstack', 'snapshot_name')
+        self.image = self.nova.images.find(name=base_image_name)
+
+        flavor_name = config.get('openstack', 'flavor_name')
+        self.flavor = self.nova.flavors.find(name=flavor_name)
+
+        self.network_name = config.get('openstack', 'network_name')
+        if config.get('openstack', 'net-id'):
+            unicode_net_id = unicode(config.get('openstack', 'net-id'))
+            self.nics = [{'net-id': unicode_net_id}]
+        else:
+            self.nics = []
+        self.ssh_security_group = config.get('openstack', 'ssh_security_group')
+
+        # Upload ssh public key
+        if add_ssh_key:
+            self.key = "{}-qserv".format(self._safe_username)
+        else:
+            self.key = None
+
+        self.key_filename = '~/.ssh/id_rsa'
+
+    def nova_image_create(self, instance):
+        """
+        Create an openstack image containing Docker
+        """
+        logging.info("Creating Qserv image")
+        qserv_image = instance.create_image(self.snapshot_name)
+        status = None
+        while status != 'ACTIVE':
+            time.sleep(5)
+            status = self.nova.images.get(qserv_image).status
+        logging.info("SUCCESS: Qserv image '{}' is active".format(self.snapshot_name))
+
+    def nova_servers_create(self, instance_id, userdata):
+        """
+        Boot an instance and check status
+        """
+        instance_name = "{0}-qserv-{1}".format(self._safe_username, instance_id)
+        logging.info("Launch an instance {}".format(instance_name))
+
+        # Launch an instance from an image
+        instance = self.nova.servers.create(name=instance_name,
+                                            image=self.image,
+                                            flavor=self.flavor,
+                                            userdata=userdata,
+                                            key_name=self.key,
+                                            nics=self.nics)
+        # Poll at 5 second intervals, until the status is no longer 'BUILD'
+        status = instance.status
+        while status != 'ACTIVE':
+            time.sleep(5)
+            instance.get()
+            status = instance.status
+        logging.info("status: {}".format(status))
+        logging.info("Instance {} is active".format(instance_name))
+
+        return instance
+
+    def detect_end_cloud_config(self, instance):
+        """
+        Add clean wait for cloud-init completion
+        """
+        check_word = "---SYSTEM READY FOR SNAPSHOT---"
+        end_word = None
+        while not end_word:
+            time.sleep(10)
+            output = instance.get_console_output()
+            logging.debug("console output: %s", output)
+            logging.debug("instance: %s",instance)
+            end_word = re.search(check_word, output)
+
+    def nova_servers_delete(self, server):
+        """
+        Shut down and delete a server
+        """
+        server.delete()
+
+    def manage_ssh_key(self):
+        """
+        Upload ssh public key
+        """
+        logging.info('Manage ssh keys: {}'.format(self.key))
+        if self.nova.keypairs.findall(name=self.key):
+            logging.debug('Remove previous ssh keys')
+            self.nova.keypairs.delete(key=self.key)
+
+        with open(os.path.expanduser(self.key_filename + ".pub")) as fpubkey:
+            self.nova.keypairs.create(name=self.key, public_key=fpubkey.read())
+
+    def get_floating_ip(self):
+        """
+        Allocate floating ip address to project
+        """
+        floating_ips = self.nova.floating_ips.list()
+        floating_ip = None
+        floating_ip_pool = self.nova.floating_ip_pools.list()[0].name
+
+        # Check for available public ip address in project
+        i = 0
+        for ip in self.nova.floating_ips.list():
+            if ip.instance_id is None:
+                floating_ip = ip
+                logging.debug('Available floating ip found %s', floating_ip)
+                break
+
+        # Check for available public ip adress in ext-net pool
+        if floating_ip is None:
+            try:
+                logging.debug("Use floating ip pool: {}".format(floating_ip_pool))
+                floating_ip = self.nova.floating_ips.create(floating_ip_pool)
+            except novaclient.exceptions.Forbidden as exc:
+                logging.fatal("Unable to retrieve public IP: {0}".format(exc))
+                sys.exit(1)
+
+        return floating_ip
+
+    def print_ssh_config(self, instances, floating_ip):
+        """
+        Print ssh client configuration to file
+        """
+        # ssh config
+        ssh_config_tpl = '''
+        Host {host}
+        HostName {fixed_ip}
+        User qserv
+        Port 22
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+        PasswordAuthentication no
+        ProxyCommand ssh -i {key_filename} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p qserv@{floating_ip}
+        IdentityFile {key_filename}
+        IdentitiesOnly yes
+        LogLevel FATAL
+        '''
+        ssh_config_extract = ""
+        for instance in instances:
+            fixed_ip = instance.networks[self.network_name][0]
+            ssh_config_extract += ssh_config_tpl.format(host=instance.name,
+                                                        fixed_ip=fixed_ip,
+                                                        floating_ip=floating_ip.ip,
+                                                        key_filename=self.key_filename)
+        logging.debug("Create SSH client config ")
+
+        f = open("ssh_config", "w")
+        f.write(ssh_config_extract)
+        f.close()
+
+    def check_ssh_up(self, instances):
+        """
+        Check if the ssh service started
+        """
+        for instance in instances:
+            cmd = ['ssh', '-t', '-F', './ssh_config', instance.name, 'true']
+            success = False
+            while not success:
+                try:
+                    check_output(cmd)
+                    success = True
+                except CalledProcessError as exc:
+                    logging.warn("Waiting for ssh to be avalaible on {}: {}".format(instance.name, exc.output))
+            logging.debug("ssh available on {}".format(instance.name))
+
+    def update_etc_hosts(self, instances):
+        """
+        Update /etc/hosts file on each machine
+        """
+        hostfile_tpl = "{ip}    {host}\n"
+
+        hostfile = ""
+        for instance in instances:
+            # Collect IP adresses
+            fixed_ip = instance.networks[self.network_name][0]
+            hostfile += hostfile_tpl.format(host=instance.name, ip=fixed_ip)
+
+        for instance in instances:
+            cmd = ['ssh', '-t', '-F', './ssh_config', instance.name,
+                   'sudo sh -c "echo \'{hostfile}\' >> /etc/hosts"'.format(hostfile=hostfile)]
+            try:
+                check_output(cmd)
+            except CalledProcessError as exc:
+                logging.error("ERROR while updating /etc/hosts: {}".format(exc.output))
+                sys.exit(1)
+
+

--- a/admin/tools/provision/cloudmanager.py
+++ b/admin/tools/provision/cloudmanager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Tools to ease Openstack infrastructure configuration
+Tools to ease OpenStack infrastructure configuration
 and provisioning
 
 @author  Oualid Achbal, IN2P3
@@ -134,7 +134,7 @@ class CloudManager(object):
 
     def nova_image_create(self, instance):
         """
-        Create an openstack image containing Docker
+        Create an OpenStack image containing Docker
         """
         logging.info("Creating Qserv image '%s'", self.snapshot_name)
         qserv_image = instance.create_image(self.snapshot_name)
@@ -209,14 +209,13 @@ class CloudManager(object):
         floating_ip_pool = self.nova.floating_ip_pools.list()[0].name
 
         # Check for available public ip address in project
-        i = 0
-        for ip in self.nova.floating_ips.list():
+        for ip in floating_ips:
             if ip.instance_id is None:
                 floating_ip = ip
                 logging.debug('Available floating ip found %s', floating_ip)
                 break
 
-        # Check for available public ip adress in ext-net pool
+        # Check for available public ip address in ext-net pool
         if floating_ip is None:
             try:
                 logging.debug("Use floating ip pool: %s", floating_ip_pool)
@@ -281,7 +280,7 @@ class CloudManager(object):
 
     def update_etc_hosts(self, instances):
         """
-        Update /etc/hosts file on each machine
+        Update /etc/hosts file on each virtual machine
         """
         hostfile_tpl = "{ip}    {host}\n"
 

--- a/admin/tools/provision/cloudmanager.py
+++ b/admin/tools/provision/cloudmanager.py
@@ -273,7 +273,7 @@ class CloudManager(object):
                     logging.warn("Waiting for ssh to be available on %s: %s", instance.name, exc.output)
                     nb_try += 1
                     if nb_try > 10:
-                        logging.fatal("No available ssh on %s OpenStack clean up is required", instance.name)
+                        logging.critical("No available ssh on %s OpenStack clean up is required", instance.name)
                         sys.exit(1)
                     time.sleep(2)
             logging.debug("ssh available on %s", instance.name)

--- a/admin/tools/provision/create-image.py
+++ b/admin/tools/provision/create-image.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+"""
+Create an image containing Docker by taking
+a snapshot from an instance,
+
+Script performs these tasks:
+  - launch instance from image
+  - install docker via cloud-init
+  - create a qserv user
+  - take a snapshot
+  - shut down and delete the instance created
+
+@author  Oualid Achbal, ISIMA student , IN2P3
+
+"""
+
+# -------------------------------
+#  Imports of standard modules --
+# -------------------------------
+import argparse
+import logging
+import sys
+
+# ----------------------------
+# Imports for other modules --
+# ----------------------------
+import cloudmanager
+
+# -----------------------
+# Exported definitions --
+# -----------------------
+def get_cloudconfig():
+    """
+    Return cloud init configuration in a string
+    """
+    userdata = '''
+        #cloud-config
+        groups:
+        - docker
+
+        users:
+        - name: qserv
+          gecos: Qserv daemon
+          groups: docker
+          lock-passwd: true
+          shell: /bin/bash
+          sudo: ALL=(ALL) NOPASSWD:ALL
+
+        packages:
+        - docker
+        - util-linux
+
+        runcmd:
+        - ['systemctl', 'enable', 'docker']
+        - ['/tmp/detect_end_cloud_config.sh']
+
+        write_files:
+        -   path: "/tmp/detect_end_cloud_config.sh"
+            permissions: "0544"
+            owner: "root"
+            content: |
+              #!/bin/sh
+              (while [ ! -f /var/lib/cloud/instance/boot-finished ] ;
+              do
+                sleep 2
+                echo "---CLOUD-INIT-DETECT RUNNING---"
+              done
+              sync
+              fsfreeze -f / && read x; fsfreeze -u /
+              echo "---SYSTEM READY FOR SNAPSHOT---") &
+
+        package_upgrade: true
+        package_reboot_if_required: true
+        timezone: Europe/Paris
+        '''
+
+    return userdata
+
+
+if __name__ == "__main__":
+    try:
+        parser = argparse.ArgumentParser(description='Create Openstack image containing Docker.')
+
+        cloudmanager.add_parser_args(parser)
+        args = parser.parse_args()
+
+        loggerName = "Provisioner"
+        cloudmanager.config_logger(loggerName, args.verbose, args.verboseAll)
+
+        cloudManager = cloudmanager.CloudManager(config_file_name=args.configFile)
+
+        userdata_snapshot = get_cloudconfig()
+
+        instance_id = "source"
+        instance_for_snapshot = cloudManager.nova_servers_create(instance_id, userdata_snapshot)
+
+        # Wait for cloud config completion
+        cloudManager.detect_end_cloud_config(instance_for_snapshot)
+
+        cloudManager.nova_image_create(instance_for_snapshot)
+
+        # Delete instance after taking a snapshot
+        cloudManager.nova_servers_delete(instance_for_snapshot)
+
+    except Exception as exc:
+        logging.critical('Exception occured: %s', exc, exc_info=True)
+        sys.exit(1)

--- a/admin/tools/provision/create-image.py
+++ b/admin/tools/provision/create-image.py
@@ -11,7 +11,7 @@ Script performs these tasks:
   - take a snapshot
   - shut down and delete the instance created
 
-@author  Oualid Achbal, ISIMA student , IN2P3
+@author  Oualid Achbal, IN2P3
 
 """
 
@@ -56,19 +56,19 @@ runcmd:
 - ['/tmp/detect_end_cloud_config.sh']
 
 write_files:
--   path: "/tmp/detect_end_cloud_config.sh"
-    permissions: "0544"
-    owner: "root"
-    content: |
-      #!/bin/sh
-      (while [ ! -f /var/lib/cloud/instance/boot-finished ] ;
-      do
-        sleep 2
-        echo "---CLOUD-INIT-DETECT RUNNING---"
-      done
-      sync
-      fsfreeze -f / && read x; fsfreeze -u /
-      echo "---SYSTEM READY FOR SNAPSHOT---") &
+- path: "/tmp/detect_end_cloud_config.sh"
+  permissions: "0544"
+  owner: "root"
+  content: |
+    #!/bin/sh
+    (while [ ! -f /var/lib/cloud/instance/boot-finished ] ;
+    do
+      sleep 2
+      echo "---CLOUD-INIT-DETECT RUNNING---"
+    done
+    sync
+    fsfreeze -f / && read x; fsfreeze -u /
+    echo "---SYSTEM READY FOR SNAPSHOT---") &
 
 package_upgrade: true
 package_reboot_if_required: true

--- a/admin/tools/provision/create-image.py
+++ b/admin/tools/provision/create-image.py
@@ -35,45 +35,45 @@ def get_cloudconfig():
     Return cloud init configuration in a string
     """
     userdata = '''
-        #cloud-config
-        groups:
-        - docker
+#cloud-config
+groups:
+- docker
 
-        users:
-        - name: qserv
-          gecos: Qserv daemon
-          groups: docker
-          lock-passwd: true
-          shell: /bin/bash
-          sudo: ALL=(ALL) NOPASSWD:ALL
+users:
+- name: qserv
+  gecos: Qserv daemon
+  groups: docker
+  lock-passwd: true
+  shell: /bin/bash
+  sudo: ALL=(ALL) NOPASSWD:ALL
 
-        packages:
-        - docker
-        - util-linux
+packages:
+- docker
+- util-linux
 
-        runcmd:
-        - ['systemctl', 'enable', 'docker']
-        - ['/tmp/detect_end_cloud_config.sh']
+runcmd:
+- ['systemctl', 'enable', 'docker']
+- ['/tmp/detect_end_cloud_config.sh']
 
-        write_files:
-        -   path: "/tmp/detect_end_cloud_config.sh"
-            permissions: "0544"
-            owner: "root"
-            content: |
-              #!/bin/sh
-              (while [ ! -f /var/lib/cloud/instance/boot-finished ] ;
-              do
-                sleep 2
-                echo "---CLOUD-INIT-DETECT RUNNING---"
-              done
-              sync
-              fsfreeze -f / && read x; fsfreeze -u /
-              echo "---SYSTEM READY FOR SNAPSHOT---") &
+write_files:
+-   path: "/tmp/detect_end_cloud_config.sh"
+    permissions: "0544"
+    owner: "root"
+    content: |
+      #!/bin/sh
+      (while [ ! -f /var/lib/cloud/instance/boot-finished ] ;
+      do
+        sleep 2
+        echo "---CLOUD-INIT-DETECT RUNNING---"
+      done
+      sync
+      fsfreeze -f / && read x; fsfreeze -u /
+      echo "---SYSTEM READY FOR SNAPSHOT---") &
 
-        package_upgrade: true
-        package_reboot_if_required: true
-        timezone: Europe/Paris
-        '''
+package_upgrade: true
+package_reboot_if_required: true
+timezone: Europe/Paris
+'''
 
     return userdata
 

--- a/admin/tools/provision/galactica.conf
+++ b/admin/tools/provision/galactica.conf
@@ -1,0 +1,7 @@
+
+[openstack]
+   
+base_image_name: CentOS 7
+snapshot_name: centos-7-qserv
+flavor_name: c1.medium
+network_name: petasky-net

--- a/admin/tools/provision/galactica.conf.example
+++ b/admin/tools/provision/galactica.conf.example
@@ -1,0 +1,7 @@
+
+[openstack]
+   
+base_image_name: CentOS 7
+snapshot_name: centos-7-qserv
+flavor_name: c1.medium
+network_name: petasky-net

--- a/admin/tools/provision/ncsa.conf
+++ b/admin/tools/provision/ncsa.conf
@@ -1,0 +1,9 @@
+[openstack]
+
+base_image_name: CentOS 7 latest
+snapshot_name: centos-7-qserv
+flavor_name: m1.medium
+network_name: LSST-net
+net-id: fc77a88d-a9fb-47bb-a65d-39d1be7a7174
+ssh_security_group: Remote SSH
+

--- a/admin/tools/provision/ncsa.conf.example
+++ b/admin/tools/provision/ncsa.conf.example
@@ -1,0 +1,9 @@
+[openstack]
+
+base_image_name: CentOS latest
+snapshot_name: centos-7-qserv
+flavor_name: m1.medium
+network_name: LSST-net
+net-id: fc77a88d-a9fb-47bb-a65d-39d1be7a7174
+ssh_security_group: Remote SSH
+

--- a/admin/tools/provision/petasky-openrc.sh
+++ b/admin/tools/provision/petasky-openrc.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# To use an OpenStack cloud you need to authenticate against the Identity
+# service named keystone, which returns a **Token** and **Service Catalog**.
+# The catalog contains the endpoints for all services the user/tenant has
+# access to - such as Compute, Image Service, Identity, Object Storage, Block
+# Storage, and Networking (code-named nova, glance, keystone, swift,
+# cinder, and neutron).
+#
+# *NOTE*: Using the 2.0 *Identity API* does not necessarily mean any other
+# OpenStack API is version 2.0. For example, your cloud provider may implement
+# Image API v1.1, Block Storage API v2, and Compute API v2.0. OS_AUTH_URL is
+# only for the Identity API served through keystone.
+export OS_AUTH_URL=https://api.isima.fr:5000/v2.0
+
+# With the addition of Keystone we have standardized on the term **tenant**
+# as the entity that owns the resources.
+export OS_TENANT_ID=d2521c9ab5c4452b802e50d05cee83e1
+export OS_TENANT_NAME="petasky"
+export OS_PROJECT_NAME="petasky"
+
+# In addition to the owning entity (tenant), OpenStack stores the entity
+# performing the action as the **user**.
+export OS_USERNAME="achbal"
+
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack Password: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+
+# If your configuration has multiple regions, we set that information here.
+# OS_REGION_NAME is optional and only valid in certain environments.
+export OS_REGION_NAME="RegionOne"
+# Don't leave a blank variable, unset it if it was empty
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi

--- a/admin/tools/provision/petasky-openrc.sh.example
+++ b/admin/tools/provision/petasky-openrc.sh.example
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# To use an OpenStack cloud you need to authenticate against the Identity
+# service named keystone, which returns a **Token** and **Service Catalog**.
+# The catalog contains the endpoints for all services the user/tenant has
+# access to - such as Compute, Image Service, Identity, Object Storage, Block
+# Storage, and Networking (code-named nova, glance, keystone, swift,
+# cinder, and neutron).
+#
+# *NOTE*: Using the 2.0 *Identity API* does not necessarily mean any other
+# OpenStack API is version 2.0. For example, your cloud provider may implement
+# Image API v1.1, Block Storage API v2, and Compute API v2.0. OS_AUTH_URL is
+# only for the Identity API served through keystone.
+export OS_AUTH_URL=https://api.isima.fr:5000/v2.0
+
+# With the addition of Keystone we have standardized on the term **tenant**
+# as the entity that owns the resources.
+export OS_TENANT_ID=d2521c9ab5c4452b802e50d05cee83e1
+export OS_TENANT_NAME="petasky"
+export OS_PROJECT_NAME="petasky"
+
+# In addition to the owning entity (tenant), OpenStack stores the entity
+# performing the action as the **user**.
+export OS_USERNAME="achbal"
+
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack Password: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+
+# If your configuration has multiple regions, we set that information here.
+# OS_REGION_NAME is optional and only valid in certain environments.
+export OS_REGION_NAME="RegionOne"
+# Don't leave a blank variable, unset it if it was empty
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi

--- a/admin/tools/provision/provision-qserv.py
+++ b/admin/tools/provision/provision-qserv.py
@@ -94,7 +94,6 @@ def main():
         sys.exit(1)
     logging.info("Add floating ip ({0}) to {1}".format(floating_ip,
                                                        gateway_instance.name))
-    gateway_instance.add_floating_ip(floating_ip)
     try:
         gateway_instance.add_floating_ip(floating_ip)
     except BadRequest as exc:

--- a/admin/tools/provision/provision-qserv.py
+++ b/admin/tools/provision/provision-qserv.py
@@ -39,34 +39,34 @@ def get_cloudconfig():
     Return cloud init configuration in a string
     """
     cloud_config_tpl = '''
-        #cloud-config
-        users:
-        - name: qserv
-          gecos: Qserv daemon
-          groups: docker
-          lock-passwd: true
-          shell: /bin/bash
-          ssh-authorized-keys:
-          - {key}
-          sudo: ALL=(ALL) NOPASSWD:ALL
+#cloud-config
+users:
+- name: qserv
+  gecos: Qserv daemon
+  groups: docker
+  lock-passwd: true
+  shell: /bin/bash
+  ssh-authorized-keys:
+  - {key}
+  sudo: ALL=(ALL) NOPASSWD:ALL
 
-        runcmd:
-        - ['/tmp/detect_end_cloud_config.sh']
-        - [mkdir, -p, '/qserv/data']
-        - [mkdir, -p, '/qserv/log']
-        - [chown, "1000:1000", '/qserv/data']
-        - [chown, "1000:1000", '/qserv/log']
-        # Allow docker to start via cloud-init
-        # see https://github.com/projectatomic/docker-storage-setup/issues/77
-        - [ sed, -i, -e, 's/After=cloud-final.service/#After=cloud-final.service/g',
-          /usr/lib/systemd/system/docker-storage-setup.service]
-        # 'overlay' seems more robust than default setting
-        - [ sed, -i, -e, '$a STORAGE_DRIVER=overlay', /etc/sysconfig/docker-storage-setup ]
-        # overlay and selinux are not compliant in docker 1.9
-        - [ sed, -i, -e, "s/OPTIONS='--selinux-enabled'/# OPTIONS='--selinux-enabled'/", /etc/sysconfig/docker ]
-        - [ /bin/systemctl, daemon-reload]
-        - [ /bin/systemctl, restart,  docker.service]
-        '''
+runcmd:
+- ['/tmp/detect_end_cloud_config.sh']
+- [mkdir, -p, '/qserv/data']
+- [mkdir, -p, '/qserv/log']
+- [chown, "1000:1000", '/qserv/data']
+- [chown, "1000:1000", '/qserv/log']
+# Allow docker to start via cloud-init
+# see https://github.com/projectatomic/docker-storage-setup/issues/77
+- [ sed, -i, -e, 's/After=cloud-final.service/#After=cloud-final.service/g',
+  /usr/lib/systemd/system/docker-storage-setup.service]
+# 'overlay' seems more robust than default setting
+- [ sed, -i, -e, '$a STORAGE_DRIVER=overlay', /etc/sysconfig/docker-storage-setup ]
+# overlay and selinux are not compliant in docker 1.9
+- [ sed, -i, -e, "s/OPTIONS='--selinux-enabled'/# OPTIONS='--selinux-enabled'/", /etc/sysconfig/docker ]
+- [ /bin/systemctl, daemon-reload]
+- [ /bin/systemctl, restart,  docker.service]
+'''
     fpubkey = open(os.path.expanduser(cloudManager.key_filename + ".pub"))
     public_key=fpubkey.read()
     userdata = cloud_config_tpl.format(key=public_key)

--- a/admin/tools/provision/provision-qserv.py
+++ b/admin/tools/provision/provision-qserv.py
@@ -2,7 +2,7 @@
 
 """
 Boot instances from an image already created containing Docker
-in Openstack infrastructure, and use cloud config to create users
+in OpenStack infrastructure, and use cloud config to create users
 on virtual machines
 
 Script performs these tasks:

--- a/admin/tools/provision/provision-qserv.py
+++ b/admin/tools/provision/provision-qserv.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+"""
+Boot instances from an image already created containing Docker
+in Openstack infrastructure, and use cloud config to create users
+on virtual machines
+
+Script performs these tasks:
+  - launch instances from image and manage ssh key
+  - create gateway vm
+  - check for available floating ip address
+  - add it to gateway
+  - create users via cloud-init
+  - update /etc/hosts on each VM
+  - print ssh client config
+
+@author  Oualid Achbal, IN2P3
+
+"""
+
+# -------------------------------
+#  Imports of standard modules --
+# -------------------------------
+import argparse
+import logging
+import os
+import sys
+
+# ----------------------------
+# Imports for other modules --
+# ----------------------------
+import cloudmanager
+
+# -----------------------
+# Exported definitions --
+# -----------------------
+def get_cloudconfig():
+    """
+    Return cloud init configuration in a string
+    """
+    cloud_config_tpl = '''
+        #cloud-config
+        users:
+        - name: qserv
+          gecos: Qserv daemon
+          groups: docker
+          lock-passwd: true
+          shell: /bin/bash
+          ssh-authorized-keys:
+          - {key}
+          sudo: ALL=(ALL) NOPASSWD:ALL
+
+        runcmd:
+        - ['/tmp/detect_end_cloud_config.sh']
+        - [mkdir, -p, '/qserv/data']
+        - [mkdir, -p, '/qserv/log']
+        - [chown, "1000:1000", '/qserv/data']
+        - [chown, "1000:1000", '/qserv/log']
+        # Allow docker to start via cloud-init
+        # see https://github.com/projectatomic/docker-storage-setup/issues/77
+        - [ sed, -i, -e, 's/After=cloud-final.service/#After=cloud-final.service/g',
+          /usr/lib/systemd/system/docker-storage-setup.service]
+        # 'overlay' seems more robust than default setting
+        - [ sed, -i, -e, '$a STORAGE_DRIVER=overlay', /etc/sysconfig/docker-storage-setup ]
+        # overlay and selinux are not compliant in docker 1.9
+        - [ sed, -i, -e, "s/OPTIONS='--selinux-enabled'/# OPTIONS='--selinux-enabled'/", /etc/sysconfig/docker ]
+        - [ /bin/systemctl, daemon-reload]
+        - [ /bin/systemctl, restart,  docker.service]
+        '''
+    fpubkey = open(os.path.expanduser(cloudManager.key_filename + ".pub"))
+    public_key=fpubkey.read()
+    userdata = cloud_config_tpl.format(key=public_key)
+
+    return userdata
+
+def main():
+    cloudManager.manage_ssh_key()
+
+    # Find a floating ip address for gateway
+    floating_ip = cloudManager.get_floating_ip()
+    if not floating_ip:
+        logging.fatal("Unable to add public ip to Qserv gateway")
+        sys.exit(1)
+
+    userdata_provision = get_cloudconfig()
+
+    # Create instances list
+    instances = []
+
+    # Create gateway instance and add floating_ip to it
+    gateway_id = 0
+    gateway_instance = cloudManager.nova_servers_create(gateway_id,
+                                                        userdata_provision)
+    logging.info("Add floating ip ({0}) to {1}".format(floating_ip,
+                                                       gateway_instance.name))
+    gateway_instance.add_floating_ip(floating_ip)
+
+    # Manage ssh security group
+    if cloudManager.ssh_security_group:
+        gateway_instance.add_security_group(cloudManager.ssh_security_group)
+
+    instances.append(gateway_instance)
+
+    # Create worker instances
+    for instance_id in range(1, args.nbServers):
+        worker_instance = cloudManager.nova_servers_create(instance_id,
+                                                           userdata_provision)
+        instances.append(worker_instance)
+
+    cloudManager.print_ssh_config(instances, floating_ip)
+
+    # Wait for cloud config completion for all machines
+    for instance in instances:
+        cloudManager.detect_end_cloud_config(instance)
+
+    cloudManager.check_ssh_up(instances)
+
+    cloudManager.update_etc_hosts(instances)
+
+    logging.debug("SUCCESS: Qserv Openstack cluster is up")
+
+
+if __name__ == "__main__":
+    try:
+        # Define command-line arguments
+        parser = argparse.ArgumentParser(description='Boot instances from image containing Docker.')
+        parser.add_argument('-n', '--nb-servers', dest='nbServers',
+                           required=False, default=3, type=int,
+                           help='Choose the number of servers to boot')
+
+        cloudmanager.add_parser_args(parser)
+        args = parser.parse_args()
+
+        loggerName = "Provisioner"
+        cloudmanager.config_logger(loggerName, args.verbose, args.verboseAll)
+
+        cloudManager = cloudmanager.CloudManager(config_file_name=args.configFile, used_image_key=cloudmanager.SNAPSHOT_IMAGE_KEY, add_ssh_key=True)
+
+        main()
+    except Exception as exc:
+        logging.critical('Exception occured: %s', exc, exc_info=True)
+        sys.exit(1)

--- a/admin/tools/provision/test.sh
+++ b/admin/tools/provision/test.sh
@@ -1,4 +1,4 @@
- #!/bin/sh
+#!/bin/bash
 
 # Test script which performs the following tasks:
 
@@ -14,8 +14,8 @@ set -e
 # and choose the configuration file which contains instance parameters
 
 # For NCSA
-. ./LSST-openrc.sh
-CONF_FILE="ncsa.conf"
+. ./LSST-openrc.sh.example
+CONF_FILE="ncsa.conf.example"
 
 # For Petasky/Galactica
 # . ./petasky-openrc.sh

--- a/admin/tools/provision/test.sh
+++ b/admin/tools/provision/test.sh
@@ -1,0 +1,80 @@
+ #!/bin/sh
+
+# Test script which performs the following tasks:
+
+# Create image
+# Boot instances
+# Launch Qserv containers
+
+# @author  Oualid Achbal, IN2P3
+
+set -e
+
+# Source the cloud openrc file
+# and choose the configuration file which contains instance parameters
+
+# For NCSA
+. ./LSST-openrc.sh
+CONF_FILE="ncsa.conf"
+
+# For Petasky/Galactica
+# . ./petasky-openrc.sh
+# CONF_FILE="galactica.conf"
+
+# Choose a number of instances to boot
+NB_SERVERS=3
+
+# Choose snapshot name and update the cloud conf file chosen
+SNAPSHOT_NAME="centos-7-qserv"
+
+# Delete the previous instances for a new test
+PREVIOUS_INSTANCE_IDS=$(openstack server list | grep "$OS_USERNAME-qserv" | cut -d'|' -f 2)
+# Test PREVIOUS_INSTANCE_IDS 
+if [ "$PREVIOUS_INSTANCE_IDS" ]
+then
+    echo "Delete the previous instances"
+	openstack server delete $PREVIOUS_INSTANCE_IDS
+else
+	echo "No existing servers to delete"
+fi
+
+# Delete the snapshot created for a new test
+PREVIOUS_IMAGE_ID=$(openstack image list | grep "$SNAPSHOT_NAME" | cut -d'|' -f 2)
+# Test PREVIOUS_IMAGE_ID
+if [ "$PREVIOUS_IMAGE_ID" ]
+then
+    echo "Delete the previous image denoted $SNAPSHOT_NAME"
+	openstack image delete $PREVIOUS_IMAGE_ID
+else
+	echo "No existing image denoted $SNAPSHOT_NAME to delete"
+fi
+
+set -x
+
+# Take a snapshot
+python create-image.py -f "$CONF_FILE" -vv
+
+# Execute provision-qserv with an input cloud conf file
+python provision-qserv.py -f "$CONF_FILE" -n "$NB_SERVERS" -vv
+
+# Warning : if  multinode tests failed save your ~/.ssh/config
+# your old ~/.ssh/config is in ~/.ssh/config.backup
+
+cp ~/.ssh/config ~/.ssh/config.backup
+
+cp ssh_config ~/.ssh/config
+
+cd ../docker/deployment/parallel
+
+# Update env.sh
+# cp env.example.sh env.sh
+sed -i -e 's/$HOSTNAME_FORMAT/$OS_USERNAME-qserv-%g/g' env.sh
+sed -i -e "s/MASTER_ID=1/MASTER_ID=0/" env.sh
+sed -i -e "s/WORKER_FIRST_ID=2/WORKER_FIRST_ID=1/" env.sh
+sed -i -e "s/WORKER_LAST_ID=3/WORKER_LAST_ID=$NB_SERVERS/" env.sh
+
+# Run multinode tests
+./run-multinode-tests.sh
+
+cp ~/.ssh/config.backup ~/.ssh/config
+


### PR DESCRIPTION
- Use cloud-init technology
- Create a customized CentOS7-based snapshot
  containing Docker
- Use overlay storage backend for Docker
- Boot Qserv master and worker nodes
- Add user ssh key inside nodes
- Add public floating ip to master node
- Wait for cloud-init completion and ssh startup
- Update /etc/hosts on each node
- Add test script
- Add documentation