### PR TITLE
Use per-table ovelaps in RelationGraph (DM-1693)

### DIFF
--- a/core/modules/qana/RelationGraph.cc
+++ b/core/modules/qana/RelationGraph.cc
@@ -732,7 +732,7 @@ RelationGraph::RelationGraph(QueryContext const& ctx,
             "passed to RelationGraph constructor.");
     }
     // Create a graph for the left-most table in a join sequence.
-    RelationGraph g(*tr, pool.get(ctx, tr->getDb(), tr->getTable()), overlap);
+    RelationGraph g(*tr, pool.get(tr->getDb(), tr->getTable()), overlap);
     // Process remaining tables in the JOIN sequence. Note that joins are
     // left-associative in the absence of parentheses, i.e. "A JOIN B JOIN C"
     // is equivalent to "(A JOIN B) JOIN C", and that relation graphs are

--- a/core/modules/qana/RelationGraph.cc
+++ b/core/modules/qana/RelationGraph.cc
@@ -245,7 +245,7 @@ size_t addEqEdge(std::string const& ca,
     }
     TableInfo const& ta = *(a->info);
     TableInfo const& tb = *(b->info);
-    LOGS(_log, LOG_LVL_DEBUG, "addEqEdge a=" << a->info->dump() << " b=" << b->info->dump());
+    LOGS(_log, LOG_LVL_DEBUG, "addEqEdge a=" << *a->info << " b=" << *b->info);
     if (ta.isEqPredAdmissible(tb, ca, cb, outer)) {
         // Add a pair of Edge objects, a → b and b → a.
         LOGS(_log, LOG_LVL_DEBUG, "addEqEdge true for (" << ca << "," << cb << ")");
@@ -498,7 +498,7 @@ size_t RelationGraph::_addWhereEqEdges(BoolTerm::Ptr where)
 /// `_addSpEdges` creates a graph edge for each admissible top-level spatial
 /// predicate extracted from the given boolean term. The number of admissible
 /// predicates is returned.
-size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt, double overlap)
+size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt)
 {
     size_t numEdges = 0;
     bt = findFirstNonTrivialChild(bt);
@@ -507,7 +507,7 @@ size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt, double overlap)
         // Recurse to the children.
         typedef BoolTerm::PtrVector::const_iterator BtIter;
         for (BtIter i = at->_terms.begin(), e = at->_terms.end(); i != e; ++i) {
-            numEdges += _addSpEdges(*i, overlap);
+            numEdges += _addSpEdges(*i);
         }
         return numEdges;
     }
@@ -524,16 +524,16 @@ size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt, double overlap)
     // Try to extract a scisql_angSep() call and a numeric constant
     // from the comparison predicate.
     FuncExpr::Ptr fe;
-    double x = std::numeric_limits<double>::quiet_NaN();
+    double angSep = std::numeric_limits<double>::quiet_NaN();
     switch (cp->op) {
         case SqlSQL2TokenTypes::LESS_THAN_OP: // fallthrough
         case SqlSQL2TokenTypes::LESS_THAN_OR_EQUALS_OP:
             fe = getAngSepFunc(cp->left);
-            x = getNumericConst(cp->right);
+            angSep = getNumericConst(cp->right);
             break;
         case SqlSQL2TokenTypes::GREATER_THAN_OP: // fallthrough
         case SqlSQL2TokenTypes::GREATER_THAN_OR_EQUALS_OP:
-            x = getNumericConst(cp->left);
+            angSep = getNumericConst(cp->left);
             fe = getAngSepFunc(cp->right);
             break;
         case SqlSQL2TokenTypes::EQUALS_OP:
@@ -542,17 +542,17 @@ size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt, double overlap)
             // technically evaluable.
             fe = getAngSepFunc(cp->left);
             if (!fe) {
-                x = getNumericConst(cp->left);
+                angSep = getNumericConst(cp->left);
                 fe = getAngSepFunc(cp->right);
             } else {
-                x = getNumericConst(cp->right);
+                angSep = getNumericConst(cp->right);
             }
             break;
     }
