### PR TITLE
Fix my.cnf for MariaDB 10.2

### DIFF
--- a/admin/templates/configuration/etc/my.cnf
+++ b/admin/templates/configuration/etc/my.cnf
@@ -11,9 +11,7 @@ symbolic-links=0
 tmp_table_size=4G
 max_heap_table_size=4G
 
-# enable InnoDB support via plugin
-ignore-builtin-innodb
-plugin-load=innodb=ha_innodb.so
+# Configure innodb (built in since MariaDB 12.2)
 innodb_file_per_table=1
 
 # Configure max number of connections


### PR DESCRIPTION
innodb is built in since MariaDB 10.2