### PR TITLE
Push images to Docker Hub after CI success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,35 @@ before_install:
   # While running 3_build-git-image.sh [option] <local-path>, <local-path> has to contain a git repository
   # whose current commit is a branch HEAD
   - git checkout -b travis
+  - export IMAGE="qserv/qserv:$(git rev-parse --short HEAD)"
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - export BRANCH_IMAGE="qserv/qserv:$BRANCH"
 
 install:
   # Retrieve container with Qserv dependencies
   - docker pull qserv/qserv:dev
 
 script:
-  - ./admin/tools/docker/3_build-git-image.sh -L -T travis "$PWD"
-  - ./admin/tools/docker/4_build-configured-images.sh -L -i travis
+  - echo "Building and testing $IMAGE (alias $BRANCH_IMAGE) and related master and worker images"
+  - ./admin/tools/docker/3_build-git-image.sh -L -T "$IMAGE" "$PWD"
+  - ./admin/tools/docker/4_build-configured-images.sh -L -i "$IMAGE"
   - ./admin/tools/docker/deployment/localhost/run-multinode-tests.sh
 
 notifications:
   slack:
     secure: eRFF9b5XJbZcyfxMojWTOB4bwWUVJf0CRaOYnCsV7cMCW5BwrDRwC+8tpZyEbetyici7XdFN33kW4rRp9UFfOCIsLS5fMJEKgjvgD0ybucThPsBqLE2VDzDzA6dUji7CATCPUtvoJEymM41pnvDZbXmtalipYzZJMPNXHyE8Yy0=
+
+after_success:
+  - echo "Push $IMAGE and associated master, worker images to Docker Hub"
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  - docker push "$IMAGE"
+  - docker push "${IMAGE}_master"
+  - docker push "${IMAGE}_worker"
+  - echo "Add tag $BRANCH to images above and push to Docker Hub"
+  - docker tag "$IMAGE" "$BRANCH_IMAGE"
+  - docker tag "${IMAGE}_master" "${BRANCH_IMAGE}_master"
+  - docker tag "${IMAGE}_worker" "${BRANCH_IMAGE}_worker"
+  - docker push "qserv/qserv:$BRANCH"
+  - docker push "${BRANCH_IMAGE}_master"
+  - docker push "${BRANCH_IMAGE}_worker"
+

--- a/admin/tools/docker/deployment/travis/env.sh
+++ b/admin/tools/docker/deployment/travis/env.sh
@@ -1,9 +1,7 @@
 # Rename this file to env.sh and edit variables
 # Configuration file sourced by other scripts from the directory
 
-# VERSION can be a git ticket branch but with _ instead of /
-# example: u_fjammes_DM-4295
-VERSION=travis
+IMAGE=$IMAGE
 
 NB_WORKERS=3
 
@@ -17,5 +15,5 @@ do
 done
 
 # Set images names
-MASTER_IMAGE="${VERSION}_master"
-WORKER_IMAGE="${VERSION}_worker"
+MASTER_IMAGE="${IMAGE}_master"
+WORKER_IMAGE="${IMAGE}_worker"

--- a/doc/source/install/docker.rst
+++ b/doc/source/install/docker.rst
@@ -6,7 +6,12 @@ Qserv is also available as a Docker image (see https://www.docker.com/).
 
 .. note::
 
-   This procedure was tested with Docker 1.8.
+   Our continuous integration service https://travis-ci.org/lsst/qserv produces automatically
+   docker containers for each commit pushed to Github. Containers names are displayed on top of travis console.
+
+.. note::
+
+   This procedure was tested with Docker 1.13.
 
 .. _docker-github:
 


### PR DESCRIPTION
- Add docker hub login
- Add branch tag
- Display image names on top of console log
- Document docker image creation with CI
- Rename VERSION to IMAGE for docker image name