### PR TITLE
Fix proxy blocking during query killing (DM-11655)

### DIFF
--- a/core/modules/ccontrol/UserQuerySelect.cc
+++ b/core/modules/ccontrol/UserQuerySelect.cc
@@ -169,7 +169,12 @@ void UserQuerySelect::kill() {
     if (!_killed) {
         _killed = true;
         try {
-            _executive->squash();
+            // make a copy of executive pointer to keep it alive and avoid race
+            // with pointer being reset in discard() method
+            std::shared_ptr<qdisp::Executive> exec = _executive;
+            if (exec != nullptr) {
+                exec->squash();
+            }
         } catch(UserQueryError const &e) {
             // Silence merger discarding errors, because this object is being
             // released. Client no longer cares about merger errors.

--- a/core/modules/czar/Czar.cc
+++ b/core/modules/czar/Czar.cc
@@ -219,7 +219,7 @@ Czar::submitQuery(std::string const& query,
     return result;
 }
 
-std::string
+void
 Czar::killQuery(std::string const& query, std::string const& clientId) {
 
     LOGS(_log, LOG_LVL_INFO, "KILL query: " << query << ", clientId: " << clientId);
@@ -233,7 +233,7 @@ Czar::killQuery(std::string const& query, std::string const& clientId) {
     int threadId = ::parseKillQuery(query);
     LOGS(_log, LOG_LVL_DEBUG, "thread ID: " << threadId);
     if (threadId < 0) {
-        return "Failed to parse query: " + query;
+        throw std::runtime_error("Failed to parse query: " + query);
     }
 
     ClientThreadId ctId(clientId, threadId);
@@ -245,7 +245,8 @@ Czar::killQuery(std::string const& query, std::string const& clientId) {
         // find it in the client map based in client/thread id
         auto iter = _clientToQuery.find(ctId);
         if (iter == _clientToQuery.end()) {
-            return "Unknown thread ID: " + query;
+            LOGS(_log, LOG_LVL_INFO, "Cannot find client thread id: " << threadId);
+            throw std::runtime_error("Unknown thread ID: " + query);
         }
         uq = iter->second.lock();
     }
@@ -255,8 +256,6 @@ Czar::killQuery(std::string const& query, std::string const& clientId) {
     if (uq) {
         uq->kill();
     }
-
-    return std::string();
 }
 
 void

--- a/core/modules/czar/Czar.h
+++ b/core/modules/czar/Czar.h
@@ -79,8 +79,9 @@ public:
      *
      * @param query: (client)proxy-provided "KILL QUERY ..." string
      * @param clientId : client name from proxy
+     * @throws Exception is thrown if query Id is not known
      */
-    std::string killQuery(std::string const& query, std::string const& clientId);
+    void killQuery(std::string const& query, std::string const& clientId);
 
     /**
      * Make new instance.

--- a/core/modules/proxy/czarProxy.cc
+++ b/core/modules/proxy/czarProxy.cc
@@ -102,12 +102,12 @@ submitQuery(std::string const& query, std::map<std::string, std::string> const& 
     return ::_czar->submitQuery(query, hints);
 }
 
-std::string
+void
 killQuery(std::string const& query, std::string const& clientId) {
     if (not ::_czar) {
         throw std::runtime_error("czarProxy/killQuery(): czar instance not initialized");
     }
-    return ::_czar->killQuery(query, clientId);
+    ::_czar->killQuery(query, clientId);
 }
 
 void log(std::string const& loggername, std::string const& level,

--- a/core/modules/proxy/czarProxy.h
+++ b/core/modules/proxy/czarProxy.h
@@ -75,9 +75,8 @@ czar::SubmitResult submitQuery(std::string const& query,
  *
  * @param query: (client)proxy-provided "KILL QUERY NNN" or "KILL NNN" string
  * @param clientId: client_dst_name from proxy
- * @return: Error message, empty on success
  */
-std::string killQuery(std::string const& query, std::string const& clientId);
+void killQuery(std::string const& query, std::string const& clientId);
 
 /**
  *  Send message to logging system. level is a string like "DEBUG".

--- a/core/modules/proxy/czarProxyLuaWrapper.cc
+++ b/core/modules/proxy/czarProxyLuaWrapper.cc
@@ -138,11 +138,10 @@ int luaKillQuery(lua_State *L) {
         const char* query = lua_tolstring(L, -2, &lenQuery);
         const char* clientId = lua_tolstring(L, -1, &lenClientId);
 
-        auto msg = lsst::qserv::proxy::killQuery(std::string(query, lenQuery),
+        lsst::qserv::proxy::killQuery(std::string(query, lenQuery),
                 std::string(clientId, lenClientId));
 
-        lua_pushlstring(L, msg.data(), msg.size());
-        return 1;
+        return 0;
 
     } catch (std::exception const& exc) {
         lua_pushstring(L, exc.what());

--- a/core/modules/proxy/mysqlProxy.lua
+++ b/core/modules/proxy/mysqlProxy.lua
@@ -380,7 +380,7 @@ function queryProcessing()
         czarProxy.log("mysql-proxy", "INFO", "Killing query/connection: " .. q)
         local ok, msg = pcall(czarProxy.killQuery, qU, proxy.connection.client.dst.name)
         if (not ok) then
-            return err.set(ERR_CZAR_EXCEPTION, "Exception in call to czar method: " .. msg)
+            return err.setAndSend(ERR_CZAR_EXCEPTION, "KILL failed: " .. msg)
         end
 
         -- Assemble result


### PR DESCRIPTION
Run query killing method in a separate detached thread and return control
to proxy immediately to avoid proxy blocking in single-threaded LUA
code.
    
Additionally fixed race condition between query killing and normal query
completion which accessed shared data without synchronization.
