### PR TITLE
Add support for disconnected queries (DM-11190)

### DIFF
--- a/admin/templates/configuration/tmp/configure/sql/QueryMetadata.sql
+++ b/admin/templates/configuration/tmp/configure/sql/QueryMetadata.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS `QInfo` (
   `completed` TIMESTAMP NULL COMMENT 'Time when query processing is completed - either the results were collected into czar-side result table or failure is detected.',
   `returned` TIMESTAMP NULL COMMENT 'Time when result is sent back to user. NULL if not completed yet.',
   `messageTable` CHAR(63) NULL COMMENT 'Name of the message table for the ASYNC query',
-  `resultLoc` TEXT NULL COMMENT 'Result destination - table name, file name, etc.',
+  `resultLocation` TEXT NULL COMMENT 'Result destination - table name, file name, etc.',
   PRIMARY KEY (`queryId`),
   INDEX `QInfo_czarId_index` (`czarId` ASC),
   CONSTRAINT `QInfo_cid`
@@ -116,7 +116,7 @@ CREATE OR REPLACE
     `QInfo`.`completed` `Completed`,
     `QInfo`.`returned` `Returned`,
     `QInfo`.`czarId` `CzarId`,
-    `QInfo`.`resultLoc` `ResultLoc`
+    REPLACE(`QInfo`.`resultLocation`, '#QID#',  `QInfo`.`queryId`) `ResultLocation`
   FROM `QInfo` LEFT OUTER JOIN `QTable` USING (`queryId`)
   GROUP BY `QInfo`.`queryId`;
 
@@ -140,7 +140,7 @@ CREATE OR REPLACE
     `QInfo`.`completed` `COMPLETED`,
     `QInfo`.`returned` `RETURNED`,
     `QInfo`.`czarId` `CZARID`,
-    `QInfo`.`resultLoc` `RESULTLOC`,
+    REPLACE(`QInfo`.`resultLocation`, '#QID#',  `QInfo`.`queryId`) `RESULTLOCATION`,
     NULLIF(COUNT(`QWorker`.`chunk`), 0) `NCHUNKS`
   FROM `QInfo` LEFT OUTER JOIN `QTable` USING (`queryId`)
         LEFT OUTER JOIN `QWorker` USING (`queryId`)

--- a/core/modules/ccontrol/UserQuery.h
+++ b/core/modules/ccontrol/UserQuery.h
@@ -80,17 +80,31 @@ public:
     // Delegate objects
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() = 0;
 
+    /// This method should disappear when we start supporting results
+    /// in locations other than MySQL tables. We'll switch to getResultLocation()
+    /// at that point.
     /// @return Name of the result table for this query, can be empty
-    virtual std::string getResultTableName() = 0;
+    virtual std::string getResultTableName() const { return std::string(); }
+
+    /// Result location could be something like "table:table_name" or
+    /// "file:/path/to/file.csv".
+    /// @return Result location for this query, can be empty
+    virtual std::string getResultLocation() const { return std::string(); }
 
     /// @return ORDER BY part of SELECT statement to be executed by proxy
-    virtual std::string getProxyOrderBy() = 0;
+    virtual std::string getProxyOrderBy() const { return std::string(); }
+
+    /// @return this query's QueryId.
+    virtual QueryId getQueryId() const { return QueryId(0); }
 
     /// @return this query's QueryId string. Many query types do not have valid Id numbers.
     virtual std::string getQueryIdString() const {
         // return a string indicating this query has no QueryId.
         return QueryIdHelper::makeIdStr(0, true);
     }
+
+    /// @return True if query is async query
+    virtual bool isAsync() const { return false; }
 };
 
 }}} // namespace lsst::qserv:ccontrol

--- a/core/modules/ccontrol/UserQueryDrop.cc
+++ b/core/modules/ccontrol/UserQueryDrop.cc
@@ -93,7 +93,7 @@ void UserQueryDrop::submit() {
     } else {
         query = "DROP TABLE " + _dbName  + "." + _tableName;
     }
