### PR TITLE
Migrate containers to Centos7 + Devtoolset6

### DIFF
--- a/admin/templates/configuration/etc/init.d/qserv-functions
+++ b/admin/templates/configuration/etc/init.d/qserv-functions
@@ -23,6 +23,13 @@ else
   }
 fi
 
+# If we don't have LSB init functions, check alternate location
+# (for getpidofproc)
+etc_functions="/etc/init.d/functions"
+if test ! -f $lsb_functions -a -f $etc_functions ; then
+  . $etc_functions
+fi
+
 # Check if any of $pid (could be plural) are running
 checkpid() {
     local i

--- a/admin/tools/docker/1_build-image.sh
+++ b/admin/tools/docker/1_build-image.sh
@@ -88,7 +88,7 @@ DEPS_DIR=$(echo "$DEPS_DIR" | sed 's%\(.*[^/]\)/*%\1%')
 # So, copy it from templates to SCRIPT_DIR directory
 SCRIPT_DIR="$DOCKERDIR/scripts"
 
-TPL_DEPS_SCRIPT="$DEPS_DIR/qserv-install-deps-debian8.sh"
+TPL_DEPS_SCRIPT="$DEPS_DIR/qserv-install-deps-rhel7.sh"
 
 printf "Add physical link to dependencies install script: %s\n" "$TPL_DEPS_SCRIPT"
 ln -f "$TPL_DEPS_SCRIPT" "$SCRIPT_DIR/install-deps.sh"

--- a/admin/tools/docker/configured/Dockerfile.tpl
+++ b/admin/tools/docker/configured/Dockerfile.tpl
@@ -1,12 +1,13 @@
 FROM <DOCKER_IMAGE>
-MAINTAINER Fabrice Jammes <fabrice.jammes@in2p3.fr>
+LABEL maintainer="Fabrice Jammes <fabrice.jammes@in2p3.fr>"
 
 # Allow the start.sh script to modify the local timezone settings
 # if requested.
 
 USER root
 
-RUN chown qserv:qserv /etc/localtime && chown qserv:qserv /etc/timezone
+RUN if [ -f /etc/localtime ]; then chown qserv:qserv /etc/localtime; fi && \
+    if [ -f /etc/timezone ]; then chown qserv:qserv /etc/timezone; fi
 
 WORKDIR /qserv
 
@@ -22,7 +23,7 @@ EXPOSE 1094 5012
 
 COPY scripts/*.sh scripts/
 
-RUN bash -c ". /qserv/stack/loadLSST.bash && setup qserv -t qserv-dev && /qserv/scripts/configure.sh <NODE_TYPE>"
+RUN bash -cl ". /qserv/stack/loadLSST.bash && setup qserv -t qserv-dev && /qserv/scripts/configure.sh <NODE_TYPE>"
 
 # WARNING: Unsafe because it is pushed in Docker Hub
 # TODO: use consul to manage secret

--- a/admin/tools/docker/deployment/localhost/run-multinode-tests.sh
+++ b/admin/tools/docker/deployment/localhost/run-multinode-tests.sh
@@ -47,8 +47,9 @@ do
     docker rm -f "$i" || echo "No existing container for $i"
     docker run --detach=true --add-host $MASTER:$MASTER_IP\
         -e "QSERV_MASTER=$MASTER" --name "$i" -h "${i}"  "$WORKER_IMAGE"
-	WORKER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $i)
-	HOSTFILE="${HOSTFILE}$WORKER_IP    $i\n"
+    WORKER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $i)
+    HOSTFILE="${HOSTFILE}$WORKER_IP    $i
+"
 done
 
 # Add worker entries to master hostfile, for data-loading

--- a/admin/tools/docker/dev/Dockerfile.tpl
+++ b/admin/tools/docker/dev/Dockerfile.tpl
@@ -1,12 +1,12 @@
 # dev and release are the same at release time
 FROM <DOCKER_REPO>:dev
-MAINTAINER Fabrice Jammes <fabrice.jammes@in2p3.fr>
+LABEL maintainer="Fabrice Jammes <fabrice.jammes@in2p3.fr>"
 
 USER qserv
 
 # Update to latest qserv dependencies, need to be publish on distribution server
 # see https://confluence.lsstcorp.org/display/DM/Qserv+Release+Procedure
-RUN bash -c ". /qserv/stack/loadLSST.bash && eups distrib install qserv_distrib -t qserv-dev -vvv"
+RUN bash -cl ". /qserv/stack/loadLSST.bash && eups distrib install qserv_distrib -t qserv-dev -vvv"
 
 ENV QSERV_RUN_DIR /qserv/run
 

--- a/admin/tools/docker/git/Dockerfile.tpl
+++ b/admin/tools/docker/git/Dockerfile.tpl
@@ -1,6 +1,6 @@
 # dev and release are the same at release time
 FROM <DOCKER_REPO>:dev
-MAINTAINER Fabrice Jammes <fabrice.jammes@in2p3.fr>
+LABEL maintainer="Fabrice Jammes <fabrice.jammes@in2p3.fr>"
 
 USER root
 
@@ -22,7 +22,7 @@ ENV QSERV_RUN_DIR /qserv/run
 #   - builds Qserv
 #   - installs Qserv inside LSST stack (i.e. /qserv/stack/Linux64/qserv/branch-version)
 #   - declares it using 'qserv-dev' tag
-RUN bash -c ". /qserv/stack/loadLSST.bash && \
+RUN bash -cl ". /qserv/stack/loadLSST.bash && \
     cp -r /home/qserv/src/qserv /tmp && \
     cd /tmp/qserv && \
     setup -r . -t qserv-dev && \
@@ -33,7 +33,7 @@ RUN bash -c ". /qserv/stack/loadLSST.bash && \
 # Generate /qserv/run/sysconfig/qserv and /qserv/run/etc/init.d/qserv-functions
 # required by k8s setup
 # TODO make it simpler
-RUN bash -c ". /qserv/stack/loadLSST.bash && \
+RUN bash -cl ". /qserv/stack/loadLSST.bash && \
              setup qserv -t qserv-dev && \
              cp \"\$SCISQL_DIR\"/lib/libscisql-scisql_?.?.so \"\$MARIADB_DIR\"/lib/plugin && \
              qserv-configure.py --init --force --qserv-run-dir \"$QSERV_RUN_DIR\" && \

--- a/admin/tools/docker/latest/Dockerfile
+++ b/admin/tools/docker/latest/Dockerfile
@@ -1,40 +1,19 @@
-FROM debian:jessie
-MAINTAINER Fabrice Jammes <fabrice.jammes@in2p3.fr>
+FROM lsstsqre/centos:7-stackbase-devtoolset-6
+LABEL maintainer="Fabrice Jammes <fabrice.jammes@in2p3.fr>"
 
 RUN sh -c "echo \"BUILD ID: $(date '+%Y%m%d_%H%M%S')\" > /BUILD_ID"
 
-# Start with this long step not to re-run it on
-# each Dockerfile update
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-RUN apt-get -y update && \
-    apt-get -y install apt-utils && \
-    apt-get -y upgrade && \
-    apt-get -y clean
-
-# Install LSST stack dependencies
+# Provide newer git for newinstall and eupspkg
 #
-RUN apt-get -y install bison \
-        bzip2 \
-        cmake \
-        curl \
-        flex \
-        g++ \
-        gettext \
-        git \
-        libbz2-dev \
-        libglib2.0-dev \
-        libpthread-workqueue-dev \
-        libreadline-dev \
-        libssl-dev \
-        make \
-        ncurses-dev \
-        openjdk-7-jre-headless \
-        openssl \
-        patch \
-        uuid-dev \
-        zlib1g-dev
+RUN yum install -y rh-git29 && \
+    yum clean all && \
+    echo ". /opt/rh/rh-git29/enable" > "/etc/profile.d/rh-git29.sh"
 
-RUN apt-get --yes -t jessie-backports install cmake
+# Install Qserv prerequisites
+#
+RUN yum install -y \
+        initscripts \
+    && yum clean all
 
 RUN groupadd qserv && \
     useradd -m -g qserv qserv && \
@@ -47,9 +26,13 @@ ARG EUPS_TAG
 # Install development and debugging tools
 #
 RUN if [ "$EUPS_TAG" = "qserv-dev" ] ; then \
-    apt-get -y install byobu dnsutils \
-        gdb graphviz lsof \
-        net-tools vim ; \
+        yum install -y \
+            byobu \
+            dnsutils \
+            gdb \
+            lsof \
+            net-tools \
+        && yum clean all; \
     fi
 
 USER qserv
@@ -57,12 +40,12 @@ USER qserv
 # Install LSST stack
 #
 ENV STACK_DIR /qserv/stack
-RUN mkdir $STACK_DIR && cd $STACK_DIR && \
-    curl -OL \
-    https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh && \
-    bash newinstall.sh -b
+RUN bash -lc "mkdir $STACK_DIR && cd $STACK_DIR && \
+              curl -OL \
+              https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh && \
+              bash newinstall.sh -bt"
 
-RUN bash -c ". $STACK_DIR/loadLSST.bash && eups distrib install qserv_distrib -t '$EUPS_TAG'"
+RUN bash -lc ". $STACK_DIR/loadLSST.bash && eups distrib install qserv_distrib -t '$EUPS_TAG'"
 
 COPY scripts/*.sh /qserv/scripts/
 
@@ -72,12 +55,12 @@ ENV QSERV_RUN_DIR /qserv/run
 
 # Generate /qserv/run/sysconfig/qserv and /qserv/run/etc/init.d/qserv-functions
 # required by k8s setup
-RUN bash -c ". /qserv/stack/loadLSST.bash && \
-             setup qserv -t qserv-dev && \
-             cp \"\$SCISQL_DIR\"/lib/libscisql-scisql_?.?.so \"\$MARIADB_DIR\"/lib/plugin && \
-             qserv-configure.py --init --force --qserv-run-dir \"$QSERV_RUN_DIR\" && \
-             qserv-configure.py --etc --qserv-run-dir \"$QSERV_RUN_DIR\" --force && \
-             rm $QSERV_RUN_DIR/qserv-meta.conf"
+RUN bash -lc ". /qserv/stack/loadLSST.bash && \
+              setup qserv -t qserv-dev && \
+              cp \"\$SCISQL_DIR\"/lib/libscisql-scisql_?.?.so \"\$MARIADB_DIR\"/lib/plugin && \
+              qserv-configure.py --init --force --qserv-run-dir \"$QSERV_RUN_DIR\" && \
+              qserv-configure.py --etc --qserv-run-dir \"$QSERV_RUN_DIR\" --force && \
+              rm $QSERV_RUN_DIR/qserv-meta.conf"
 
 # Allow install of additional packages in pods and ease install scripts
 # execution


### PR DESCRIPTION
This should address currently busted Travis CI runs, restore buildability of containers off master (sphgeom pybind11 compiler compatibility problem), and pave the way for integration of Antler4 on master.  Notes from the git commit log:

- Switch base container to lsstsqre/centos:7-stackbase-devtoolset-6
- Remove installation of stack prereqs already in base image
- Use yum instead of apt for remaining package installs
- Add package rh-git29 to meet git version dependency for newinstall and eupspkg
- Add package initscripts (and update qserv-functions) for getpidofproc
- Add -l arg to "RUN bash" lines throughout dockerfiles to pick up scl enables
- Replace deprecated "MAINTAINER" in dockerfiles with now-preferred "LABEL maintainer="
- Remove graphviz from installed debug/utility packages
- Check for existence of /etc/localtime and /etc/timezone before attempting to chown
- Fix Debian-specific "\n" expansion problem in run-multinode-tests.sh