### PR TITLE
DM-6972: Updates for new newinstall.sh location

### DIFF
--- a/admin/tools/qserv-install.sh
+++ b/admin/tools/qserv-install.sh
@@ -7,7 +7,7 @@ DIR=$(cd "$(dirname "$0")"; pwd -P)
 
 # Default values below may be overidden by cmd-line options
 MODE="internet mode"
-NEWINSTALL_URL="https://sw.lsstcorp.org/eupspkg/newinstall.sh"
+NEWINSTALL_URL="https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh"
 VERSION="-t qserv"
 
 underline() {
@@ -106,7 +106,7 @@ cd $STACK_DIR ||
 }
 
 underline "Installing LSST stack : $MODE, version : $VERSION"
-curl -O ${NEWINSTALL_URL} ||
+curl -OL ${NEWINSTALL_URL} ||
 {
     >&2 printf "Unable to download from ${NEWINSTALL_URL}\n"
     exit 2

--- a/admin/tools/qserv-package-internet-free-distserver.sh
+++ b/admin/tools/qserv-package-internet-free-distserver.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# First, with lsstsw tools : 
+# First, with lsstsw tools :
 # rebuild lsst qserv qserv_testdata
 # publish -t qserv -b bXX lsst qserv qserv_testdata
 
@@ -45,12 +45,12 @@ git_update_bare() {
         echo "Updating ${giturl}"
         cd ${product}
         git fetch origin +refs/heads/*:refs/heads/* && retval=0
-        cd .. 
+        cd ..
     fi
 
-    if [ ! retval ]; then 
+    if [ ! retval ]; then
         echo "ERROR : git update failed"
-    fi  
+    fi
     return ${retval}
 }
 
@@ -95,7 +95,7 @@ echo
 echo "Downloading LSST stack install script"
 echo "====================================="
 echo
-curl -O https://sw.lsstcorp.org/eupspkg/newinstall.sh
+curl -OL https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh
 mv newinstall.sh ${EUPS_PKGROOT}
 
 

--- a/doc/source/install/quick-start.rst
+++ b/doc/source/install/quick-start.rst
@@ -42,13 +42,13 @@ First, log in with a **non-root user account**.
 
 .. code-block:: bash
 
-   NEWINSTALL_URL=https://sw.lsstcorp.org/eupspkg/newinstall.sh
-   # create a new directory stack and initialize INSTALL_DIR as an absolute path to stack 
+   NEWINSTALL_URL=https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh
+   # create a new directory stack and initialize INSTALL_DIR as an absolute path to stack
    mkdir stack
    INSTALL_DIR=/path/to/lsst/stack/
    # e.g. ~qserv, please note that $INSTALL_DIR must be empty
    cd $INSTALL_DIR
-   curl -O ${NEWINSTALL_URL}
+   curl -OL ${NEWINSTALL_URL}
    # script below will ask some questions. Unless you know what you're doing,
    # and you need a fine tuned setup, please answer 'yes' everywhere.
    bash newinstall.sh
@@ -124,7 +124,7 @@ Testing
 For a mono-node instance.
 
 .. code-block:: bash
-   
+
    # default value for QSERV_RUN_DIR
    QSERV_RUN_DIR="$HOME/qserv-run/$(qserv-version.sh)"
    # start qserv
@@ -135,11 +135,11 @@ For a mono-node instance.
    # fine-tuning is available (see --help)
    qserv-check-integration.py --case=01 --load
    # to avoid conflict you can stop qserv
-   $QSERV_RUN_DIR/bin/qserv-stop.sh 
+   $QSERV_RUN_DIR/bin/qserv-stop.sh
 
 ********************
 For more information
 ********************
 
 https://confluence.lsstcorp.org/display/LSWUG/Building+the+LSST+Stack+from+Source
-   
+


### PR DESCRIPTION
Change scripts and docs to curl newinstall.sh from new location, as documented at https://pipelines.lsst.io/install/newinstall.html (plus some trailing whitespace removal courtesy of sublimetext)

Note that the corresponding change to admin/tools//docker/latest/scripts/install-stack.sh is done as part of a separate ticket (DM-6922).