-    qmeta::QInfo qInfo(qType, _qMetaCzarId, user, query, "", "", "");
+    qmeta::QInfo qInfo(qType, _qMetaCzarId, user, query, "", "", "", "", "");
     qmeta::QMeta::TableNames tableNames;
     QueryId qMetaQueryId = 0;
     try {

--- a/core/modules/ccontrol/UserQueryDrop.h
+++ b/core/modules/ccontrol/UserQueryDrop.h
@@ -98,12 +98,6 @@ public:
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
 
-    /// @return Name of the result table for this query, can be empty
-    virtual std::string getResultTableName() override { return std::string(); }
-
-    /// @return ORDER BY part of SELECT statement to be executed by proxy
-    virtual std::string getProxyOrderBy() override { return std::string(); }
-
 private:
 
     /// Check the status of item to be dropped

--- a/core/modules/ccontrol/UserQueryFactory.cc
+++ b/core/modules/ccontrol/UserQueryFactory.cc
@@ -102,7 +102,12 @@ UserQuery::Ptr
 UserQueryFactory::newUserQuery(std::string const& aQuery,
                                std::string const& defaultDb,
                                qdisp::LargeResultMgr::Ptr const& largeResultMgr,
-                               std::string const& userQueryId) {
+                               std::string const& userQueryId,
+                               std::string const& msgTableName) {
+
+    // result location could potentially be specified by SUBMIT command, for now
+    // we keep it empty which means that UserQuerySelect uses default result table.
+    std::string resultLocation;
 
     // First check for SUBMIT and strip it
     std::string query = aQuery;
@@ -188,7 +193,7 @@ UserQueryFactory::newUserQuery(std::string const& aQuery,
                                                     _impl->qMetaCzarId, largeResultMgr,
                                                     errorExtra, async);
         if (sessionValid) {
-            uq->qMetaRegister();
+            uq->qMetaRegister(resultLocation, msgTableName);
             uq->setupChunking();
         }
         return uq;

--- a/core/modules/ccontrol/UserQueryFactory.h
+++ b/core/modules/ccontrol/UserQueryFactory.h
@@ -66,11 +66,13 @@ public:
     /// @param defaultDb:   Default database name, may be empty
     /// @param largeResultMgr: Manager instance for large results
     /// @param userQueryId: Unique string identifying query
+    /// @param msgTableName: Name of the message table without database name.
     /// @return new UserQuery object
     UserQuery::Ptr newUserQuery(std::string const& query,
                                 std::string const& defaultDb,
                                 qdisp::LargeResultMgr::Ptr const& largeResultMgr,
-                                std::string const& userQueryId);
+                                std::string const& userQueryId,
+                                std::string const& msgTableName);
 
 private:
     class Impl;

--- a/core/modules/ccontrol/UserQueryFlushChunksCache.h
+++ b/core/modules/ccontrol/UserQueryFlushChunksCache.h
@@ -90,12 +90,6 @@ public:
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
 
-    /// @return Name of the result table for this query, can be empty
-    virtual std::string getResultTableName() override { return std::string(); }
-
-    /// @return ORDER BY part of SELECT statement to be executed by proxy
-    virtual std::string getProxyOrderBy() override { return std::string(); }
-
 protected:
 
 private:

--- a/core/modules/ccontrol/UserQueryInvalid.h
+++ b/core/modules/ccontrol/UserQueryInvalid.h
@@ -76,12 +76,6 @@ public:
     virtual std::shared_ptr<qdisp::MessageStore> getMessageStore() override {
         return _messageStore; }
 
-    /// @return Name of the result table for this query, can be empty
-    virtual std::string getResultTableName() override { return std::string(); }
-
-    /// @return ORDER BY part of SELECT statement to be executed by proxy
-    virtual std::string getProxyOrderBy() override { return std::string(); }
-
 private:
 
     std::string const _message;

--- a/core/modules/ccontrol/UserQueryProcessList.cc
+++ b/core/modules/ccontrol/UserQueryProcessList.cc
@@ -115,7 +115,7 @@ UserQueryProcessList::UserQueryProcessList(bool full,
     _query = "SELECT Id, User, Host, db, Command, Time, State, ";
     _query += full ? "Info, " : "SUBSTRING(Info FROM 1 FOR 100) Info, ";
     // These are non-standard but they need to be there because they appear in WHERE
-    _query += "CzarId, Submitted, Completed";
+    _query += "CzarId, Submitted, Completed, ResultLocation";
     _query += " FROM ShowProcessList";
 
     // only show stuff for current czar and not too old

--- a/core/modules/ccontrol/UserQueryProcessList.h
+++ b/core/modules/ccontrol/UserQueryProcessList.h
@@ -114,10 +114,13 @@ public:
         return _messageStore; }
 
     /// @return Name of the result table for this query, can be empty
-    std::string getResultTableName() override { return _resultTableName; }
+    std::string getResultTableName() const override { return _resultTableName; }
+
+    /// @return Result location for this query, can be empty
+    std::string getResultLocation() const override { return "table:" + _resultTableName; }
 
     /// @return ORDER BY part of SELECT statement to be executed by proxy
-    std::string getProxyOrderBy() override { return _orderBy; }
+    std::string getProxyOrderBy() const override { return _orderBy; }
 
 private:
 

--- a/core/modules/ccontrol/UserQuerySelect.h
+++ b/core/modules/ccontrol/UserQuerySelect.h
@@ -92,7 +92,12 @@ public:
     UserQuerySelect(UserQuerySelect const&) = delete;
     UserQuerySelect& operator=(UserQuerySelect const&) = delete;
 
-    void qMetaRegister();
+    /**
+     *  @param resultLocation:  Result location, if empty use result table with unique
+     *                          name generated from query ID.
+     *  @param msgTableName:  Message table name.
+     */
+    void qMetaRegister(std::string const& resultLocation, std::string const& msgTableName);
 
     // Accessors
 
@@ -118,12 +123,21 @@ public:
         return _messageStore; }
 
     /// @return Name of the result table for this query, can be empty
-    virtual std::string getResultTableName() override { return _resultTable; }
+    virtual std::string getResultTableName() const override { return _resultTable; }
+
+    /// @return Result location for this query, can be empty
+    virtual std::string getResultLocation() const override { return _resultLoc; }
 
     /// @return ORDER BY part of SELECT statement to be executed by proxy
-    virtual std::string getProxyOrderBy() override;
+    virtual std::string getProxyOrderBy() const override;
 
     virtual std::string getQueryIdString() const override;
+
+    /// @return this query's QueryId.
+    virtual QueryId getQueryId() const override { return _qMetaQueryId; }
+
+    /// @return True if query is async query
+    virtual bool isAsync() const override { return _async; }
 
     void setupChunking();
 
@@ -151,6 +165,7 @@ private:
     std::mutex _killMutex;
     std::string _errorExtra;    ///< Additional error information
     std::string _resultTable;   ///< Result table name
+    std::string _resultLoc;     ///< Result location
     bool _async;                ///< true for async query
 };
 

