### PR TITLE
Add support for SUBMIT to qserv parser (DM-3245)

### DIFF
--- a/core/modules/ccontrol/UserQuerySelect.h
+++ b/core/modules/ccontrol/UserQuerySelect.h
@@ -86,7 +86,8 @@ public:
                     std::shared_ptr<qmeta::QMeta> const& queryMetadata,
                     qmeta::CzarId czarId,
                     std::shared_ptr<qdisp::LargeResultMgr> const& largeResultMgr,
-                    std::string const& errorExtra);
+                    std::string const& errorExtra,
+                    bool async);
 
     UserQuerySelect(UserQuerySelect const&) = delete;
     UserQuerySelect& operator=(UserQuerySelect const&) = delete;
@@ -150,6 +151,7 @@ private:
     std::mutex _killMutex;
     std::string _errorExtra;    ///< Additional error information
     std::string _resultTable;   ///< Result table name
+    bool _async;                ///< true for async query
 };
 
 }}} // namespace lsst::qserv:ccontrol

--- a/core/modules/ccontrol/UserQueryType.cc
+++ b/core/modules/ccontrol/UserQueryType.cc
@@ -66,6 +66,12 @@ boost::regex _flushEmptyRe(R"(^flush\s+qserv_chunks_cache(\s+for\s+(["`]?)(\w+)\
 // Note that parens around whole string are not part of the regex but raw string literal
 boost::regex _showProcessListRe(R"(^show\s+(full\s+)?processlist$)",
                                 boost::regex::ECMAScript | boost::regex::icase | boost::regex::optimize);
+
+// regex for SUBMIT ...
+// group 1 is the query without SUBMIT prefix
+// Note that parens around whole string are not part of the regex but raw string literal
+boost::regex _submitRe(R"(^submit\s+(.+)$)",
+                       boost::regex::ECMAScript | boost::regex::icase | boost::regex::optimize);
 }
 
 namespace lsst {
@@ -143,5 +149,18 @@ UserQueryType::isProcessListTable(std::string const& dbName, std::string const& 
     return boost::to_upper_copy(dbName) == "INFORMATION_SCHEMA" &&
             boost::to_upper_copy(tblName) == "PROCESSLIST";
 }
+
+/// Returns true if query is SUBMIT ...
+bool
+UserQueryType::isSubmit(std::string const& query, std::string& stripped) {
+     LOGS(_log, LOG_LVL_DEBUG, "isSubmit: " << query);
+     boost::smatch sm;
+     bool match = boost::regex_match(query, sm, _submitRe);
+     if (match) {
+         stripped = sm.str(1);
+         LOGS(_log, LOG_LVL_DEBUG, "isSubmit: match: " << stripped);
+     }
+     return match;
+ }
 
 }}} // namespace lsst::qserv::ccontrol

--- a/core/modules/ccontrol/UserQueryType.h
+++ b/core/modules/ccontrol/UserQueryType.h
@@ -72,6 +72,12 @@ public:
      */
     static bool isProcessListTable(std::string const& dbName, std::string const& tblName);
 
+    /**
+     *  Returns true if query is SUBMIT ..., returns query without "SUBMIT"
+     *  in `stripped` string.
+     */
+    static bool isSubmit(std::string const& query, std::string& stripped);
+
 };
 
 }}} // namespace lsst::qserv::ccontrol

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -50,6 +50,18 @@ BOOST_AUTO_TEST_CASE(testUserQueryType) {
     BOOST_CHECK(not UserQueryType::isSelect("unselect X"));
     BOOST_CHECK(not UserQueryType::isSelect("DROP SELECT;"));
 
+    std::string stripped;
+    BOOST_CHECK(UserQueryType::isSubmit("SUBMIT SELECT", stripped));
+    BOOST_CHECK_EQUAL("SELECT", stripped);
+    BOOST_CHECK(UserQueryType::isSubmit("submit\tselect  ", stripped));
+    BOOST_CHECK_EQUAL("select  ", stripped);
+    BOOST_CHECK(UserQueryType::isSubmit("SubMiT \n SelEcT", stripped));
+    BOOST_CHECK_EQUAL("SelEcT", stripped);
+    BOOST_CHECK(not UserQueryType::isSubmit("submit", stripped));
+    BOOST_CHECK(not UserQueryType::isSubmit("submit ", stripped));
+    BOOST_CHECK(not UserQueryType::isSubmit("unsubmit select", stripped));
+    BOOST_CHECK(not UserQueryType::isSubmit("submitting select", stripped));
+
     struct {
         const char* query;
         const char* db;


### PR DESCRIPTION
This is the first step in implementing async queries, Qserv now accepts
"SUBMIT SELECT" queries, parses them and passes the async flag to
UserQuerySelect class. The rest of the logic will be implemented in the
next steps, for now SUBMIT SELECT is essentially the same as SELECT
(except that query is marked ASYNC in QMeta).