-    if (!fe || (boost::math::isnan)(x) || x > overlap) {
+    if (!fe || boost::math::isnan(angSep)) {
         // The scisql_angSep() call and/or numeric constant is missing,
-        // the constant exceeds the partition overlap or the comparison
-        // operator is invalid (e.g. "x < scisql_angSep(...)")
+        // or the comparison operator is invalid (e.g.
+        // "angSep < scisql_angSep(...)")
         return 0;
     }
     // Extract column references from fe
@@ -594,8 +594,8 @@ size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt, double overlap)
         return 0;
     }
     // Finally, add an edge between v[0] and v[2].
-    v[0]->insert(Edge(v[2], x));
-    v[2]->insert(Edge(v[0], x));
+    v[0]->insert(Edge(v[2], angSep));
+    v[2]->insert(Edge(v[0], angSep));
     return 1;
 }
 
@@ -605,7 +605,6 @@ size_t RelationGraph::_addSpEdges(BoolTerm::Ptr bt, double overlap)
 void RelationGraph::_fuse(JoinRef::Type joinType,
                           bool natural,
                           JoinSpec::Ptr const& joinSpec,
-                          double overlap,
                           RelationGraph& g)
 {
     if (this == &g) {
@@ -668,15 +667,14 @@ void RelationGraph::_fuse(JoinRef::Type joinType,
     _map.fuse(g._map, natural, usingCols);
     // Add spatial edges
     if (!outer && joinSpec && joinSpec->getOn()) {
-        _addSpEdges(joinSpec->getOn(), overlap);
+        _addSpEdges(joinSpec->getOn());
     }
 }
 
 /// This constructor creates a relation graph for a single partitioned
 /// table reference.
-RelationGraph::RelationGraph(TableRef& tr,
-                             TableInfo const* info,
-                             double overlap) :
+/// `matchAngSep` - assumed angular separation for match tables
+RelationGraph::RelationGraph(TableRef& tr, TableInfo const* info) :
     _query(0)
 {
     typedef std::vector<ColumnRefConstPtr>::const_iterator Iter;
@@ -684,10 +682,14 @@ RelationGraph::RelationGraph(TableRef& tr,
     if (!info) {
         return;
     } else if (info->kind != TableInfo::MATCH) {
+        LOGS(_log, LOG_LVL_DEBUG, "RG: non-match table tr=\"" << tr << "\" info=" << *info);
         _vertices.push_back(Vertex(tr, info));
         ColumnVertexMap m(_vertices.front());
         _map.swap(m);
     } else {
+        double matchAngSep = static_cast<MatchTableInfo const&>(*info).angSep;
+        LOGS(_log, LOG_LVL_DEBUG, "RG: match table tr=\"" << tr << "\" info=" << *info
+                << " matchAngSep=" << matchAngSep);
         // Decompose match table references into a pair of vertices - one for
         // each foreign key in the match table.
         _vertices.push_back(Vertex(tr, info));
@@ -696,8 +698,8 @@ RelationGraph::RelationGraph(TableRef& tr,
         // match table metadata included the maximum angular separation between
         // matched entities, it could be used instead of the partition overlap
         // below (the latter is an upper bound on the former).
-        _vertices.front().insert(Edge(&_vertices.back(), overlap));
-        _vertices.back().insert(Edge(&_vertices.front(), overlap));
+        _vertices.front().insert(Edge(&_vertices.back(), matchAngSep));
+        _vertices.back().insert(Edge(&_vertices.front(), matchAngSep));
         // Split column references for the match table reference across vertices.
         std::vector<ColumnRefConstPtr> refs =
             info->makeColumnRefs(tr.getAlias());
@@ -720,10 +722,7 @@ RelationGraph::RelationGraph(TableRef& tr,
 
 /// This constructor creates a relation graph for a `TableRef`
 /// and its constituent joins.
-RelationGraph::RelationGraph(QueryContext const& ctx,
-                             TableRef::Ptr const& tr,
-                             double overlap,
-                             TableInfoPool& pool) :
+RelationGraph::RelationGraph(TableRef::Ptr const& tr, TableInfoPool& pool) :
     _query(0)
 {
     if (!tr) {
@@ -731,8 +730,10 @@ RelationGraph::RelationGraph(QueryContext const& ctx,
             "Parser/query analysis bug: NULL TableRef pointer "
             "passed to RelationGraph constructor.");
     }
+    LOGS(_log, LOG_LVL_DEBUG, "RG: tr=" << *tr);
+
     // Create a graph for the left-most table in a join sequence.
-    RelationGraph g(*tr, pool.get(tr->getDb(), tr->getTable()), overlap);
+    RelationGraph g(*tr, pool.get(tr->getDb(), tr->getTable()));
     // Process remaining tables in the JOIN sequence. Note that joins are
     // left-associative in the absence of parentheses, i.e. "A JOIN B JOIN C"
     // is equivalent to "(A JOIN B) JOIN C", and that relation graphs are
@@ -744,8 +745,8 @@ RelationGraph::RelationGraph(QueryContext const& ctx,
     typedef JoinRefPtrVector::const_iterator Iter;
     for (Iter i = joins.begin(), e = joins.end(); i != e; ++i) {
         JoinRef& j = **i;
-        RelationGraph tmp(ctx, j.getRight(), overlap, pool);
-        g._fuse(j.getJoinType(), j.isNatural(), j.getSpec(), overlap, tmp);
+        RelationGraph tmp(j.getRight(), pool);
+        g._fuse(j.getJoinType(), j.isNatural(), j.getSpec(), tmp);
     }
     swap(g);
 }
@@ -794,18 +795,15 @@ struct VertexQueue {
 };
 
 /// `computeMinimumOverlap` visits every vertex linked to `v` via one or more
-/// paths and computes its minimum required overlap (if it is less than or
-/// equal to `partitionOverlap`).
-void computeMinimumOverlap(Vertex* v, double const partitionOverlap)
+/// paths and computes its minimum required overlap.
+void computeMinimumOverlap(Vertex& vtx)
 {
     typedef std::vector<Edge>::const_iterator Iter;
 
     VertexQueue q;
-    if (v) {
-        // The required overlap for the initial vertex is 0.
-        v->overlap = 0;
-    }
-    while (v) {
+    // The required overlap for the initial vertex is 0.
+    vtx.overlap = 0;
+    for (Vertex* v = &vtx; v != nullptr; v = q.dequeue()) {
         // Loop over edges incident to v.
         for (Iter e = v->edges.begin(), end = v->edges.end(); e != end; ++e) {
             Vertex* u = e->vertex;
@@ -820,10 +818,11 @@ void computeMinimumOverlap(Vertex* v, double const partitionOverlap)
             // between the pair of vertices created for a single match table
             // reference.
             double availableOverlap = 0.0;
-            if (u->info->kind == TableInfo::DIRECTOR ||
-                (u->info->kind == TableInfo::MATCH &&
-                 v->info->kind == TableInfo::MATCH)) {
-                availableOverlap = partitionOverlap;
+            if (u->info->kind == TableInfo::DIRECTOR) {
+                availableOverlap = static_cast<DirTableInfo const&>(*u->info).overlap;
+            } else if (u->info->kind == TableInfo::MATCH &&
+                 v->info->kind == TableInfo::MATCH) {
+                availableOverlap = static_cast<MatchTableInfo const&>(*u->info).angSep;
             }
             // The overlap required for u is the overlap required for v plus
             // the angular separation threshold of the edge between them.
@@ -853,9 +852,6 @@ void computeMinimumOverlap(Vertex* v, double const partitionOverlap)
                 q.enqueue(u);
             }
         }
-        // Remove a vertex from the visitation queue and repeat the process.
-        // When q is empty, v is null and the loop terminates.
-        v = q.dequeue();
     }
 }
 
@@ -885,15 +881,15 @@ void resetVertices(std::list<Vertex>& vertices)
 
 /// `_validate` searches for a graph traversal that proves the input query
 /// is evaluable.
-bool RelationGraph::_validate(double overlap)
+bool RelationGraph::_validate()
 {
     typedef std::list<Vertex>::iterator Iter;
     size_t numStarts = 0;
-    for (Iter i = _vertices.begin(), e = _vertices.end(); i != e; ++i) {
-        if (i->info->kind != TableInfo::MATCH) {
+    for (Vertex& vtx: _vertices) {
+        if (vtx.info->kind != TableInfo::MATCH) {
             ++numStarts;
             resetVertices(_vertices);
-            computeMinimumOverlap(&(*i), overlap);
+            computeMinimumOverlap(vtx);
             if (isEvaluable(_vertices)) {
                 return true;
             }
@@ -911,11 +907,11 @@ bool RelationGraph::_validate(double overlap)
     return false;
 }
 
-RelationGraph::RelationGraph(QueryContext const& ctx,
-                             SelectStmt& stmt,
-                             TableInfoPool& pool) :
+RelationGraph::RelationGraph(SelectStmt& stmt, TableInfoPool& pool) :
     _query(&stmt)
 {
+    LOGS(_log, LOG_LVL_DEBUG, "RG: stmt=" << stmt);
+
     // Check that at least one thing is being selected.
     if (!stmt.getSelectList().getValueExprList() ||
         stmt.getSelectList().getValueExprList()->empty()) {
@@ -927,29 +923,51 @@ RelationGraph::RelationGraph(QueryContext const& ctx,
         throw QueryNotEvaluableError(
             "Query must include at least one table reference");
     }
-    double overlap = ctx.css->getDbStriping(ctx.dominantDb).overlap;
     // Build a graph for the first entry in the from list
-    RelationGraph g(ctx, refs.front(), overlap, pool);
+    RelationGraph g(refs.front(), pool);
     // "SELECT ... FROM A, B, C, ..." is equivalent to
     // "SELECT ... FROM ((A CROSS JOIN B) CROSS JOIN C) ..."
     typedef TableRefList::const_iterator Iter;
     for (Iter i = ++refs.begin(), e = refs.end(); i != e; ++i) {
-        RelationGraph tmp(ctx, *i, overlap, pool);
-        g._fuse(JoinRef::CROSS, false, JoinSpec::Ptr(), overlap, tmp);
+        RelationGraph tmp(*i, pool);
+        g._fuse(JoinRef::CROSS, false, JoinSpec::Ptr(), tmp);
     }
     // Add edges for admissible join predicates extracted from the
     // WHERE clause
     if (stmt.hasWhereClause()) {
         BoolTerm::Ptr where = stmt.getWhereClause().getRootTerm();
         g._addWhereEqEdges(where);
-        g._addSpEdges(where, overlap);
+        g._addSpEdges(where);
     }
-    if (!g._validate(overlap)) {
+
+    g._dumpGraph();
+
+    if (!g._validate()) {
         throw QueryNotEvaluableError(
             "Query involves partitioned table joins that Qserv does not "
             "know how to evaluate using only partition-local data");
     }
+
     swap(g);
+}
+
+void RelationGraph::_dumpGraph() const {
+    // dump graph
+    if (LOG_CHECK_LVL(_log, LOG_LVL_DEBUG)) {
+        LOGS(_log, LOG_LVL_DEBUG, "RelationGraph:");
+        std::map<Vertex const*, int> vtxId;
+        for (auto&& vtx: _vertices) {
+            int id = vtxId.size();
+            vtxId[&vtx] = id;
+            LOGS(_log, LOG_LVL_DEBUG, "   vertex " << id << " info=" << *vtx.info);
+        }
+        for (auto&& vtx: _vertices) {
+            for (auto&& edge: vtx.edges) {
+                LOGS(_log, LOG_LVL_DEBUG, "   edge " << vtxId[&vtx] << " <-> "
+                        << vtxId[edge.vertex] << " angSep=" << edge.angSep);
+            }
+        }
+    }
 }
 
 void RelationGraph::rewrite(SelectStmtPtrVector& outputs,

--- a/core/modules/qana/RelationGraph.h
+++ b/core/modules/qana/RelationGraph.h
@@ -618,8 +618,7 @@ public:
 
     /// This constructor creates a relation graph from a query.
     /// If the query is not evaluable, an exception is thrown.
-    RelationGraph(query::QueryContext const& ctx,
-                  query::SelectStmt& stmt,
+    RelationGraph(query::SelectStmt& stmt,
                   TableInfoPool& pool);
 
     /// `empty` returns `true` if this graph has no vertices.
@@ -645,13 +644,8 @@ private:
 
     // Constructors and related helpers
     RelationGraph() : _query(0) {}
-    RelationGraph(query::TableRef& tr,
-                  TableInfo const* info,
-                  double overlap);
-    RelationGraph(query::QueryContext const& ctx,
-                  query::TableRef::Ptr const& tr,
-                  double overlap,
-                  TableInfoPool& pool);
+    RelationGraph(query::TableRef& tr, TableInfo const* info);
+    RelationGraph(query::TableRef::Ptr const& tr, TableInfoPool& pool);
 
     size_t _addOnEqEdges(query::BoolTerm::Ptr on,
                          bool outer,
@@ -661,15 +655,15 @@ private:
                             bool outer,
                             RelationGraph& g);
     size_t _addWhereEqEdges(query::BoolTerm::Ptr where);
-    size_t _addSpEdges(query::BoolTerm::Ptr bt, double overlap);
+    size_t _addSpEdges(query::BoolTerm::Ptr bt);
     void _fuse(query::JoinRef::Type joinType,
                bool natural,
                query::JoinSpec::Ptr const& joinSpec,
-               double overlap,
                RelationGraph& g);
+    void _dumpGraph() const;
 
     // Graph validation
-    bool _validate(double overlap);
+    bool _validate();
 };
 
 }}} // namespace lsst::qserv::qana

--- a/core/modules/qana/TableInfo.cc
+++ b/core/modules/qana/TableInfo.cc
@@ -78,69 +78,34 @@ std::string const TableInfo::CHUNK_TAG("%CC%");
 std::string const TableInfo::SUBCHUNK_TAG("%SS%");
 
 
-std::ostream& operator<<(std::ostream& os, TableInfo const& ti) {
-    return os << "TI(" << ti.database << "." << ti.table << " kind=" << ti.kind << ")";
+void TableInfo::dump(std::ostream& os) const {
+    os << "TI(" << database << "." << table << " kind=" << kind << ")";
 }
 
+void DirTableInfo::dump(std::ostream& os) const {
+    os << "DTI(" << database << "." << table << " kind=" << kind
+       << " pk=" << pk
+       << " lon=" << lon
+       << " lat=" << lat
+       << " partId=" << partitioningId
+       << ")";
+}
 
-std::ostream& operator<<(std::ostream& os, ChildTableInfo const& cti) {
-    os << "CTI(" << static_cast<TableInfo const&>(cti)
-       << " fk=" << cti.fk
-       << " director=(" << *cti.director
+void ChildTableInfo::dump(std::ostream& os) const {
+    os << "CTI(" << database << "." << table << " kind=" << kind
+       << " fk=" << fk
+       << " director=(" << *director
        << "))";
-    return os;
 }
 
-
-std::ostream& operator<<(std::ostream& os, DirTableInfo const& dti) {
-    os << "DTI(" << static_cast<TableInfo const&>(dti)
-       << " pk=" << dti.pk
-       << " lon=" << dti.lon
-       << " lat=" << dti.lat
-       << " partId=" << dti.partitioningId
+void MatchTableInfo::dump(std::ostream& os) const {
+    os << "MTI(" << database << "." << table << " kind=" << kind
+       << " director_1[" << *director.first << "]"
+       << " director_2[" << *director.second << "]"
+       << " fk_1=" << fk.first
+       << " fk_2=" << fk.second
        << ")";
-    return os;
 }
-
-
-std::ostream& operator<<(std::ostream& os, MatchTableInfo const& mti) {
-    os << "MTI(" << static_cast<TableInfo const&>( mti )
-       << " director_1[" << *mti.director.first << "]"
-       << " director_2[" << *mti.director.second << "]"
-       << " fk_1=" << mti.fk.first
-       << " fk_2=" << mti.fk.second
-       << ")";
-    return os;
-}
-
-
-std::string TableInfo::dump() const {
-    std::ostringstream os;
-    os << *this;
-    return os.str();
-}
-
-
-std::string DirTableInfo::dump() const {
-    std::ostringstream os;
-    os << *this;
-    return os.str();
-}
-
-
-std::string ChildTableInfo::dump() const {
-    std::ostringstream os;
-    os << *this;
-    return os.str();
-}
-
-
-std::string MatchTableInfo::dump() const {
-    std::ostringstream os;
-    os << *this;
-    return os.str();
-}
-
 
 std::vector<ColumnRefConstPtr> const DirTableInfo::makeColumnRefs(
     std::string const& tableAlias) const

--- a/core/modules/qana/TableInfo.h
+++ b/core/modules/qana/TableInfo.h
@@ -184,9 +184,10 @@ struct DirTableInfo : TableInfo {
     std::string lon; ///< `lon` is the name of the director's longitude column.
     std::string lat; ///< `lat` is the name of the director's latitude column.
     int32_t partitioningId;
+    double overlap;  ///< overlap value for partitioning of this table
 
-    DirTableInfo(std::string const& db, std::string const& t) :
-        TableInfo(db, t, DIRECTOR), partitioningId(0) {}
+    DirTableInfo(std::string const& db, std::string const& t, double o) :
+        TableInfo(db, t, DIRECTOR), partitioningId(0), overlap(o) {}
 
     virtual std::vector<ColumnRefConstPtr> const makeColumnRefs(
         std::string const& tableAlias) const;
@@ -265,10 +266,10 @@ struct MatchTableInfo : TableInfo {
     /// `fk` is the pair of names for the foreign key columns referencing
     /// `director.first->pk` and `director.second->pk`.
     std::pair<std::string, std::string> fk;
+    double angSep; ///< allowed angular separation between objects in director tables
 
-    MatchTableInfo(std::string const& db, std::string const& t) :
-        TableInfo(db, t, MATCH),
-        director(static_cast<DirTableInfo*>(nullptr), static_cast<DirTableInfo*>(nullptr)) {}
+    MatchTableInfo(std::string const& db, std::string const& t, double sep) :
+        TableInfo(db, t, MATCH), director(), angSep(sep) {}
 
     virtual std::vector<ColumnRefConstPtr> const makeColumnRefs(
         std::string const& tableAlias) const;

--- a/core/modules/qana/TableInfo.h
+++ b/core/modules/qana/TableInfo.h
@@ -63,6 +63,7 @@
 // System headers
 #include <cstddef>
 #include <memory>
+#include <iostream>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -172,11 +173,15 @@ struct TableInfo {
         return table + "FullOverlap_" + CHUNK_TAG + "_" + SUBCHUNK_TAG;
     }
 
-    /// C++ isn't doing the redirection on  os << *(a->info); to use the child classes' operator<< functions.
-    /// Overloading the pointer could work, but then it is more difficult to print the raw pointer. Meh.
-    virtual std::string dump() const;
-    friend std::ostream& operator<<(std::ostream& os, TableInfo const& ti);
+    virtual void dump(std::ostream& os) const;
 };
+
+inline
+std::ostream&
+operator<<(std::ostream& os, TableInfo const& ti) {
+    ti.dump(os);
+    return os;
+}
 
 /// `DirTableInfo` contains metadata for director tables.
 struct DirTableInfo : TableInfo {
@@ -211,8 +216,7 @@ struct DirTableInfo : TableInfo {
                                     std::string const& a,
                                     std::string const& b,
                                     bool outer) const;
-    std::string dump() const override;
-    friend std::ostream& operator<<(std::ostream& os, DirTableInfo const& dti);
+    void dump(std::ostream& os) const override;
 };
 
 
@@ -253,8 +257,7 @@ struct ChildTableInfo : TableInfo {
                                     std::string const& b,
                                     bool outer) const;
 
-    std::string dump() const override;
-    friend std::ostream& operator<<(std::ostream& os, ChildTableInfo const& cti);
+    void dump(std::ostream& os) const override;
 };
 
 
@@ -296,8 +299,7 @@ struct MatchTableInfo : TableInfo {
         return t.isEqPredAdmissible(*this, b, a, outer);
     }
 
-    std::string dump() const override;
-    friend std::ostream& operator<<(std::ostream& os, MatchTableInfo const& mti);
+    void dump(std::ostream& os) const override;
 };
 
 }}} // namespace lsst::qserv::qana

--- a/core/modules/qana/TableInfo.h
+++ b/core/modules/qana/TableInfo.h
@@ -178,16 +178,6 @@ struct TableInfo {
     friend std::ostream& operator<<(std::ostream& os, TableInfo const& ti);
 };
 
-/// `TableInfoLt` is a less-than comparison functor for non-null `TableInfo`
-/// pointers.
-struct TableInfoLt {
-    bool operator()(TableInfo const* t1, TableInfo const* t2) const {
-        int c = t1->table.compare(t2->table);
-        return c < 0 || (c == 0 && t1->database < t2->database);
-    }
-};
-
-
 /// `DirTableInfo` contains metadata for director tables.
 struct DirTableInfo : TableInfo {
     std::string pk;  ///< `pk` is the name of the director's primary key column.

--- a/core/modules/qana/TableInfoPool.cc
+++ b/core/modules/qana/TableInfoPool.cc
@@ -40,54 +40,50 @@
 #include "qana/TableInfo.h"
 #include "query/QueryContext.h"
 
+namespace {
+/// `TableInfoLt` is a less-than comparison functor for non-null `TableInfo`
+/// pointers.
+struct TableInfoLt {
+    bool operator()(std::unique_ptr<lsst::qserv::qana::TableInfo const> const& t1,
+            std::unique_ptr<lsst::qserv::qana::TableInfo const> const& t2) const {
+        return *t1 < *t2;
+    }
+};
+}
+
 
 namespace lsst {
 namespace qserv {
 namespace qana {
 
-TableInfoPool::~TableInfoPool() {
-    // Delete all table metadata objects in the pool
-    for (Pool::iterator i = _pool.begin(), e = _pool.end(); i != e; ++i) {
-        delete *i;
-    }
-}
+TableInfo const*
+TableInfoPool::get(std::string const& db, std::string const& table) {
 
-TableInfo const* TableInfoPool::get(std::string const& db,
-                                    std::string const& table) const
-{
+    std::string const& db_ = db.empty() ? _defaultDb : db;
+
     // Note that t.kind is irrelevant to the search,
     // and is set to an arbitrary value.
-    TableInfo t(db, table, TableInfo::DIRECTOR);
-    std::pair<Pool::const_iterator, Pool::const_iterator> p =
-        std::equal_range(_pool.begin(), _pool.end(), &t, TableInfoLt());
-    return (p.first == p.second) ? 0 : *p.first;
-}
-
-TableInfo const* TableInfoPool::get(query::QueryContext const& ctx,
-                                    std::string const& db,
-                                    std::string const& table)
-{
-    std::string const& db_ = db.empty() ? ctx.defaultDb : db;
-    TableInfo const* t = get(db_, table);
-    if (t) {
-        return t;
+    std::unique_ptr<TableInfo const> t(new TableInfo(db, table, TableInfo::DIRECTOR));
+    auto range = std::equal_range(_pool.begin(), _pool.end(), t, TableInfoLt());
+    if (range.first != range.second) {
+        return range.first->get();
     }
-    css::CssAccess const& css = *ctx.css;
-    css::TableParams const tParam = css.getTableParams(db_, table);
+
+    css::TableParams const tParam = _css.getTableParams(db_, table);
     css::PartTableParams const& partParam = tParam.partitioning;
     int const chunkLevel = partParam.chunkLevel();
     // unpartitioned table
     if (chunkLevel == 0) {
-        return 0;
+        return nullptr;
     }
     // match table
     if (tParam.match.isMatchTable()) {
         css::MatchTableParams const& m = tParam.match;
         std::unique_ptr<MatchTableInfo> p(new MatchTableInfo(db_, table));
         p->director.first = dynamic_cast<DirTableInfo const*>(
-            get(ctx, db_, m.dirTable1));
+            get(db_, m.dirTable1));
         p->director.second = dynamic_cast<DirTableInfo const*>(
-            get(ctx, db_, m.dirTable2));
+            get(db_, m.dirTable2));
         if (!p->director.first || !p->director.second) {
             throw InvalidTableError(db_ + "." + table + " is a match table, but"
                                     " does not reference two director tables!");
@@ -106,8 +102,7 @@ TableInfo const* TableInfoPool::get(query::QueryContext const& ctx,
                                     " relates two director tables with"
                                     " different partitionings!");
         }
-        _insert(p.get());
-        return p.release();
+        return _insert(std::move(p));
     }
     std::string const& dirTable = partParam.dirTable;
     // director table
@@ -117,7 +112,7 @@ TableInfo const* TableInfoPool::get(query::QueryContext const& ctx,
                                     "table, but cannot be sub-chunked!");
         }
         std::unique_ptr<DirTableInfo> p(new DirTableInfo(db_, table));
-        std::vector<std::string> v = css.getPartTableParams(db, table).partitionCols();
+        std::vector<std::string> v = _css.getPartTableParams(db, table).partitionCols();
         if (v.size() != 3 ||
             v[0].empty() || v[1].empty() || v[2].empty() ||
             v[0] == v[1] || v[1] == v[2] || v[0] == v[2]) {
@@ -129,9 +124,8 @@ TableInfo const* TableInfoPool::get(query::QueryContext const& ctx,
         p->pk = v[2];
         p->lon = v[0];
         p->lat = v[1];
-        p->partitioningId = css.getDbStriping(db_).partitioningId;
-        _insert(p.get());
-        return p.release();
+        p->partitioningId = _css.getDbStriping(db_).partitioningId;
+        return _insert(std::move(p));
     }
     // child table
     if (chunkLevel != 1) {
@@ -140,7 +134,7 @@ TableInfo const* TableInfoPool::get(query::QueryContext const& ctx,
     }
     std::unique_ptr<ChildTableInfo> p(new ChildTableInfo(db_, table));
     p->director = dynamic_cast<DirTableInfo const*>(
-        get(ctx, db_, partParam.dirTable));
+        get(db_, partParam.dirTable));
     if (!p->director) {
         throw InvalidTableError(db_ + "." + table + " is a child table, but"
                                 " does not reference a director table!");
@@ -150,16 +144,19 @@ TableInfo const* TableInfoPool::get(query::QueryContext const& ctx,
         throw InvalidTableError("Child table " + db_ + "." + table + " metadata"
                                 " does not contain a director column name!");
     }
-    _insert(p.get());
-    return p.release();
+
+    return _insert(std::move(p));
 }
 
-void TableInfoPool::_insert(TableInfo const* t) {
-    if (t) {
-        Pool::iterator i =
+TableInfo const*
+TableInfoPool::_insert(std::unique_ptr<TableInfo const> t) {
+    if (t != nullptr) {
+        Pool::iterator iter =
             std::upper_bound(_pool.begin(), _pool.end(), t, TableInfoLt());
-        _pool.insert(i, t);
+        iter = _pool.insert(iter, std::move(t));
+        return iter->get();
     }
+    return nullptr;
 }
 
 }}} // namespace lsst::qserv::qana

--- a/core/modules/qana/TablePlugin.cc
+++ b/core/modules/qana/TablePlugin.cc
@@ -325,7 +325,7 @@ void
 TablePlugin::applyPhysical(QueryPlugin::Plan& p,
                            query::QueryContext& context)
 {
-    TableInfoPool pool;
+    TableInfoPool pool(context.defaultDb, *context.css);
     if (!context.queryMapping) {
         context.queryMapping = std::make_shared<QueryMapping>();
     }

--- a/core/modules/qana/TablePlugin.cc
+++ b/core/modules/qana/TablePlugin.cc
@@ -333,7 +333,7 @@ TablePlugin::applyPhysical(QueryPlugin::Plan& p,
     typedef SelectStmtPtrVector::iterator Iter;
     SelectStmtPtrVector newList;
     for(Iter i=p.stmtParallel.begin(), e=p.stmtParallel.end(); i != e; ++i) {
-        RelationGraph g(context, **i, pool);
+        RelationGraph g(**i, pool);
         g.rewrite(newList, *context.queryMapping);
     }
     p.dominantDb = _dominantDb;


### PR DESCRIPTION
Updated RelationGraph code to use per-table overlap values from CSS.
Minor refactoring and simplification. There is still an issue with match
tables, angular separation for them comes from database-global overlap
parameter which is not right. Will work on that in next ticket.

Tested and works OK, integration test needed small fix in one query.