--- a/core/modules/czar/Czar.h
+++ b/core/modules/czar/Czar.h
@@ -110,6 +110,11 @@ private:
     /// Private constructor for singleton.
     Czar(std::string const& configPath, std::string const& czarName);
 
+    /// Clean client-to-query map from expired entries, add new query
+    void _updateQueryHistory(std::string const& clientId,
+                             int threadId,
+                             ccontrol::UserQuery::Ptr const& uq);
+
     static Ptr _czar; ///< Pointer to single instance of the Czar.
 
     // combines client name (ID) and its thread ID into one unique ID

--- a/core/modules/czar/Czar.h
+++ b/core/modules/czar/Czar.h
@@ -115,6 +115,11 @@ private:
                              int threadId,
                              ccontrol::UserQuery::Ptr const& uq);
 
+    /// Create and fill async result table
+    void _makeAsyncResult(std::string const& asyncResultTable,
+                          QueryId queryId,
+                          std::string const& resultLoc);
+
     static Ptr _czar; ///< Pointer to single instance of the Czar.
 
     // combines client name (ID) and its thread ID into one unique ID

--- a/core/modules/czar/MessageTable.h
+++ b/core/modules/czar/MessageTable.h
@@ -59,6 +59,9 @@ public:
     // Constructor takes table name including database name
     explicit MessageTable(std::string const& tableName, mysql::MySqlConfig const& resultConfig);
 
+    /// Create the table, do not lock
+    void create();
+
     /// Create and lock the table
     void lock();
 

--- a/core/modules/qmeta/QInfo.h
+++ b/core/modules/qmeta/QInfo.h
@@ -80,13 +80,15 @@ public:
     QInfo(QType qType, int czarId, std::string const& user,
           std::string const& qText, std::string const& qTemplate,
           std::string const& qMerge, std::string const& qProxyOrderBy,
+          std::string const& resultLoc, std::string const& msgTableName,
           QStatus qStatus = EXECUTING,
           std::time_t submitted = std::time_t(0),
           std::time_t completed = std::time_t(0),
           std::time_t returned = std::time_t(0))
         : _qType(qType), _qStatus(qStatus), _czarId(czarId), _user(user),
           _qText(qText), _qTemplate(qTemplate), _qMerge(qMerge),
-          _qProxyOrderBy(qProxyOrderBy), _submitted(submitted),
+          _qProxyOrderBy(qProxyOrderBy), _resultLoc(resultLoc),
+          _msgTableName(msgTableName), _submitted(submitted),
           _completed(completed), _returned(returned)
     {}
 
@@ -114,6 +116,12 @@ public:
     /// Returns query executed by proxy (which may be empty)
     std::string const& proxyOrderBy() const { return _qProxyOrderBy; }
 
+    /// Returns location of query result
+    std::string const& resultLocation() const { return _resultLoc; }
+
+    /// Returns message table name
+    std::string const& msgTableName() const { return _msgTableName; }
+
     /// Return time when query was submitted
     std::time_t submitted() const { return _submitted; }
 
@@ -138,6 +146,8 @@ private:
     std::string _qTemplate; // Query template used to build per-chunk queries.
     std::string _qMerge;    // Aggregate query to be executed on results table, possibly empty.
     std::string _qProxyOrderBy; // ORDER BY clause for proxy-side SELECT statement, possibly empty.
+    std::string _resultLoc; // Location of query result, e.g. table:result_12345
+    std::string _msgTableName; // Name of the message table for this query
     std::time_t _submitted; // Time when query was submitted (seconds since epoch).
     std::time_t _completed; // Time when query finished execution, 0 if not finished.
     std::time_t _returned;  // Time when query result was sent to client, 0 if not sent yet.

--- a/core/modules/qmeta/SConscript
+++ b/core/modules/qmeta/SConscript
@@ -25,3 +25,6 @@ pySwig = env.File(os.path.join('python', 'qmetaLib.py'))
 
 # runs standard stuff _after_ above to install Python module
 standardModule(env, unit_tests=[])
+
+# install schema files
+build_data['install'] += env.Install("$prefix/share/qserv/schema/qmeta", env.Glob("schema/*.sql"))

