### PR TITLE
Fix Python3 compatibility for scons scripts (DM-11411)

### DIFF
--- a/site_scons/site_tools/compiler.py
+++ b/site_scons/site_tools/compiler.py
@@ -97,7 +97,7 @@ def generate(env):
         if not re.search(r"-install_name", str(env['SHLINKFLAGS'])):
             env.Append(SHLINKFLAGS=["-install_name", "@rpath/${TARGET.file}"])
 
-    elif platform == 'linux2':
+    elif platform.startswith('linux'):
         # Linux with any compiler
 
         # Increase compiler strictness


### PR DESCRIPTION
In site_scons/site_tools/compiler.py we are using sys.platform to check
for Linux. In Python2 it used to be "linux2" but changed to "linux" in
Python3. Changed equality test to startswith() to work in both 2 and 3.