### PR TITLE
Add support for query killing by query ID (DM-11729)

### DIFF
--- a/core/modules/ccontrol/UserQuerySelect.cc
+++ b/core/modules/ccontrol/UserQuerySelect.cc
@@ -291,6 +291,10 @@ QueryState UserQuerySelect::join() {
         _qMetaUpdateStatus(qmeta::QInfo::COMPLETED);
         LOGS(_log, LOG_LVL_DEBUG, getQueryIdString() << " Joined everything (success)");
         return SUCCESS;
+    } else if (_killed) {
+        // status is already set to ABORTED
+        LOGS(_log, LOG_LVL_ERROR, getQueryIdString() << " Joined everything (killed)");
+        return ERROR;
     } else {
         _qMetaUpdateStatus(qmeta::QInfo::FAILED);
         LOGS(_log, LOG_LVL_ERROR, getQueryIdString() << " Joined everything (failure!)");

--- a/core/modules/ccontrol/UserQueryType.h
+++ b/core/modules/ccontrol/UserQueryType.h
@@ -85,6 +85,18 @@ public:
      */
     static bool isSelectResult(std::string const& query, QueryId& queryId);
 
+    /**
+     *  Returns true if query is KILL [QUERY|CONNECTION] NNN, returns
+     *  thread ID in `threadId` argument.
+     */
+    static bool isKill(std::string const& query, int& threadId);
+
+    /**
+     *  Returns true if query is CANCEL NNN, returns
+     *  query ID in `queryId` argument.
+     */
+    static bool isCancel(std::string const& query, QueryId& queryId);
+
 };
 
 }}} // namespace lsst::qserv::ccontrol

--- a/core/modules/czar/Czar.cc
+++ b/core/modules/czar/Czar.cc
@@ -58,8 +58,10 @@ std::string const createAsyncResultTmpl("CREATE TABLE IF NOT EXISTS %1% "
 
 LOG_LOGGER _log = LOG_GET("lsst.qserv.czar.Czar");
 
-// parse KILL query, return thread ID or -1
-int parseKillQuery(std::string const& query);
+// Parse KILL/CANCEL query.
+// Returns false on parsing failure. On success for KILL queries threadId will
+// be non-zero, for CANCEL query queryId will be non-zero.
+bool parseKillQuery(std::string const& aQuery, int& threadId, lsst::qserv::QueryId& queryId);
 
 } // anonymous namespace
 