--- a/core/modules/qmeta/python/__init__.py
+++ b/core/modules/qmeta/python/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Top level QMeta module
 """

--- a/core/modules/qmeta/python/schema_migration.py
+++ b/core/modules/qmeta/python/schema_migration.py
@@ -1,0 +1,219 @@
+"""Module defining methods used in schema migration of QMeta database.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["make_migration_manager"]
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+import logging
+import os
+import re
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+from lsst.qserv.schema import SchemaMigMgr
+from lsst.db import utils
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+_log = logging.getLogger(__name__)
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+class QMetaMigrationManager(SchemaMigMgr):
+    """Class implementing schema migration for QMeta database.
+    """
+
+    # migration script has name "migrate-N-to-M.sql" or "migrate-N-to-M-something.sql"
+    # when applying scripts for any given version N the names are sorted first.
+    _mig_name_re = re.compile(r"migrate-(?P<from>\d+)-to-(?P<to>\d+)(-.*)?.sql")
+
+    def __init__(self, name, engine, scripts_dir):
+
+        SchemaMigMgr.__init__(self)
+
+        self.engine = engine
+
+        # scripts are located in qmeta/ sub-dir
+        scripts_dir = os.path.join(scripts_dir, name)
+
+        # find all migration scripts, add full script path to each
+        scripts = self.findScripts(scripts_dir, self._script_match)
+        self.scripts = [(v0, v1, fname, os.path.join(scripts_dir, fname))
+                        for v0, v1, fname in scripts]
+
+    @classmethod
+    def _script_match(cls, fname):
+        """Match script name against pattern.
+
+        Returns
+        -------
+        None if no match, pair of version numbers if there is match.
+        """
+        match = cls._mig_name_re.match(fname)
+        if match:
+            v_from = int(match.group('from'))
+            v_to = int(match.group('to'))
+            return (v_from, v_to)
+        return None
+
+    def current_version(self):
+        """Returns current schema version.
+
+        Returns
+        -------
+        Integer number
+        """
+
+        # Initial QMeta implementation did not have version number stored at all,
+        # and we call this version 0. Since version=1 version number is stored in
+        # QMetadata table with key="version"
+        if not utils.tableExists(self.engine, "QMetadata"):
+            _log.debug("QMetadata missing: version=0")
+            return 0
+        else:
+            query = "SELECT value FROM QMetadata WHERE metakey = 'version'"
+            result = self.engine.execute(query)
+            row = result.first()
+            if row:
+                _log.debug("found version in database: %s", row[0])
+                return int(row[0])
+
+    def latest_version(self):
+        """Returns latest known schema version.
+
+        Returns
+        -------
+        Integer number
+        """
+        if self.scripts:
+            version = max(script[1] for script in self.scripts)
+            _log.debug("latest version from migration scripts: %s", version)
+        else:
+            # no migration scripts - current version is latest
+            version = self.current_version()
+            _log.debug("no migration scripts, returning current version %s", version)
+        return version
+
+    def migrations(self):
+        """Returns all known migrations.
+
+        Returns
+        -------
+        List of tuples, each tuple contains three elements:
+        - starting schema version (int)
+        - final schema version (usually starting + 1)
+        - migration script name (or any arbitrary string)
+        """
+        return [script[:3] for script in self.scripts]
+
+    def migrate(self, version=None, do_migrate=False):
+        """Perform schema migration from current version to given version.
+
+        Parameters
+        ----------
+        version : int or None
+            If None then migrate to latest known version, otherwise only
+            migrate to given version.
+        do_migrate : bool
+            If True performa migration, otherwise only print steps that
+            should be performed
+
+        Returns
+        -------
+        None if no migrations were performed or the version number at
+        which migration has stopped.
+
+        Raises
+        ------
+        Exception is raised for any migration errors. The state of the
+        database is not guaranteed to be consistent after exception.
+        """
+
+        # checks for requested version
+        if version is not None:
+            current = self.current_version()
+            if current >= version:
+                _log.debug("current version (%s) is already same or newer as requested (%s)",
+                           current, version)
+                return None
+            final_versions = [s[1] for s in self.scripts]
+            if version not in final_versions:
+                raise ValueError("No known migration scripts for requested version ({})".format(version))
+
+        # apply all migration scripts in a loop
+        result = None
+        current = self.current_version()
+        while True:
+
+            if version is not None and current >= version:
+                _log.debug("current version (%s) is now same or newer as requested (%s)",
+                           current, version)
+                break
+
+            # find all migrations for current version
+            scripts = [s for s in self.scripts if s[0] == current]
+            if not scripts:
+                _log.debug("no migration scripts found for current version (%s)", current)
+                break
+
+            # if there are more than one final version use the latest or requested one
+            final_versions = set([s[1] for s in scripts])
+            final = max(final_versions)
+            if version is not None:
+                if version in final_versions:
+                    final = version
+
+            # only use scripts for that final version
+            scripts = sorted([s[2:4] for s in scripts if s[1] == final])
+
+            # apply all scripts
+            for script, path in scripts:
+                _log.info("--- Executing migration script %s", script)
+                if do_migrate:
+                    utils.loadSqlScript(self.engine, path)
+                    _log.info("+++ Script %s completed successfully", script)
+
+            # make sure that current version is updated in database
+            if do_migrate:
+                query = "UPDATE QMetadata SET value = {} WHERE metakey = 'version'".format(final)
+                self.engine.execute(query)
+
+                # read it back and compare with expected
+                current = self.current_version()
+                if current != final:
+                    raise RuntimeError("failed to update version number in database to {}, "
+                                       "current version is now {}".format(final, current))
+            else:
+                # pretend that we migrated to this new version
+                current = final
+
+            result = final
+
+        return result
+
+
+def make_migration_manager(name, engine, scripts_dir):
+    """Factory method for QMeta schema migration manager
+
+    This method is needed to support dynamic loading in `qserv-smig` script.
+
+    Parameters
+    ----------
+    name : `str`
+        Module name, e.g. "qmeta"
+    engine : object
+        Sqlalchemy engine instance.
+    scripts_dir : `str`
+        Path where migration scripts are located, this is system-level directory,
+        per-module scripts are usually located in sub-directories.
+    """
+    return QMetaMigrationManager(name, engine, scripts_dir)

