### PR TITLE
Replace use of static Log::logMsg method with non-static (DM-6978)

### DIFF
--- a/core/modules/proxy/czarProxy.cc
+++ b/core/modules/proxy/czarProxy.cc
@@ -113,9 +113,10 @@ killQuery(std::string const& query, std::string const& clientId) {
 void log(std::string const& loggername, std::string const& level,
          std::string const& filename, std::string const& funcname,
          unsigned int lineno, std::string const& message) {
-    lsst::log::Log::logMsg(lsst::log::Log::getLogger(loggername), log4cxx::Level::toLevel(level),
-                           log4cxx::spi::LocationInfo(filename.c_str(), funcname.c_str(), lineno),
-                           message);
+    auto logger = lsst::log::Log::getLogger(loggername);
+    logger.logMsg(log4cxx::Level::toLevel(level),
+                  log4cxx::spi::LocationInfo(filename.c_str(), funcname.c_str(), lineno),
+                  message);
 }
 
 


### PR DESCRIPTION
Follow up for log package refactoring, we want to get rid of some of the
static methods in Log class. QServ was the only place which used one of
those deprecated methods, update to qserv code was needed.