### PR TITLE
Implement returning results of disconnected queries/jobs (DM-11191)

### DIFF
--- a/core/modules/ccontrol/UserQueryAsyncResult.cc
+++ b/core/modules/ccontrol/UserQueryAsyncResult.cc
@@ -1,0 +1,214 @@
+/*
+ * LSST Data Management System
+ * Copyright 2017 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Class header
+#include "ccontrol/UserQueryAsyncResult.h"
+
+// System headers
+
+// Third-party headers
+
+// LSST headers
+#include "lsst/log/Log.h"
+
+// Qserv headers
+#include "qmeta/Exceptions.h"
+#include "qmeta/QMeta.h"
+#include "qdisp/MessageStore.h"
+#include "sql/SqlConnection.h"
+#include "sql/SqlResults.h"
+
+namespace {
+LOG_LOGGER _log = LOG_GET("lsst.qserv.ccontrol.UserQueryProcessList");
+}
+
+namespace lsst {
+namespace qserv {
+namespace ccontrol {
+
+// Constructors
+UserQueryAsyncResult::UserQueryAsyncResult(QueryId queryId,
+                                           qmeta::CzarId qMetaCzarId,
+                                           std::shared_ptr<qmeta::QMeta> const& qMeta,
+                                           sql::SqlConnection* resultDbConn)
+    : UserQuery(), _qMetaCzarId(qMetaCzarId),
+      _resultDbConn(resultDbConn),
+      _messageStore(std::make_shared<qdisp::MessageStore>()) {
+
+    LOGS(_log, LOG_LVL_DEBUG, "UserQueryAsyncResult: QID=" << queryId);
+
+    // get query info from QMeta
+    try {
+        _qInfo = qMeta->getQueryInfo(queryId);
+        LOGS(_log, LOG_LVL_DEBUG, "found QMeta record: czar=" << _qInfo.czarId()
+             << " status=" << _qInfo.queryStatus() << " resultLoc=" << _qInfo.resultLocation()
+             << " msgTableName=" << _qInfo.msgTableName());
+    } catch (qmeta::QueryIdError const& exc) {
+        std::string message = "No job found for ID=" + std::to_string(queryId);
+        LOGS(_log, LOG_LVL_DEBUG, message);
+        _messageStore->addErrorMessage(message);
+    } catch (std::exception const& exc) {
+        LOGS(_log, LOG_LVL_ERROR, "error in querying QMeta: " << exc.what());
+        std::string message = "Internal failure, error in querying QMeta: ";
+        message += exc.what();
+        _messageStore->addErrorMessage(message);
+    }
+}
+
+// Destructor
+UserQueryAsyncResult::~UserQueryAsyncResult() {
+}
+
+
+std::string UserQueryAsyncResult::getError() const {
+    return std::string();
+}
+
+void UserQueryAsyncResult::submit() {
+
+    _qState = ERROR;
+
+    // if there are messages already it means the error was detected, stop right here
+    if (_messageStore->messageCount() > 0) {
+        return;
+    }
+
+    // Presently we cannot return query results that originated from different czar
+    if (_qInfo.czarId() != _qMetaCzarId) {
+        // TODO: tell user which czar was it?
+        std::string message = "Query originated from different czar";
+        _messageStore->addErrorMessage(message);
+        return;
+    }
+
+    // TODO: check user name, does not matter now as we are not keeping tack of users.
+    // TODO: this is supposed to be used with ASYNC queries only but I can imagine that
+    // it could be useful with SYNC too if/when we manage result lifetime properly
+
+    // If query has not finished yet return error
+    // TODO: there may be more info available if status is FAILED or ABORTED
+    if (_qInfo.queryStatus() != qmeta::QInfo::COMPLETED) {
+        std::string message = "Query is still executing (or FAILED)";
+        LOGS(_log, LOG_LVL_DEBUG, message);
+        _messageStore->addErrorMessage(message);
+        return;
+    }
+
+    // Can only return results from mysql tables
+    if (_qInfo.resultLocation().compare(0, 6, "table:") != 0) {
+        std::string message = "Cannot return result as it is not stored in table.";
+        LOGS(_log, LOG_LVL_DEBUG, message);
+        _messageStore->addErrorMessage(message);
+        return;
+    }
+    std::string const resultTableName = _qInfo.resultLocation().substr(6);
+
+    // check that message and result tables exist
+    sql::SqlErrorObject sqlErrObj;
+    if (!_resultDbConn->tableExists(_qInfo.msgTableName(), sqlErrObj) or
+        !_resultDbConn->tableExists(resultTableName, sqlErrObj)) {
+        std::string message = "Result or message table does not exist, result is likely expired.";
+        LOGS(_log, LOG_LVL_DEBUG, message);
+        _messageStore->addErrorMessage(message);
+        return;
+    }
+
+    // all checks are OK, copy message table from original query
+    // into the message store, at this point original result table must be unlocked
+    std::string query = "SELECT chunkId, code, message, severity, timeStamp FROM " +
+                    _qInfo.msgTableName();
+    sql::SqlResults sqlResults;
+    if (!_resultDbConn->runQuery(query, sqlResults, sqlErrObj)) {
+        LOGS(_log, LOG_LVL_ERROR, "Failed to retrieve message table data: " << sqlErrObj.errMsg());
+        std::string message = "Failed to retrieve message table data.";
+        _messageStore->addErrorMessage(message);
+        return;
+    }
+
+    // copy messages
+    int count = 0;
+    for (auto&& row: sqlResults) {
+        try {
+            int chunkId = boost::lexical_cast<int>(row[0].first);
+            int code = boost::lexical_cast<int>(row[1].first);
+            std::string message = row[2].first;
+            std::string sevStr = row[3].first;
+            float timestamp = boost::lexical_cast<float>(row[4].first);
+            MessageSeverity sev = sevStr == "INFO" ? MSG_INFO : MSG_ERROR;
+            _messageStore->addMessage(chunkId, code, message, sev, std::time_t(timestamp));
+        } catch (std::exception const& exc) {
+            LOGS(_log, LOG_LVL_ERROR, "Error reading message table data: " << exc.what());
+            std::string message = "Error reading message table data.";
+            _messageStore->addErrorMessage(message);
+            return;
+        }
+        ++ count;
+    }
+    LOGS(_log, LOG_LVL_DEBUG, "Copied " << count << " messages from " << _qInfo.msgTableName());
+
+    // Original message table is not useful any more because the result table
+    // will be deleted by proxy anyways. Until we have better lifetime management
+    // of results I'm going to drop this table now, meaning result can be only
+    // retrieved once.
+    query = "DROP TABLE " + _qInfo.msgTableName();
+    if (!_resultDbConn->runQuery(query, sqlErrObj)) {
+        LOGS(_log, LOG_LVL_ERROR, "Failed to drop message table: " << sqlErrObj.errMsg());
+        // Users do not care about this error, so don't send it upstream.
+    } else {
+        LOGS(_log, LOG_LVL_DEBUG, "Deleted message table " << _qInfo.msgTableName());
+    }
+
+    // done
+    _qState = SUCCESS;
+}
+
+QueryState UserQueryAsyncResult::join() {
+    return _qState;
+}
+
+void UserQueryAsyncResult::kill() {
+}
+
+void UserQueryAsyncResult::discard() {
+}
+
+std::shared_ptr<qdisp::MessageStore> UserQueryAsyncResult::getMessageStore() {
+    return _messageStore;
+}
+
+std::string UserQueryAsyncResult::getResultTableName() const {
+    if (_qInfo.resultLocation().compare(0, 6, "table:") == 0) {
+        return _qInfo.resultLocation().substr(6);
+    } else {
+        return std::string();
+    }
+}
+
+std::string UserQueryAsyncResult::getResultLocation() const {
+    return "table:" + getResultTableName();
+}
+
+std::string UserQueryAsyncResult::getProxyOrderBy() const {
+    return _qInfo.proxyOrderBy();
+}
+
+}}} // namespace lsst::qserv::ccontrol

--- a/core/modules/ccontrol/UserQueryAsyncResult.h
+++ b/core/modules/ccontrol/UserQueryAsyncResult.h
@@ -1,0 +1,130 @@
+/*
+ * LSST Data Management System
+ * Copyright 2017 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_QSERV_CCONTROL_USERQUERYASYNCRESULT_H
+#define LSST_QSERV_CCONTROL_USERQUERYASYNCRESULT_H
+
+// System headers
+
+// Third-party headers
+
+// Qserv headers
+#include "ccontrol/UserQuery.h"
+#include "qmeta/QInfo.h"
+#include "qmeta/types.h"
+
+namespace lsst {
+namespace qserv {
+namespace qdisp {
+class MessageStore;
+}
+namespace qmeta {
+class QMeta;
+}
+namespace sql {
+class SqlConnection;
+}}}
+
+
+namespace lsst {
+namespace qserv {
+namespace ccontrol {
+
+/// @addtogroup ccontrol
+
+/**
+ *  @ingroup ccontrol
+ *
+ *  @brief UserQuery implementation for returning results of async queries.
+ */
+
+class UserQueryAsyncResult : public UserQuery {
+public:
+
+    /**
+     *  Constructor for "SELECT * FROM QSERV_RESULT(QID)".
+     *
+     *  @param queryId:       Query ID for which to return result
+     *  @param qMetaCzarId:   ID for current czar
+     *  @param qMetaSelect:   QMetaSelect instance
+     *  @param resultDbConn:  Connection to results database
+     */
+    UserQueryAsyncResult(QueryId queryId,
+                         qmeta::CzarId qMetaCzarId,
+                         std::shared_ptr<qmeta::QMeta> const& qMeta,
+                         sql::SqlConnection* resultDbConn);
+
+    // Destructor
+    ~UserQueryAsyncResult();
+
+    UserQueryAsyncResult(UserQueryAsyncResult const&) = delete;
+    UserQueryAsyncResult& operator=(UserQueryAsyncResult const&) = delete;
+
+    /// @return a non-empty string describing the current error state
+    /// Returns an empty string if no errors have been detected.
+    std::string getError() const override;
+
+    /// Begin execution of the query over all ChunkSpecs added so far.
+    void submit() override;
+
+    /// Wait until the query has completed execution.
+    /// @return the final execution state.
+    QueryState join() override;
+
+    /// Stop a query in progress (for immediate shutdowns)
+    void kill() override;
+
+    /// Release resources related to user query
+    void discard() override;
+
+    // Delegate objects
+    std::shared_ptr<qdisp::MessageStore> getMessageStore() override;
+
+    /// This method should disappear when we start supporting results
+    /// in locations other than MySQL tables. We'll switch to getResultLocation()
+    /// at that point.
+    /// @return Name of the result table for this query, can be empty
+    std::string getResultTableName() const override;
+
+    /// Result location could be something like "table:table_name" or
+    /// "file:/path/to/file.csv".
+    /// @return Result location for this query, can be empty
+    std::string getResultLocation() const override;
+
+    /// @return ORDER BY part of SELECT statement to be executed by proxy
+    std::string getProxyOrderBy() const override;
+
+protected:
+
+private:
+
+    QueryId _queryId;
+    qmeta::CzarId _qMetaCzarId;
+    std::shared_ptr<qmeta::QMeta> _qMeta;
+    sql::SqlConnection* _resultDbConn;
+    qmeta::QInfo _qInfo;
+    std::shared_ptr<qdisp::MessageStore> _messageStore;
+    QueryState _qState = UNKNOWN;
+};
+
+}}} // namespace lsst::qserv::ccontrol
+
+#endif // LSST_QSERV_CCONTROL_USERQUERYASYNCRESULT_H