--- a/core/modules/qmeta/schema/migrate-0-to-1.sql
+++ b/core/modules/qmeta/schema/migrate-0-to-1.sql
@@ -1,0 +1,73 @@
+--
+-- Migration script from version 0 to version 1 of QMeta database:
+--   - QInfo table adds two new columns
+--   - processlist views add result location column
+--   - QMetadata table is added to keep schema version
+--
+
+
+-- -----------------------------------------------------
+-- Add new columns to table `QInfo`
+-- -----------------------------------------------------
+ALTER TABLE `QInfo` ADD COLUMN (
+  `messageTable` CHAR(63) NULL COMMENT 'Name of the message table for the ASYNC query',
+  `resultLocation` TEXT NULL COMMENT 'Result destination - table name, file name, etc.'
+);
+
+-- -----------------------------------------------------
+-- Update view `ShowProcessList`
+-- -----------------------------------------------------
+ALTER  VIEW `ShowProcessList` AS
+  SELECT DISTINCT
+    `QInfo`.`queryId` `Id`,
+    `QInfo`.`user` `User`,
+    NULL `Host`,
+    GROUP_CONCAT(DISTINCT `QTable`.`dbName`) `db`,
+    `QInfo`.`qType` `Command`,
+    NULL `Time`,
+    `QInfo`.`status` `State`,
+    `QInfo`.`query` `Info`,
+    NULL `Progress`,
+    `QInfo`.`submitted` `Submitted`,
+    `QInfo`.`completed` `Completed`,
+    `QInfo`.`returned` `Returned`,
+    `QInfo`.`czarId` `CzarId`,
+    REPLACE(`QInfo`.`resultLocation`, '#QID#',  `QInfo`.`queryId`) `ResultLocation`
+  FROM `QInfo` LEFT OUTER JOIN `QTable` USING (`queryId`)
+  GROUP BY `QInfo`.`queryId`;
+
+-- -----------------------------------------------------
+-- Update view `InfoSchemaProcessList`
+-- -----------------------------------------------------
+ALTER VIEW `InfoSchemaProcessList` AS
+  SELECT DISTINCT
+    `QInfo`.`queryId` `ID`,
+    `QInfo`.`user` `USER`,
+    NULL `HOST`,
+    GROUP_CONCAT(DISTINCT `QTable`.`dbName`) `DB`,
+    `QInfo`.`qType` `COMMAND`,
+    NULL `TIME`,
+    `QInfo`.`status` `STATE`,
+    `QInfo`.`query` `INFO`,
+    `QInfo`.`submitted` `SUBMITTED`,
+    `QInfo`.`completed` `COMPLETED`,
+    `QInfo`.`returned` `RETURNED`,
+    `QInfo`.`czarId` `CZARID`,
+    REPLACE(`QInfo`.`resultLocation`, '#QID#',  `QInfo`.`queryId`) `RESULTLOCATION`,
+    NULLIF(COUNT(`QWorker`.`chunk`), 0) `NCHUNKS`
+  FROM `QInfo` LEFT OUTER JOIN `QTable` USING (`queryId`)
+        LEFT OUTER JOIN `QWorker` USING (`queryId`)
+  GROUP BY `QInfo`.`queryId`;
+
+-- -----------------------------------------------------
+-- Create table `QMetadata`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `QMetadata` (
+  `metakey` CHAR(64) NOT NULL COMMENT 'Key string',
+  `value` TEXT NULL COMMENT 'Key string',
+  PRIMARY KEY (`metakey`))
+ENGINE = InnoDB
+COMMENT = 'Metadata about database as a whole, bunch of key-value pairs';
+
+-- Add record for schema version, migration script expects this record to exist
+INSERT INTO `QMetadata` (`metakey`, `value`) VALUES ('version', '1');

--- a/core/modules/qmeta/testQMeta.cc
+++ b/core/modules/qmeta/testQMeta.cc
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(messWithQueries) {
 
     // resister one query
     QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}",
-                "SELECT Merge ' query", "SELECT Proxy query");
+                "SELECT Merge ' query", "SELECT Proxy query", "result_#QID#", "message_12345");
     QMeta::TableNames tables(1, std::make_pair("TestDB", "Object"));
     lsst::qserv::QueryId qid1 = qMeta->registerQuery(qinfo, tables);
     BOOST_CHECK(qid1 != 0U);
@@ -154,6 +154,8 @@ BOOST_AUTO_TEST_CASE(messWithQueries) {
     BOOST_CHECK_EQUAL(qinfo1.queryTemplate(), qinfo.queryTemplate());
     BOOST_CHECK_EQUAL(qinfo1.mergeQuery(), qinfo.mergeQuery());
     BOOST_CHECK_EQUAL(qinfo1.proxyOrderBy(), qinfo.proxyOrderBy());
+    BOOST_CHECK_EQUAL(qinfo1.msgTableName(), qinfo.msgTableName());
+    BOOST_CHECK_EQUAL(qinfo1.resultLocation(), "result_" + std::to_string(qid1));
     BOOST_CHECK(qinfo1.submitted() != std::time_t(0));
     BOOST_CHECK_EQUAL(qinfo1.completed(), std::time_t(0));
     BOOST_CHECK_EQUAL(qinfo1.returned(), std::time_t(0));
@@ -248,11 +250,11 @@ BOOST_AUTO_TEST_CASE(messWithQueries2) {
     BOOST_CHECK(cid2 != 0U);
 
     // resister few queries
-    QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}", "", "");
+    QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}", "", "", "", "");
     QMeta::TableNames tables(1, std::make_pair("TestDB", "Object"));
     lsst::qserv::QueryId qid1 = qMeta->registerQuery(qinfo, tables);
     lsst::qserv::QueryId qid2 = qMeta->registerQuery(qinfo, tables);
-    qinfo = QInfo(QInfo::ASYNC, cid2, "user2", "SELECT * from Object", "SELECT * from Object_{}", "", "");
+    qinfo = QInfo(QInfo::ASYNC, cid2, "user2", "SELECT * from Object", "SELECT * from Object_{}", "", "", "", "");
     lsst::qserv::QueryId qid3 = qMeta->registerQuery(qinfo, tables);
     lsst::qserv::QueryId qid4 = qMeta->registerQuery(qinfo, tables);
 