@@ -229,39 +231,86 @@ Czar::killQuery(std::string const& query, std::string const& clientId) {
     //   "KILL CONNECTION NNN" - kills connection associated with thread NNN
     //                           and all queries in that connection
     //   "KILL NNN" - same as "KILL CONNECTION NNN"
+    //   "CANCEL NNN" - kill query with ID=NNN
 
-    int threadId = ::parseKillQuery(query);
-    LOGS(_log, LOG_LVL_DEBUG, "thread ID: " << threadId);
-    if (threadId < 0) {
+    int threadId;
+    QueryId queryId;
+    if (! parseKillQuery(query, threadId, queryId)) {
         throw std::runtime_error("Failed to parse query: " + query);
     }
 
-    ClientThreadId ctId(clientId, threadId);
-    ccontrol::UserQuery::Ptr uq;
+    // Clean query maps from expired entries
+    _cleanupQueryHistory();
 
-    {
+    ccontrol::UserQuery::Ptr uq;
+    if (threadId != 0) {
+        LOGS(_log, LOG_LVL_DEBUG, "thread ID: " << threadId);
         std::lock_guard<std::mutex> lock(_mutex);
 
         // find it in the client map based in client/thread id
+        ClientThreadId ctId(clientId, threadId);
         auto iter = _clientToQuery.find(ctId);
         if (iter == _clientToQuery.end()) {
             LOGS(_log, LOG_LVL_INFO, "Cannot find client thread id: " << threadId);
             throw std::runtime_error("Unknown thread ID: " + query);
         }
         uq = iter->second.lock();
+    } else if (queryId != QueryId(0)) {
+        LOGS(_log, LOG_LVL_DEBUG, "query ID: " << queryId);
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        // find it in the client map based in client/thread id
+        auto iter = _idToQuery.find(queryId);
+        if (iter == _idToQuery.end()) {
+            LOGS(_log, LOG_LVL_INFO, "Cannot find query id: " << queryId);
+            throw std::runtime_error("Unknown or finished query ID: " + query);
+        }
+        uq = iter->second.lock();
+    } else {
+        throw std::runtime_error("Failed to parse query: " + query);
     }
 
     // assume this cannot fail or throw
-    LOGS(_log, LOG_LVL_DEBUG, "Killing query for thread: " << threadId);
     if (uq) {
+        LOGS(_log, LOG_LVL_DEBUG, "Killing query: " << uq->getQueryId());
         // query killing can potentially take very long and we do now want to block
         // proxy from serving other requests so run it in a detached thread
         std::thread killThread([uq, threadId]() {
             uq->kill();
-            LOGS(_log, LOG_LVL_DEBUG, "Finished killing query for thread: " << threadId);
+            LOGS(_log, LOG_LVL_DEBUG, "Finished killing query: " << uq->getQueryId());
         });
         killThread.detach();
+    } else {
+        LOGS(_log, LOG_LVL_DEBUG, "Query has expired/finished: " << query);
+        throw std::runtime_error("Query has already finished: " + query);
     }
+}
+
+void
+Czar::_cleanupQueryHistoryLocked() {
+    // _mutex must be locked
+
+    // first cleanup client query maps from completed queries
+    for (auto iter = _clientToQuery.begin(); iter != _clientToQuery.end(); ) {
+        if (iter->second.expired()) {
+            iter = _clientToQuery.erase(iter);
+        } else {
+            ++ iter;
+        }
+    }
+    for (auto iter = _idToQuery.begin(); iter != _idToQuery.end(); ) {
+        if (iter->second.expired()) {
+            iter = _idToQuery.erase(iter);
+        } else {
+            ++ iter;
+        }
+    }
+}
+
+void
+Czar::_cleanupQueryHistory() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _cleanupQueryHistoryLocked();
 }
 
 void
@@ -271,16 +320,16 @@ Czar::_updateQueryHistory(std::string const& clientId,
 
     std::lock_guard<std::mutex> lock(_mutex);
 
-    // first cleanup client query map from completed queries
-    for (auto iter = _clientToQuery.begin(); iter != _clientToQuery.end(); ) {
-        if (iter->second.expired()) {
-            iter = _clientToQuery.erase(iter);
-        } else {
-            ++ iter;
-        }
-    }
+    // first cleanup client query maps from completed queries
+    _cleanupQueryHistoryLocked();
 
     // remember query (weak pointer) in case we want to kill query
+    if (uq->getQueryId() != QueryId(0)) {
+        _idToQuery.insert(std::make_pair(uq->getQueryId(), uq));
+        LOGS(_log, LOG_LVL_DEBUG, uq->getQueryIdString() << " Remembering query ID: "
+             << uq->getQueryId() << " (new map size: "
+             << _idToQuery.size() << ")");
+    }
     if (not clientId.empty() and threadId >= 0) {
         ClientThreadId ctId(clientId, threadId);
         _clientToQuery.insert(std::make_pair(ctId, uq));
@@ -320,8 +369,8 @@ Czar::_makeAsyncResult(std::string const& asyncResultTable,
 
 namespace {
 
-int
-parseKillQuery(std::string const& aQuery) {
+bool
+parseKillQuery(std::string const& aQuery, int& threadId, lsst::qserv::QueryId& queryId) {
     // the query that proxy passes us is all uppercase and spaces compressed
     // but it may have trailing space which we strip first
     std::string query = aQuery;
@@ -329,22 +378,31 @@ parseKillQuery(std::string const& aQuery) {
     query.erase(pos+1);
 
     // try to match against one or another form of KILL
-    static const std::string prefixes[] = {"KILL QUERY ", "KILL CONNECTION ", "KILL "};
+    threadId = 0;
+    queryId = 0;
+    static const std::string prefixes[] = {"KILL QUERY ", "KILL CONNECTION ", "KILL ", "CANCEL "};
     for (auto& prefix: prefixes) {
         LOGS(_log, LOG_LVL_DEBUG, "checking prefix: '" << prefix << "'");
         if (query.compare(0, prefix.size(), prefix) == 0) {
             LOGS(_log, LOG_LVL_DEBUG, "match found");
             try {
-                LOGS(_log, LOG_LVL_DEBUG, "thread id: '" << query.substr(prefix.size()) << "'");
-                return boost::lexical_cast<int>(query.substr(prefix.size()));
+                std::string const idStr(query, prefix.size());
+                if (prefix == "CANCEL ") {
+                    LOGS(_log, LOG_LVL_DEBUG, "query id: '" << idStr << "'");
+                    queryId = boost::lexical_cast<uint64_t>(idStr);
+                } else {
+                    LOGS(_log, LOG_LVL_DEBUG, "thread id: '" << idStr << "'");
+                    threadId = boost::lexical_cast<int>(idStr);
+                }
+                return true;
             } catch (boost::bad_lexical_cast const& exc) {
                 // error in query syntax
-                return -1;
+                return false;
             }
         }
     }
 
-    return -1;
+    return false;
 }
 
 } // namespace

--- a/core/modules/proxy/mysqlProxy.lua
+++ b/core/modules/proxy/mysqlProxy.lua
@@ -232,7 +232,8 @@ function queryType()
     ---------------------------------------------------------------------------
 
     local isKill = function(qU)
-        if string.find(qU, "^KILL ") then
+        if string.find(qU, "^KILL ") or
+           string.find(qU, "^CANCEL ") then
             return true
         end
         return false
@@ -380,7 +381,7 @@ function queryProcessing()
         czarProxy.log("mysql-proxy", "INFO", "Killing query/connection: " .. q)
         local ok, msg = pcall(czarProxy.killQuery, qU, proxy.connection.client.dst.name)
         if (not ok) then
-            return err.setAndSend(ERR_CZAR_EXCEPTION, "KILL failed: " .. msg)
+            return err.setAndSend(ERR_CZAR_EXCEPTION, "KILL/CANCEL failed: " .. msg)
         end
 
         -- Assemble result


### PR DESCRIPTION
Implemented new SQL command "CANCEL NNN" which takes query Id and tries to kill running query with given ID.