--- a/core/modules/ccontrol/UserQueryType.h
+++ b/core/modules/ccontrol/UserQueryType.h
@@ -23,12 +23,13 @@
 #define LSST_QSERV_CCONTROL_USERQUERYTYPE_H
 
 // System headers
+#include <cstdint>
 #include <string>
 
 // Third-party headers
 
 // Qserv headers
-
+#include "global/intTypes.h"
 
 namespace lsst {
 namespace qserv {
@@ -51,7 +52,7 @@ public:
     /// Returns true if query is DROP TABLE
     static bool isDropTable(std::string const& query, std::string& dbName, std::string& tableName);
 
-    /// Returns true if query is SELECT
+    /// Returns true if query is regular SELECT (not isSelectResult())
     static bool isSelect(std::string const& query);
 
     /// Returns true if query is FLUSH QSERV_CHUNKS_CACHE [FOR database]
@@ -77,6 +78,12 @@ public:
      *  in `stripped` string.
      */
     static bool isSubmit(std::string const& query, std::string& stripped);
+
+    /**
+     *  Returns true if query is SELECT * FROM QSERV_RESULT(...), returns
+     *  query ID in `queryId` argument.
+     */
+    static bool isSelectResult(std::string const& query, QueryId& queryId);
 
 };
 

--- a/core/modules/qdisp/MessageStore.cc
+++ b/core/modules/qdisp/MessageStore.cc
@@ -49,13 +49,19 @@ namespace qdisp {
 // public
 ////////////////////////////////////////////////////////////////////////
 
-void MessageStore::addMessage(int chunkId, int code, std::string const& description, MessageSeverity severity) {
+void MessageStore::addMessage(int chunkId, int code,
+                              std::string const& description,
+                              MessageSeverity severity,
+                              std::time_t timestamp) {
+    if (timestamp == std::time_t(0)) {
+        timestamp = std::time(nullptr);
+    }
     auto level = code < 0 ? LOG_LVL_ERROR : LOG_LVL_DEBUG;
     LOGS(_log, level, "Add msg: " << chunkId << " " << code << " " << description);
     {
         std::lock_guard<std::mutex> lock(_storeMutex);
         _queryMessages.insert(_queryMessages.end(),
-                              QueryMessage(chunkId, code, description, std::time(0), severity));
+                              QueryMessage(chunkId, code, description, timestamp, severity));
     }
 }
 

--- a/core/modules/qdisp/MessageStore.h
+++ b/core/modules/qdisp/MessageStore.h
@@ -88,7 +88,8 @@ public:
      * @param severity_ message severity level, default to MSG_INFO
      */
     void addMessage(int chunkId, int code, std::string const& description,
-                    MessageSeverity severity_ = MessageSeverity::MSG_INFO);
+                    MessageSeverity severity_ = MessageSeverity::MSG_INFO,
+                    std::time_t timestamp = std::time_t(0));
 
     /** Add an error message to this MessageStore
      *

--- a/core/modules/qmeta/QInfo.h
+++ b/core/modules/qmeta/QInfo.h
@@ -26,6 +26,9 @@
 #include <ctime>
 #include <string>
 
+// Qserv headers
+#include "qmeta/types.h"
+
 namespace lsst {
 namespace qserv {
 namespace qmeta {
@@ -77,7 +80,7 @@ public:
      *  @param completed: Time when query finished execution, 0 if not finished.
      *  @param returned: Time when query result was sent to client, 0 if not sent yet.
      */
-    QInfo(QType qType, int czarId, std::string const& user,
+    QInfo(QType qType, CzarId czarId, std::string const& user,
           std::string const& qText, std::string const& qTemplate,
           std::string const& qMerge, std::string const& qProxyOrderBy,
           std::string const& resultLoc, std::string const& msgTableName,
@@ -99,7 +102,7 @@ public:
     QStatus queryStatus() const { return _qStatus; }
 
     /// Returns czar Id
-    int czarId() const { return _czarId; }
+    CzarId czarId() const { return _czarId; }
 
     /// Returns user name
     std::string const& user() const { return _user; }
@@ -140,7 +143,7 @@ private:
 
     QType _qType;           // Query type, one of QType constants
     QStatus _qStatus;       // Query processing status
-    int _czarId;            // Czar ID, non-negative number.
+    CzarId _czarId;         // Czar ID, non-negative number.
     std::string _user;      // User name for user who issued the query.
     std::string _qText;     // Original query text as given by user.
     std::string _qTemplate; // Query template used to build per-chunk queries.


### PR DESCRIPTION
New UserQuery subclass (UserQueryAsyncResult) handles most of the job.
It finds necessary info in QMeta and when query is finished it pretends
that its own result table is the result table of original query. Message
table of original query needs to be copied to a new message table.
Presently result can be returned only once (proxy drops result table),
in the future we'll need better lifetime management for results.