### PR TITLE
Fix integration test worker crash for MariaDB 10.2

### DIFF
--- a/core/modules/ccontrol/UserQueryProcessList.cc
+++ b/core/modules/ccontrol/UserQueryProcessList.cc
@@ -171,7 +171,6 @@ void UserQueryProcessList::submit() {
         createTable += " ";
         createTable += col.colType.sqlType;
         if (col.colType.sqlType == "TIMESTAMP") createTable += " NULL";
-        if (col.hasDefault) createTable += " DEFAULT '" + col.defaultValue + "'";
     }
     createTable += ')';
     LOGS(_log, LOG_LVL_DEBUG, "creating result table: " << createTable);

--- a/core/modules/mysql/SchemaFactory.cc
+++ b/core/modules/mysql/SchemaFactory.cc
@@ -147,33 +147,6 @@ private:
 /// Set a ColSchema according to the contents of a MYSQL_FIELD
 void setColSchemaTo(sql::ColSchema& cs, MYSQL_FIELD const& f) {
     cs.name = f.name;
-    cs.hasDefault = false;
-    if (f.def_length) {
-        // If there is a default value stored, record it.
-        // There is probably a default value.
-        cs.defaultValue = std::string(f.def, f.def_length);
-        cs.hasDefault = true;
-        // (I hope I don't need to escape this string--if I do, then I
-        // need a MYSQL*, which is ridiculous, but
-        // mysql_real_escape_string needs one so it can peek inside
-        // for the charset, rather than allowing you to specify a
-        // charset externally. -danielw )
-    }
-    // ...but BLOBs can't have default values
-    switch(f.type) {
-    case MYSQL_TYPE_TINY_BLOB:
-    case MYSQL_TYPE_MEDIUM_BLOB:
-    case MYSQL_TYPE_LONG_BLOB:
-    case MYSQL_TYPE_BLOB:
-        cs.hasDefault = false;
-        break;
-    default:
-        break;
-    }
-    // ...and if the flag is set, then you really can't have a default value.
-    if (f.flags & NO_DEFAULT_VALUE_FLAG) {
-        cs.hasDefault = false;
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/core/modules/proto/worker.proto
+++ b/core/modules/proto/worker.proto
@@ -89,9 +89,8 @@ message ProtoHeader {
 
 message ColumnSchema {
     optional string name = 1; // Optional to allow type-only transmission
-    required bool hasdefault = 2; // unambiguous flag--
-    // has_defaultvalue() often tests true even after clear_defaultvalue()
-    optional bytes defaultvalue = 3;
+    required bool deprecated_hasdefault = 2; // DEPRECATED (but 'required', so will have to continue to be set)
+    optional bytes deprecated_defaultvalue = 3; // DEPRECATED
     required string sqltype = 4;
     optional int32 mysqltype = 5;
 }

--- a/core/modules/rproc/InfileMerger.cc
+++ b/core/modules/rproc/InfileMerger.cc
@@ -488,12 +488,6 @@ bool InfileMerger::_setupTable(proto::WorkerResponse const& response) {
             proto::ColumnSchema const& cs = rs.columnschema(i);
             sql::ColSchema scs;
             scs.name = cs.name();
-            if (cs.hasdefault()) {
-                scs.defaultValue = cs.defaultvalue();
-                scs.hasDefault = true;
-            } else {
-                scs.hasDefault = false;
-            }
             if (cs.has_mysqltype()) {
                 scs.colType.mysqlType = cs.mysqltype();
             }
@@ -515,7 +509,6 @@ bool InfileMerger::_setupTable(proto::WorkerResponse const& response) {
         {
             sql::ColSchema scs;
             scs.name              = _jobIdColName;
-            scs.hasDefault        = false;
             scs.colType.mysqlType = _jobIdMysqlType;
             scs.colType.sqlType   = _jobIdSqlType;
             schema.columns.push_back(scs);

--- a/core/modules/rproc/ProtoRowBuffer.cc
+++ b/core/modules/rproc/ProtoRowBuffer.cc
@@ -114,7 +114,6 @@ void ProtoRowBuffer::_initSchema() {
     // Set jobId and attemptCount
     sql::ColSchema jobIdCol;
     jobIdCol.name = _jobIdColName;
-    jobIdCol.hasDefault = false;
     jobIdCol.colType.sqlType = _jobIdSqlType;
     jobIdCol.colType.mysqlType = _jobIdMysqlType;
     _schema.columns.push_back(jobIdCol);
@@ -125,10 +124,6 @@ void ProtoRowBuffer::_initSchema() {
         sql::ColSchema cs;
         if (pcs.has_name()) {
             cs.name = pcs.name();
-        }
-        cs.hasDefault = pcs.has_defaultvalue();
-        if (cs.hasDefault) {
-            cs.defaultValue = pcs.defaultvalue();
         }
         cs.colType.sqlType = pcs.sqltype();
         if (pcs.has_mysqltype()) {
@@ -143,7 +138,6 @@ std::string ProtoRowBuffer::dump() const {
     std::string str("ProtoRowBuffer schema(");
     for (auto sCol : _schema.columns) {
         str += "(Name=" + sCol.name;
-        str += ",defaultValue=" + sCol.defaultValue;
         str += ",colType=" + sCol.colType.sqlType + ":" + std::to_string(sCol.colType.mysqlType) + ")";
     }
     str += ") ";

--- a/core/modules/sql/Schema.h
+++ b/core/modules/sql/Schema.h
@@ -51,8 +51,6 @@ inline std::ostream& operator<<(std::ostream& os, ColType const& ct) {
 /// Schema for a single column
 struct ColSchema {
     std::string name; ///< Column name
-    bool hasDefault; ///< true if column has a default
-    std::string defaultValue; // default value
     ColType colType; ///< Column type
 };
 
@@ -62,9 +60,6 @@ typedef ColSchemaVector::const_iterator ColumnsIter;
 
 inline std::ostream& operator<<(std::ostream& os, ColSchema const& cs) {
     os << "`" << cs.name << "` " << cs.colType;
-    if(cs.hasDefault) {
-        os << " DEFAULT '" << cs.defaultValue << "'";
-    }
     return os;
 }
 

--- a/core/modules/wdb/QueryRunner.cc
+++ b/core/modules/wdb/QueryRunner.cc
@@ -207,14 +207,7 @@ void QueryRunner::_fillSchema(MYSQL_RES* result) {
     for(auto i=s.columns.begin(), e=s.columns.end(); i != e; ++i) {
         proto::ColumnSchema* cs = _result->mutable_rowschema()->add_columnschema();
         cs->set_name(i->name);
-        if (i->hasDefault) {
-            cs->set_hasdefault(true);
-            cs->set_defaultvalue(i->defaultValue);
-            LOGS(_log, LOG_LVL_DEBUG, i->name << " has default.");
-        } else {
-            cs->set_hasdefault(false);
-            cs->clear_defaultvalue();
-        }
+        cs->set_deprecated_hasdefault(false); // still need to set deprecated but 'required' protobuf field
         cs->set_sqltype(i->colType.sqlType);
         cs->set_mysqltype(i->colType.mysqlType);
     }


### PR DESCRIPTION
Under MariaDB 10.2.14, the MYSQL_FIELD def_length field is sometimes coming back garbage (bignum), causing the std::string ctor below to blow up.

MySQL docs say this field and its partner are not set unless this MYSQL_FIELD comes back from a call to mysql_list_fields(), which is not the case in this call chain.  Perhaps this field happened to be init'd or harmless in previous versions of MariaDB, but is seems no more...

With the unsafe code simply ellided per below, the integration tests pass.  Do we need this code?  Was it ever doing anything correct/useful?