### PR TITLE
Cleanup QMeta state after czar restart (DM-12204)

### DIFF
--- a/core/modules/ccontrol/UserQueryFactory.cc
+++ b/core/modules/ccontrol/UserQueryFactory.cc
@@ -97,6 +97,12 @@ UserQueryFactory::UserQueryFactory(czar::CzarConfig const& czarConfig,
     // register czar in QMeta
     // TODO: check that czar with the same name is not active already?
     _impl->qMetaCzarId = _impl->queryMetadata->registerCzar(czarName);
+
+    // When czar crashes/exits while some queries are still in flight they
+    // are left in EXECUTING state in QMeta. We want to cleanup that state
+    // to avoid confusion. Note that when/if clean czar restart is implemented
+    // we'll need a new logic to restart query processing.
+    _impl->queryMetadata->cleanup(_impl->qMetaCzarId);
 }
 
 UserQuery::Ptr

--- a/core/modules/qmeta/QMeta.h
+++ b/core/modules/qmeta/QMeta.h
@@ -116,6 +116,15 @@ public:
     virtual void setCzarActive(CzarId czarId, bool active) = 0;
 
     /**
+     *  @brief Cleanup of query status.
+     *
+     *  Usually called when czar starts to do post-crash cleanup.
+     *
+     *  @param name:  Czar ID, non-negative number.
+     */
+    virtual void cleanup(CzarId czarId) = 0;
+
+    /**
      *  @brief Register new query.
      *
      *  This method will throw if czar ID is not known.

--- a/core/modules/qmeta/QMetaMysql.h
+++ b/core/modules/qmeta/QMetaMysql.h
@@ -92,6 +92,15 @@ public:
     virtual void setCzarActive(CzarId czarId, bool active) override;
 
     /**
+     *  @brief Cleanup of query status.
+     *
+     *  Usually called when czar starts to do post-crash cleanup.
+     *
+     *  @param name:  Czar ID, non-negative number.
+     */
+    void cleanup(CzarId czarId) override;
+
+    /**
      *  @brief Register new query.
      *
      *  This method will throw if czar ID is not known.


### PR DESCRIPTION
This should take care of the stale "EXECUTING" queries appearing in
SHOW PROCESSLIST output when czar crashes or is killed.