@@ -293,11 +295,11 @@ BOOST_AUTO_TEST_CASE(messWithTables) {
     BOOST_CHECK(cid2 != 0U);
 
     // resister few queries
-    QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}", "", "");
+    QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}", "", "", "", "");
     QMeta::TableNames tables(1, std::make_pair("TestDB", "Object"));
     lsst::qserv::QueryId qid1 = qMeta->registerQuery(qinfo, tables);
     lsst::qserv::QueryId qid2 = qMeta->registerQuery(qinfo, tables);
-    qinfo = QInfo(QInfo::ASYNC, cid2, "user2", "SELECT * from Object", "SELECT * from Object_{}", "", "");
+    qinfo = QInfo(QInfo::ASYNC, cid2, "user2", "SELECT * from Object", "SELECT * from Object_{}", "", "", "", "");
     tables.push_back(std::make_pair("TestDB", "Source"));
     lsst::qserv::QueryId qid3 = qMeta->registerQuery(qinfo, tables);
     lsst::qserv::QueryId qid4 = qMeta->registerQuery(qinfo, tables);
@@ -339,7 +341,7 @@ BOOST_AUTO_TEST_CASE(messWithChunks) {
     BOOST_CHECK(cid2 != 0U);
 
     // resister one query
-    QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}", "", "");
+    QInfo qinfo(QInfo::SYNC, cid1, "user1", "SELECT * from Object", "SELECT * from Object_{}", "", "", "", "");
     QMeta::TableNames tables;
     tables.push_back(std::make_pair("TestDB", "Object"));
     lsst::qserv::QueryId qid1 = qMeta->registerQuery(qinfo, tables);

--- a/core/modules/schema/README.md
+++ b/core/modules/schema/README.md
@@ -1,0 +1,116 @@
+Qserv tools for schema migration
+================================
+
+This package contains code for managing of the schema migration process
+for Qserv databases (e.g. QMeta or CSS). The code in this package is a
+generic framework, specific details of migration process are implemented
+in the packages which define schema and provide migration scripts for the
+schema.
+
+Main item in this framework is a `qserv-smig.py` application, this
+application does not have direct dependency on any specific schema, instead
+it is designed to discover and load schema-specific code at run time. Here
+is how it works:
+- application takes the name of the module that is supposed to provide
+  migration module for its schema
+- given that name `smig` imports a module with the name
+  `lsst.qserv.<name>.schema_migration`, this module is supposed to
+  implement a factory method with the name `make_migration_manager`.
+- `smig` calls this method with a bunch of parameters, and method should
+  return an instance of the special _migration manager_ class which
+  implements interface defined by `schema.SchemaMigMgr` class.
+- `smig` call various methods of this instance to either obtain
+  information about schema or perform schema migration.
+
+The modules that need to support schema migration for the databases defined
+in these modules typically need to implement following:
+- define a Python module with the name `schema_migration`, this typically
+  goes into `python` sub-directory of the module and is installed in
+  `lib/python/lsst/qserv/<module>` folder to be imported by `smig`.
+- that module has to implement single method `make_migration_manager`
+  which takes few parameters (check `qmeta` module for example) and returns
+  new instance of `schema.SchemaMigMgr` class.
+
+The methods in `schema.SchemaMigMgr` sub-classes can be implemented in
+any reasonable way. Typical implementation can, for example, be defined in
+terms of separate SQL scripts which are installed in `share/qmeta/schema`
+sub-directory (this is default location used by `smig`) and named to
+reflect version numbers of the schema (e.g. `migrate-0-to-1.sql`).
+
+There is an implementation of these concepts in `qmeta` module, presently
+it supports migration of `QMeta` schema from version 0 to version 1. That
+module can be used as an example for implementing migration for other modules.
+
+Performing migration
+====================
+
+`qserv-smig.py` is the main tool for all migration-related tasks. Because
+it can run migration for any module it needs a bunch of parameters to
+identify particular module and its database. The module name s passed as a
+positional parameter to the script. Database connection can be specified in
+couple different ways:
+- as a sqlalchemy-style URL using -c option: `-c mysql://user:pass@host:port/dbName`
+- as a reference to a configuration section in some INI file:
+  `-f etc/qserv-czar.cnf -s css`.
+
+Latter case can be used when database connection parameters are stores in
+existing configuration files (e.g. files in existing qserv installation),
+though in many cases schema migration will require administrator-level
+access so URL-style connection would be more convenient in that case.
+
+Here are few use cases for `qserv-smig` script.
+
+Dump schema information
+-----------------------
+
+Running script without any option will dump some useful info, for example:
+
+    $  qserv-smig.py -c mysql://root:***@127.0.0.1:13306/qservMeta qmeta
+    Current schema version: 0
+    Latest schema version: 1
+    Known migrations:
+      0 -> 1 : migrate-0-to-1.sql (X)
+    Database would be migrated to version 1
+
+The information displayed here includes:
+- schema version currently defined by database,
+- latest schema version which is determined as highest schema number in
+  migration scripts,
+- migration steps - starting version, final version and corresponding script,
+  `(X)` marks scripts that would be applied to current setup,
+- final version that would be active after migration
+
+Check schema version
+--------------------
+
+To check that migration is needed for current setup `--check` option
+could be used:
+
+    $  qserv-smig.py --check -c mysql://root:***@127.0.0.1:13306/qservMeta qmeta
+
+This will print the same info but will also return code to the shell,
+code 0 means that schema does not need migration, code 1 means that schema
+needs update.
+
+Migrating schema
+----------------
+
+Actual migration is only performed if option `-m` appears on command line:
+
+    $  qserv-smig.py -m -c mysql://root:***@127.0.0.1:13306/qservMeta qmeta
+    Current schema version: 0
+    Latest schema version: 1
+    Known migrations:
+      0 -> 1 : migrate-0-to-1.sql (X)
+    Database was migrated to version 1
+
+It prints the same info but last line now says that schema was updated. Use
+`-v` option to also see extra info during migration process.
+
+Normally `smig` tries to update schema to the latest version, but it is
+possible to stop migration process at specific version by using `-n` option:
+
+    $  qserv-smig.py -m -n 100 -c mysql://root:***@127.0.0.1:13306/qservMeta qmeta
+
+this will stop migration after version 100 even if there migration scripts
+for later versions.

