### PR TITLE
respect CXX when being built by eupspkg

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=bash
+
+build() {
+  scons -j"$NJOBS" prefix="$PREFIX" version="$VERSION" CXX="$CXX" \
+    --verbose
+}
+
+# scons rechecks the compiler even when installing...
+install() {
+  scons -j"$NJOBS" prefix="$PREFIX" version="$VERSION" CXX="$CXX" install \
+    --verbose
+
+  if [[ -d "ups" && ! -d "$PREFIX/ups" ]]; then
+    install_ups
+  fi
+}


### PR DESCRIPTION
This is needed in order to be able to use clang on el-7.