### PR TITLE
Fix Docker build issue with $QSERV_RUN_DIR

### DIFF
--- a/admin/tools/docker/dev/Dockerfile.tpl
+++ b/admin/tools/docker/dev/Dockerfile.tpl
@@ -8,6 +8,8 @@ USER qserv
 # see https://confluence.lsstcorp.org/display/DM/Qserv+Release+Procedure
 RUN bash -c ". /qserv/stack/loadLSST.bash && eups distrib install qserv_distrib -t qserv-dev -vvv"
 
+ENV QSERV_RUN_DIR /qserv/run
+
 # Generate /qserv/run/sysconfig/qserv and /qserv/run/etc/init.d/qserv-functions
 # required by k8s setup
 RUN bash -c ". /qserv/stack/loadLSST.bash && \

--- a/admin/tools/docker/git/Dockerfile.tpl
+++ b/admin/tools/docker/git/Dockerfile.tpl
@@ -29,6 +29,8 @@ RUN bash -c ". /qserv/stack/loadLSST.bash && \
 # Ease container management in k8s
 #
 
+ENV QSERV_RUN_DIR /qserv/run
+
 # Generate /qserv/run/sysconfig/qserv and /qserv/run/etc/init.d/qserv-functions
 # required by k8s setup
 RUN bash -c ". /qserv/stack/loadLSST.bash && \


### PR DESCRIPTION
An "ENV" directive providing a default for this variable seemed to
have been missed for a couple Dockerfiles in ticket DM-13095