--- a/core/modules/schema/bin/qserv-smig.py
+++ b/core/modules/schema/bin/qserv-smig.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+
+# LSST Data Management System
+# Copyright 2017 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+"""Application which implements migration process for qserv databases.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+# --------------------------------
+#  Imports of standard modules --
+# --------------------------------
+import argparse
+import importlib
+import logging
+import os
+import sys
+
+try:
+    import configparser
+except ImportError:
+    # for Python2
+    import ConfigParser as configparser
+
+# -----------------------------
+# Imports for other modules --
+# -----------------------------
+from lsst.db import engineFactory
+import sqlalchemy
+from sqlalchemy.engine.url import make_url
+
+# ----------------------------------
+# Local non-exported definitions --
+# ----------------------------------
+
+_def_scripts = os.path.join(os.environ.get("QSERV_DIR", ""), "share/qserv/schema")
+
+_mig_module_name = "schema_migration"
+_factory_method_name = "make_migration_manager"
+
+def _load_migration_mgr(mod_name, engine, scripts_dir):
+    """Dynamic loading of the migration manager based on module name.
+
+    Parameters
+    ----------
+    mod_name : `str`
+        Module name, e.g. "qmeta"
+    engine : object
+        Sqlalchemy engine instance.
+    scripts_dir : `str`
+        Path where migration scripts are located, this is system-level directory,
+        per-module scripts are usually located in sub-directories.
+
+    Returns
+    -------
+    Object which manages migrations for that module.
+
+    Raises
+    ------
+    Exception is raised for any error.
+    """
+
+    # load module "lsst.qserv.<module>.schema_migration"
+    try:
+        mod_instance = importlib.import_module("lsst.qserv." + mod_name + "." + _mig_module_name)
+    except ImportError:
+        logging.error("Failed to load %s module from lsst.qserv.%s package",
+                      _mig_module_name, mod_name)
+        raise
+
+    # find a method with name "make_migration_manager"
+    try:
+        factory = getattr(mod_instance, _factory_method_name)
+    except AttributeError:
+        logging.error("Module %s does not contain factory method %s.",
+                      _mig_module_name, _factory_method_name)
+        raise
+
+    # call factory method, pass all needed arguments
+    mgr = factory(name=mod_name, engine=engine, scripts_dir=scripts_dir)
+
+    return mgr
+
+
+def _normalizeConfig(config):
+    """Make connection parameters out of config.
+
+    We have a mess in our INI files in how we specify connection parameters
+    depending on which piece of C++ or Python code uses those parameters.
+    For our purposes I need to convert that mess into a mess acceptable by
+    getEngineFromArgs() method.
+
+    Parameters
+    ----------
+    config : dict
+        Parameters read from configuration file
+
+    Returns
+    -------
+    Dictionary with parameters passed to getEngineFromArgs()
+    """
+    res = {}
+    if config.get("technology") == "mysql":
+        res["drivername"] = "mysql+mysqldb"
+    elif config.get("technology") is not None:
+        raise ValueError("Unexpected technology specified for connection: " +
+                         str(config.get("technology")))
+    res["username"] = config.get("username") or config.get("user")
+    res["password"] = config.get("password") or config.get("passwd") or config.get("pass")
+    res["host"] = config.get("hostname") or config.get("host")
+    res["port"] = config.get("port")
+    res["database"] = config.get("database") or config.get("db")
+    socket = config.get("unix_socket") or config.get("socket")
+    if socket:
+        res["query"] = dict(unix_socket=socket)
+
+    return res
+
+# ------------------------
+# Exported definitions --
+# ------------------------
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="Qserv database schema migration.")
+
+    parser.add_argument("-v", "--verbose", default=0, action="count",
+                        help="Use one -v for INFO logging, two for DEBUG.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-m", "--do-migrate", default=False, action="store_true",
+                       help="Do migration, without this option script prints various info "
+                       "and exits.")
+    group.add_argument("--check", default=False, action="store_true",
+                       help="Check that migration is needed, script returns 0 if schema is "
+                       "up-to-date, 1 otherwise.")
+    parser.add_argument("-n", "--final", default=None, action="store", type=int,
+                        metavar="VERSION",
+                        help="Stop migration at given version, by default update to "
+                        "latest version.")
+    parser.add_argument("--scripts", default=_def_scripts, action="store",
+                        metavar="PATH",
+                        help="Location for migration scripts, def: %(default)s.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-c", "--connection", metavar="CONNECTION",
+                       help="Connection string in format mysql://user:pass@host:port/database.")
+    group.add_argument("-f", "--config-file", metavar="PATH",
+                       help="Name of configuration file in INI format with connection parameters.")
+    parser.add_argument("-s", "--config-section", metavar="NAME",
+                        help="Name of configuration section in configuration file.")
+
+    parser.add_argument("module",
+                        help="Name of Qserv module for which to update schema, e.g. qmeta.")
+
+    args = parser.parse_args()
+
+    # configure logging
+    levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    level = levels.get(args.verbose, logging.DEBUG)
+    fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt)
+
+    if args.connection:
+        url = make_url(args.connection)
+        engine = sqlalchemy.create_engine(url)
+    elif args.config_file:
+        if not args.config_section:
+            parser.error("-s options required with -f")
+
+        cfg = configparser.SafeConfigParser()
+        if not cfg.read([args.config_file]):
+            # file was not found, generate exception which should happen
+            # if we tried to open that file
+            raise IOError(2, "No such file or directory: '{}'".format(args.config_file))
+
+        # will throw is section is missing
+        config = dict(cfg.items(args.config_section))
+
+        # instantiate database engine
+        config = _normalizeConfig(config)
+        engine = engineFactory.getEngineFromArgs(**config)
+
+    # make an object which will manage migration process
+    mgr = _load_migration_mgr(args.module, engine=engine, scripts_dir=args.scripts)
+
+    current = mgr.current_version()
+    print("Current schema version: {}".format(current))
+
+    latest = mgr.latest_version()
+    print("Latest schema version: {}".format(latest))
+
+    migrations = mgr.migrations()
+    print("Known migrations:")
+    for v0, v1, script in migrations:
+        tag = " (X)" if v0 >= current else ""
+        print("  {} -> {} : {}{}".format(v0, v1, script, tag))
+
+    if args.check:
+        return 0 if mgr.current_version() == mgr.latest_version() else 1
+
+    # do the migrations
+    final = mgr.migrate(args.final, args.do_migrate)
+    if final is None:
+        print("No migration was needed")
+    else:
+        if args.do_migrate:
+            print("Database was migrated to version {}".format(final))
+        else:
+            print("Database would be migrated to version {}".format(final))
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/modules/schema/python/__init__.py
+++ b/core/modules/schema/python/__init__.py
@@ -1,0 +1,2 @@
+
+from schemaMigMgr import SchemaMigMgr

