### PR TITLE
[DM-10286] Update cmake in qserv containers

### DIFF
--- a/admin/bootstrap/qserv-install-deps-debian8.sh
+++ b/admin/bootstrap/qserv-install-deps-debian8.sh
@@ -31,7 +31,6 @@
 apt-get --yes install bash \
     bison \
     bzip2 \
-    cmake \
     curl \
     flex \
     g++ \
@@ -51,3 +50,5 @@ apt-get --yes install bash \
     python-dev \
     python-setuptools \
     zlib1g-dev
+
+apt-get --yes -t jessie-backports install cmake

--- a/admin/tools/docker/latest/Dockerfile
+++ b/admin/tools/docker/latest/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:jessie
 MAINTAINER Fabrice Jammes <fabrice.jammes@in2p3.fr>
 
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 COPY scripts/install-deps.sh /root/install-deps.sh
 
 # Start with this long step not to re-run it on


### PR DESCRIPTION
Update cmake in base containers to jessie-backports version;
the standard jessie version is binarily incompatible with
more modern libcurl as packaged by eups