--- a/core/modules/schema/python/schemaMigMgr.py
+++ b/core/modules/schema/python/schemaMigMgr.py
@@ -1,0 +1,133 @@
+"""Module defining SchemaMigMgr abstract base class.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["SchemaMigMgr"]
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+from abc import ABCMeta, abstractmethod
+import logging
+import os
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+_log = logging.getLogger(__name__)
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+class SchemaMigMgr:
+    """Abstract base class for schema migration managers.
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def current_version(self):
+        """Returns current schema version.
+
+        Returns
+        -------
+        Integer number
+        """
+        pass
+
+    @abstractmethod
+    def latest_version(self):
+        """Returns latest known schema version.
+
+        Returns
+        -------
+        Integer number
+        """
+        pass
+
+    @abstractmethod
+    def migrations(self):
+        """Returns all known migrations.
+
+        Returns
+        -------
+        List of tuples, each tuple contains three elements:
+        - starting schema version (int)
+        - final schema version (usually starting + 1)
+        - migration script name (or any arbitrary string)
+        """
+        pass
+
+    @abstractmethod
+    def migrate(self, version=None, do_migrate=False):
+        """Perform schema migration from current version to given version.
+
+        Parameters
+        ----------
+        version : int or None
+            If None then migrate to latest known version, otherwise only
+            migrate to given version.
+        do_migrate : bool
+            If True performa migration, otherwise only print steps that
+            should be performed
+
+        Returns
+        -------
+        None if no migrations were performed or the version number at
+        which migration has stopped.
+
+        Raises
+        ------
+        Exception is raised for any migration errors. The state of the
+        database is not guaranteed to be consistent after exception.
+        """
+        pass
+
+    @classmethod
+    def findScripts(cls, scripts_dir, match_fun):
+        """Helper function for finding migration scripts.
+
+        Parameters
+        ----------
+        scripts_dir : str
+            Path to a directory where scripts are located.
+        match_fun : function
+            Function which takes one argument which is a script name
+            (without directory) and returns None if script is not useful
+            or 2-tuple (from_version, to_version) with version numbers.
+            If versions are identical then script is ignored.
+
+        Returns
+        -------
+        List of tuples, one tuple per script, each tuple contains three items:
+            from_version : int
+                Schema version number to apply this script to
+            to_version : int
+                Schema version number for resulting schema
+            name : str
+                Script name (without directory)
+
+        Raises
+        ------
+        Exception is raised if directory does not exist or if `match_fun`
+        raises exception or returns unexpected value.
+        """
+        scripts = []
+        for fname in os.listdir(scripts_dir):
+            _log.debug("checking script %s", fname)
+            match = match_fun(fname)
+            if match is not None:
+                v_from, v_to = match
+                _log.debug("matching script %s: %s -> %s", fname, v_from, v_to)
+                if v_from == v_to:
+                    _log.warn("script %s has identical versions, skipping", path)
+                else:
+                    scripts.append((v_from, v_to, fname))
+        return scripts


### PR DESCRIPTION
SUBMIT query now sends query for execution and returns immediately with the result containing just query ID and name of the result table. Retrieving of the actual result of the disconnected query will be implemented later.

Because QMeta database schema needs update for this new feature I have also implemented generic framework for schema migration and added migration of QMeta schema from version 0 to version 1. When deploying this new code on existing installation one will have to run migration script for QMeta.
