### PR TITLE
Tickets/DM-15922: Fix remaining unit test queries to execute using antlr4 parser

### DIFF
--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -369,7 +369,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT count(*) FROM Object"
        " WHERE  qserv_areaspec_box(1,3,2,4) AND"
        "  scisql_fluxToAbMag(zFlux_PS) BETWEEN 21 AND 21.5;",
-    //fails "SELECT f(one)/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
+    "SELECT f(one)/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
     //fails "SELECT (1+f(one))/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
     // An example slow query from French Petasky colleagues
     //fails "SELECT objectId as id, COUNT(sourceId) AS c"

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -372,8 +372,8 @@ static const std::vector< std::string > QUERIES = {
     "SELECT f(one)/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
     "SELECT (1+f(one))/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
     // An example slow query from French Petasky colleagues
-    //fails "SELECT objectId as id, COUNT(sourceId) AS c"
-    //    " FROM Source GROUP BY objectId HAVING  c > 1000 LIMIT 10;",
+    "SELECT objectId as id, COUNT(sourceId) AS c"
+        " FROM Source GROUP BY objectId HAVING  c > 1000 LIMIT 10;",
     // A query with some expressions
     //fails "SELECT "
     //   "ROUND(scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS), 0) AS UG, "

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -481,17 +481,17 @@ static const std::vector< std::string > QUERIES = {
     //   "from Source s join RefObjMatch rom using (objectId) "
     //   "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;",
 
-    //fails "SELECT objectId, "
-    //   "scisql_fluxToAbMag(uFlux_PS), scisql_fluxToAbMag(gFlux_PS), "
-    //   "scisql_fluxToAbMag(rFlux_PS), scisql_fluxToAbMag(iFlux_PS), "
-    //   "scisql_fluxToAbMag(zFlux_PS), scisql_fluxToAbMag(yFlux_PS), "
-    //   "ra_PS, decl_PS FROM   Object "
-    //   "WHERE  ( scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 0.7 OR scisql_fluxToAbMag(gFlux_PS) > 22.3 ) "
-    //   "AND    scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 0.1 "
-    //   "AND    ( scisql_fluxToAbMag(rFlux_PS)-scisql_fluxToAbMag(iFlux_PS) "
-    //   "< (0.08 + 0.42 * (scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) - 0.96)) "
-    //   " OR scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 1.26 ) "
-    //   "AND    scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) < 0.8;",
+    "SELECT objectId, "
+       "scisql_fluxToAbMag(uFlux_PS), scisql_fluxToAbMag(gFlux_PS), "
+       "scisql_fluxToAbMag(rFlux_PS), scisql_fluxToAbMag(iFlux_PS), "
+       "scisql_fluxToAbMag(zFlux_PS), scisql_fluxToAbMag(yFlux_PS), "
+       "ra_PS, decl_PS FROM   Object "
+       "WHERE  ( scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 0.7 OR scisql_fluxToAbMag(gFlux_PS) > 22.3 ) "
+       "AND    scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 0.1 "
+       "AND    ( scisql_fluxToAbMag(rFlux_PS)-scisql_fluxToAbMag(iFlux_PS) "
+       "< (0.08 + 0.42 * (scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) - 0.96)) "
+       " OR scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 1.26 ) "
+       "AND    scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) < 0.8;",
     //fails "SELECT  COUNT(*) AS totalCount, "
     //   "SUM(CASE WHEN (typeId=3) THEN 1 ELSE 0 END) AS galaxyCount "
     //   "FROM Object WHERE rFlux_PS > 10;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -394,7 +394,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT foo FROM Filter f limit 5;",
     "SELECT foo FROM Filter f limit 5;; ",
 
-    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // this is not supposed to produce a valid query. test and fix as needed in DM-16166
     //fails "SELECT foo from Filter f limit 5 garbage query !#$%!#$",
     //fails "SELECT foo from Filter f limit 5; garbage query !#$%!#$",
 
@@ -410,7 +410,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT * FROM RefObjMatch;",
     "SELECT * FROM RefObjMatch WHERE "
                       "foo<>bar AND baz<3.14159;",
-    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // this is not supposed to produce a valid query. test and fix as needed in DM-16166
     //fails "LECT sce.filterName,sce.field "
     //   "FROM LSST.Science_Ccd_Exposure AS sce "
     //   "WHERE sce.field=535 AND sce.camcol LIKE '%' ",
@@ -476,7 +476,7 @@ static const std::vector< std::string > QUERIES = {
        "FROM Source s1 CROSS JOIN Source s2 "
        "WHERE s1.bar = s2.bar;",
 
-    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // this is not supposed to produce a valid query. test and fix as needed in DM-16166
     //fails "select objectId, sro.*, (sro.refObjectId-1)/2%pow(2,10), typeId "
     //   "from Source s join RefObjMatch rom using (objectId) "
     //   "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;",
@@ -493,12 +493,12 @@ static const std::vector< std::string > QUERIES = {
        " OR scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 1.26 ) "
        "AND    scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) < 0.8;",
 
-    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // this is not supposed to produce a valid query. test and fix as needed in DM-16166
     // per testQueryAnaGeneral: CASE in column spec is illegal.
     //"SELECT  COUNT(*) AS totalCount, "
     //   "SUM(CASE WHEN (typeId=3) THEN 1 ELSE 0 END) AS galaxyCount "
     //   "FROM Object WHERE rFlux_PS > 10;",
-    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // this is not supposed to produce a valid query. test and fix as needed in DM-16166
     // per testQueryAnaGeneral: CASE in column spec is illegal.
     //fails "SELECT scisql_fluxToAbMag(uFlux_PS) "
     //   "FROM   Object WHERE  (objectId % 100 ) = 40;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -364,7 +364,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT * from Object order by ra_PS limit 3;",
     "SELECT run FROM LSST.Science_Ccd_Exposure order by field limit 2;",
     "SELECT count(*) from Science_Ccd_Exposure group by visit;",
-    //fails "select count(*) from Object group by flags having count(*) > 3;",
+    "select count(*) from Object group by flags having count(*) > 3;",
     "SELECT count(*), sum(Source.flux), flux2, Source.flux3 from Source where qserv_areaspec_box(0,0,1,1) and flux4=2 and Source.flux5=3;",
     "SELECT count(*) FROM Object"
        " WHERE  qserv_areaspec_box(1,3,2,4) AND"

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -428,21 +428,21 @@ static const std::vector< std::string > QUERIES = {
        "JOIN Source s2 ON s.objectIdSourceTest = s2.objectIdSourceTest "
        "WHERE LSST.Object.objectId = 430209694171136;",
 
-    //fails "SELECT s1.foo, s2.foo AS s2_foo "
-    //   "FROM Source s1 NATURAL LEFT JOIN Source s2 "
-    //   "WHERE s1.bar = s2.bar;",
-    //fails "SELECT s1.foo, s2.foo AS s2_foo "
-    //   "FROM Source s1 NATURAL LEFT JOIN Source s2 "
-    //   "WHERE s1.bar = s2.bar;",
-    //fails "SELECT s1.foo, s2.foo AS s2_foo "
-    //   "FROM Source s1 NATURAL RIGHT JOIN Source s2 "
-    //   "WHERE s1.bar = s2.bar;",
-    //fails "SELECT s1.foo, s2.foo AS s2_foo "
-    //   "FROM Source s1 NATURAL LEFT OUTER JOIN Source s2 "
-    //   "WHERE s1.bar = s2.bar;",
-    //fails "SELECT s1.foo, s2.foo AS s2_foo "
-    //   "FROM Source s1 NATURAL JOIN Source s2 "
-    //   "WHERE s1.bar = s2.bar;",
+    "SELECT s1.foo, s2.foo AS s2_foo "
+       "FROM Source s1 NATURAL LEFT JOIN Source s2 "
+       "WHERE s1.bar = s2.bar;",
+    "SELECT s1.foo, s2.foo AS s2_foo "
+       "FROM Source s1 NATURAL LEFT JOIN Source s2 "
+       "WHERE s1.bar = s2.bar;",
+    "SELECT s1.foo, s2.foo AS s2_foo "
+       "FROM Source s1 NATURAL RIGHT JOIN Source s2 "
+       "WHERE s1.bar = s2.bar;",
+    "SELECT s1.foo, s2.foo AS s2_foo "
+       "FROM Source s1 NATURAL LEFT OUTER JOIN Source s2 "
+       "WHERE s1.bar = s2.bar;",
+    "SELECT s1.foo, s2.foo AS s2_foo "
+       "FROM Source s1 NATURAL JOIN Source s2 "
+       "WHERE s1.bar = s2.bar;",
     "SELECT * "
        "FROM Filter f JOIN Science_Ccd_Exposure USING(exposureId);",
     "SELECT * FROM Object WHERE objectIdObjTest = 430213989000;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -286,11 +286,213 @@ static const std::vector< std::string > QUERIES = {
     // case05/queries/1051_nn.sql.FIXME
     "SELECT o1.objectId AS objId1, o2.objectId AS objId2, scisql_angSep(o1.ra_PS, o1.decl_PS, o2.ra_PS, o2.decl_PS) AS distance FROM Object o1, Object o2 WHERE qserv_areaspec_box(0, 0, 0.2, 1) AND scisql_angSep(o1.ra_PS, o1.decl_PS, o2.ra_PS, o2.decl_PS) < 1 AND o1.objectId <> o2.objectId",
 
+
+    // from unit tests
+    //fails "select sum(pm_declErr),chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    //fails "select chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0;",
+    "select * from Object where objectIdObjTest between 386942193651347 and 386942193651349;",
+    "select * from Object where someField between 386942193651347 and 386942193651349;",
+    "select * from Object where objectIdObjTest between 38 and 40 and objectIdObjTest IN (10, 30, 70);",
+    "select * from Object o, Source s where o.objectIdObjTest between 38 and 40 AND s.objectIdSourceTest IN (10, 30, 70);",
+    "select chunkId as f1, pm_declErr AS f1 from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    "select chunkId, CHUNKID from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    //fails "select sum(pm_declErr), chunkId as f1, chunkId AS f1, avg(pm_declErr) from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    "select pm_declErr, chunkId, ra_Test from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    "SELECT o1.objectId, o2.objectId, scisql_angSep(o1.ra_PS, o1.decl_PS, o2.ra_PS, o2.decl_PS) AS distance "
+               "FROM Object o1, Object o2 "
+               "WHERE scisql_angSep(o1.ra_PS, o1.decl_PS, o2.ra_PS, o2.decl_PS) < 0.05 "
+               "AND  o1.objectId <> o2.objectId;",
+    "SELECT * FROM Object WHERE someField > 5.0;",
+    "SELECT * FROM LSST.Object WHERE someField > 5.0;",
+    "SELECT * FROM Filter WHERE filterId=4;",
+    "select * from LSST.Object WHERE ra_PS BETWEEN 150 AND 150.2 and decl_PS between 1.6 and 1.7 limit 2;",
+    "select * from LSST.Object WHERE ra_PS BETWEEN 150 AND 150.2 and decl_PS between 1.6 and 1.7 ORDER BY objectId;",
+    "select * from Object where qserv_areaspec_box(0,0,1,1);",
+    "select count(*) from Object as o1, Object as o2 "
+       "where qserv_areaspec_box(6,6,7,7) AND rFlux_PS<0.005 AND scisql_angSep(o1.ra_Test,o1.decl_Test,o2.ra_Test,o2.decl_Test) < 0.001;",
+    "select * from LSST.Object as o1, LSST.Object as o2, LSST.Source "
+       "where o1.id <> o2.id and "
+       "0.024 > scisql_angSep(o1.ra_Test,o1.decl_Test,o2.ra_Test,o2.decl_Test) and "
+       "Source.objectIdSourceTest=o2.objectIdObjTest;",
+    "select count(*) from Bad.Object as o1, Object o2 where qserv_areaspec_box(6,6,7,7) AND o1.ra_PS between 6 and 7 and o1.decl_PS between 6 and 7 ;",
+    "select * from LSST.Object o, Source s WHERE "
+       "qserv_areaspec_box(2,2,3,3) AND o.objectIdObjTest = s.objectIdSourceTest;",
+    "select count(*) from Object as o1, Object as o2;",
+    "select count(*) from LSST.Object as o1, LSST.Object as o2 "
+       "WHERE o1.objectIdObjTest = o2.objectIdObjTest and o1.iFlux > 0.4 and o2.gFlux > 0.4;",
+    // AS alias in column select, <> operator
+    "select o1.objectId, o2.objectI2, scisql_angSep(o1.ra_PS,o1.decl_PS,o2.ra_PS,o2.decl_PS) AS distance "
+       "from LSST.Object as o1, LSST.Object as o2 "
+       "where o1.foo <> o2.foo and o1.objectIdObjTest = o2.objectIdObjTest;",
+    "select count(*) from LSST.Object as o1, LSST.Object as o2;",
+    "select count(*) from LSST.Object o1,LSST.Object o2 "
+       "WHERE qserv_areaspec_box(5.5, 5.5, 6.1, 6.1) AND "
+       "scisql_angSep(o1.ra_Test,o1.decl_Test,o2.ra_Test,o2.decl_Test) < 0.02",
+    // o2.ra_PS and o2.ra_PS_Sigma have to be aliased in order to produce
+    // a result that can't be stored in a table as-is.
+    // It's also a non-distance-bound spatially-unlimited query. Qserv should
+    // reject this during query analysis. But the parser should still handle it.
+    "select o1.ra_PS, o1.ra_PS_Sigma, o2.ra_PS ra_PS2, o2.ra_PS_Sigma ra_PS_Sigma2 "
+      "from Object o1, Object o2 "
+      "where o1.ra_PS_Sigma < 4e-7 and o2.ra_PS_Sigma < 4e-7;",
+    "select o1.ra_PS, o1.ra_PS_Sigma, s.dummy, Exposure.exposureTime "
+       "from LSST.Object o1,  Source s, Exposure "
+       "WHERE o1.objectIdObjTest = s.objectIdSourceTest AND Exposure.id = o1.exposureId;",
+    "select count(*) from Object where qserv_areaspec_box(359.1, 3.16, 359.2,3.17);",
+    "select count(*) from LSST.Object where qserv_areaspec_box(359.1, 3.16, 359.2,3.17);",
+    " SELECT count(*) AS n, AVG(ra_PS), AVG(decl_PS), x_chunkId FROM Object GROUP BY x_chunkId;",
+    "select count(*) from Object where qserv_areaspec_box(359.1, 3.16, 359.2, 3.17);",
+    "SELECT offset, mjdRef, drift FROM LeapSeconds where offset = 10",
+    "SELECT count(*) from Object;",
+    "SELECT count(*) from LSST.Source;",
+    "SELECT count(*) FROM Object WHERE iFlux < 0.4;",
+    "SELECT rFlux FROM Object WHERE iFlux < 0.4 ;",
+    "SELECT * FROM Object WHERE iRadius_SG between 0.02 AND 0.021 LIMIT 3;",
+    "SELECT * from Science_Ccd_Exposure limit 3;",
+    //fails "SELECT table1.* from Science_Ccd_Exposure limit 3;",
+    "SELECT * from Science_Ccd_Exposure limit 1;",
+    "select ra_PS ra1,decl_PS as dec1 from Object order by dec1;",
+    "select o1.iflux_PS o1ps, o2.iFlux_PS o2ps, computeX(o1.one, o2.one) from Object o1, Object o2 order by o1.objectId;",
+    "select ra_PS from LSST.Object where ra_PS between 3 and 4;",
+    "select count(*) from LSST.Object_3840, usnob.Object_3840 where LSST.Object_3840.objectId > usnob.Object_3840.objectId;",
+    "select count(*), max(iFlux_PS) from LSST.Object where iFlux_PS > 100 and col1=col2;",
+    "select count(*), max(iFlux_PS) from LSST.Object where qserv_areaspec_box(0,0,1,1) and iFlux_PS > 100 and col1=col2 and col3=4;",
+    "SELECT * from Object order by ra_PS limit 3;",
+    "SELECT run FROM LSST.Science_Ccd_Exposure order by field limit 2;",
+    "SELECT count(*) from Science_Ccd_Exposure group by visit;",
+    //fails "select count(*) from Object group by flags having count(*) > 3;",
+    //fails "SELECT count(*), sum(Source.flux), flux2, Source.flux3 from Source where qserv_areaspec_box(0,0,1,1) and flux4=2 and Source.flux5=3;",
+    "SELECT count(*) FROM Object"
+       " WHERE  qserv_areaspec_box(1,3,2,4) AND"
+       "  scisql_fluxToAbMag(zFlux_PS) BETWEEN 21 AND 21.5;",
+    //fails "SELECT f(one)/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
+    //fails "SELECT (1+f(one))/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
+    // An example slow query from French Petasky colleagues
+    //fails "SELECT objectId as id, COUNT(sourceId) AS c"
+    //    " FROM Source GROUP BY objectId HAVING  c > 1000 LIMIT 10;",
+    // A query with some expressions
+    //fails "SELECT "
+    //   "ROUND(scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS), 0) AS UG, "
+    //   "ROUND(scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS), 0) AS GR "
+    //   "FROM Object "
+    //   "WHERE scisql_fluxToAbMag(gFlux_PS) < 0.2 "
+    //   "AND scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS) >=-0.27 "
+    //   "AND scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) >=-0.24 "
+    //   "AND scisql_fluxToAbMag(rFlux_PS)-scisql_fluxToAbMag(iFlux_PS) >=-0.27 "
+    //   "AND scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) >=-0.35 "
+    //   "AND scisql_fluxToAbMag(zFlux_PS)-scisql_fluxToAbMag(yFlux_PS) >=-0.40;",
+    // non-chunked query
+    "SELECT DISTINCT foo FROM Filter f;",
+    // chunked query
+    "SELECT DISTINCT zNumObs FROM Object;",
+    // Stricter sql_stmt grammer rules: reject trailing garbage
+    "SELECT foo FROM Filter f limit 5",
+    "SELECT foo FROM Filter f limit 5;",
+    "SELECT foo FROM Filter f limit 5;; ",
+
+    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    //fails "SELECT foo from Filter f limit 5 garbage query !#$%!#$",
+    //fails "SELECT foo from Filter f limit 5; garbage query !#$%!#$",
+
+    // DM-1784: Nested ValueExpr in function calls.
+    //fails "SELECT  o1.objectId "
+    //   "FROM Object o1 "
+    //   "WHERE ABS( (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) - (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) ) < 1;",
+    //fails "SELECT  o1.objectId, o2.objectId objectId2 "
+    //   "FROM Object o1, Object o2 "
+    //   "WHERE scisql_angSep(o1.ra_Test, o1.decl_Test, o2.ra_Test, o2.decl_Test) < 0.00001 "
+    //   "AND o1.objectId <> o2.objectId AND "
+    //   "ABS( (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) - (scisql_fluxToAbMag(o2.gFlux_PS)-scisql_fluxToAbMag(o2.rFlux_PS)) ) < 1;",
+    "SELECT * FROM RefObjMatch;",
+    "SELECT * FROM RefObjMatch WHERE "
+                      "foo<>bar AND baz<3.14159;",
+    //fails "LECT sce.filterName,sce.field "
+    //   "FROM LSST.Science_Ccd_Exposure AS sce "
+    //   "WHERE sce.field=535 AND sce.camcol LIKE '%' ",
+    // Equi-join using index and free-form syntax
+    "SELECT s.ra, s.decl, o.foo FROM Source s, Object o "
+       "WHERE s.objectIdSourceTest=o.objectIdObjTest and o.objectIdObjTest = 430209694171136;",
+    // Equi-join syntax, not supported yet
+    "SELECT s.ra, s.decl, o.foo "
+       "FROM Object o JOIN Source2 s USING (objectIdObjTest) JOIN Source2 s2 USING (objectIdObjTest) "
+       "WHERE o.objectId = 430209694171136;",
+
+    //fails "SELECT s.ra, s.decl, o.foo "
+    //   "FROM Object o "
+    //   "JOIN Source s ON s.objectIdSourceTest = Object.objectIdObjTest "
+    //   "JOIN Source s2 ON s.objectIdSourceTest = s2.objectIdSourceTest "
+    //   "WHERE LSST.Object.objectId = 430209694171136;",
+
+    //fails "SELECT s1.foo, s2.foo AS s2_foo "
+    //   "FROM Source s1 NATURAL LEFT JOIN Source s2 "
+    //   "WHERE s1.bar = s2.bar;",
+    //fails "SELECT s1.foo, s2.foo AS s2_foo "
+    //   "FROM Source s1 NATURAL LEFT JOIN Source s2 "
+    //   "WHERE s1.bar = s2.bar;",
+    //fails "SELECT s1.foo, s2.foo AS s2_foo "
+    //   "FROM Source s1 NATURAL RIGHT JOIN Source s2 "
+    //   "WHERE s1.bar = s2.bar;",
+    //fails "SELECT s1.foo, s2.foo AS s2_foo "
+    //   "FROM Source s1 NATURAL LEFT OUTER JOIN Source s2 "
+    //   "WHERE s1.bar = s2.bar;",
+    //fails "SELECT s1.foo, s2.foo AS s2_foo "
+    //   "FROM Source s1 NATURAL JOIN Source s2 "
+    //   "WHERE s1.bar = s2.bar;",
+    "SELECT * "
+       "FROM Filter f JOIN Science_Ccd_Exposure USING(exposureId);",
+    "SELECT * FROM Object WHERE objectIdObjTest = 430213989000;",
+    "SELECT s.ra, s.decl, o.raRange, o.declRange "
+       "FROM   Object o "
+       "JOIN   Source2 s USING (objectIdObjTest) "
+       "WHERE  o.objectIdObjTest = 390034570102582 "
+       "AND    o.latestObsTime = s.taiMidPoint;",
+    "SELECT sce.filterId, sce.filterName "
+       "FROM Science_Ccd_Exposure AS sce "
+       "WHERE (sce.visit = 887404831) "
+       "AND (sce.raftName = '3,3') "
+       "AND (sce.ccdName LIKE '%')",
+
+    // this query should fail because it contains grammer that is unsupported in SQL92. TBD what grammar fragment(s) are illegal.
+    // "SELECT objectId, ROUND(iE1_SG, 3), ROUND(ABS(iE1_SG), 3) FROM Object WHERE iE1_SG between -0.1 and 0.1 ORDER BY ROUND(ABS(iE1_SG), 3);",
+
+    "SELECT objectId, taiMidPoint, scisql_fluxToAbMag(psfFlux) "
+       "FROM   Source "
+       "JOIN   Object USING(objectId) JOIN   Filter USING(filterId) "
+       "WHERE qserv_areaspec_box(355, 0, 360, 20) AND filterName = 'g' "
+       "ORDER BY objectId, taiMidPoint ASC;",
+    "SELECT DISTINCT rFlux_PS FROM Object;",
+    //fails "SELECT count(*) FROM   Object o "
+    //   "INNER JOIN RefObjMatch o2t ON (o.objectIdObjTest = o2t.objectId) "
+    //   "INNER JOIN SimRefObject t ON (o2t.refObjectId = t.refObjectId) "
+    //   "WHERE  closestToObj = 1 OR closestToObj is NULL;",
+    //fails "SELECT * "
+    //   "FROM Source s1 CROSS JOIN Source s2 "
+    //   "WHERE s1.bar = s2.bar;",
+    //fails "select objectId, sro.*, (sro.refObjectId-1)/2%pow(2,10), typeId "
+    //   "from Source s join RefObjMatch rom using (objectId) "
+    //   "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;",
+    //fails "SELECT objectId, "
+    //   "scisql_fluxToAbMag(uFlux_PS), scisql_fluxToAbMag(gFlux_PS), "
+    //   "scisql_fluxToAbMag(rFlux_PS), scisql_fluxToAbMag(iFlux_PS), "
+    //   "scisql_fluxToAbMag(zFlux_PS), scisql_fluxToAbMag(yFlux_PS), "
+    //   "ra_PS, decl_PS FROM   Object "
+    //   "WHERE  ( scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 0.7 OR scisql_fluxToAbMag(gFlux_PS) > 22.3 ) "
+    //   "AND    scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 0.1 "
+    //   "AND    ( scisql_fluxToAbMag(rFlux_PS)-scisql_fluxToAbMag(iFlux_PS) "
+    //   "< (0.08 + 0.42 * (scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) - 0.96)) "
+    //   " OR scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 1.26 ) "
+    //   "AND    scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) < 0.8;",
+    //fails "SELECT  COUNT(*) AS totalCount, "
+    //   "SUM(CASE WHEN (typeId=3) THEN 1 ELSE 0 END) AS galaxyCount "
+    //   "FROM Object WHERE rFlux_PS > 10;",
+    //fails "SELECT scisql_fluxToAbMag(uFlux_PS) "
+    //   "FROM   Object WHERE  (objectId % 100 ) = 40;",
+
+
     // case01/queries/0013_groupedLogicalTerm.sql
 // TODO this needs to be fixed, by proper handling of nested statements in the where clause. This is implemented but not yet checked in.
 //    "select objectId, ra_PS from Object where ra_PS > 359.5 and (objectId = 417853073271391 or  objectId = 399294519599888)",
 
-//    "select sum(pm_declErr),chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0 GROUP BY chunkId;"
 };
 
 // These queries are all marked "FIXME" in the integration tests, and we don't test them (yet).

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -475,9 +475,12 @@ static const std::vector< std::string > QUERIES = {
     "SELECT * "
        "FROM Source s1 CROSS JOIN Source s2 "
        "WHERE s1.bar = s2.bar;",
+
+    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
     //fails "select objectId, sro.*, (sro.refObjectId-1)/2%pow(2,10), typeId "
     //   "from Source s join RefObjMatch rom using (objectId) "
     //   "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;",
+
     //fails "SELECT objectId, "
     //   "scisql_fluxToAbMag(uFlux_PS), scisql_fluxToAbMag(gFlux_PS), "
     //   "scisql_fluxToAbMag(rFlux_PS), scisql_fluxToAbMag(iFlux_PS), "

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -468,13 +468,13 @@ static const std::vector< std::string > QUERIES = {
     "SELECT DISTINCT rFlux_PS FROM Object;",
     "SELECT count(*) FROM   Object o "
        "WHERE closestToObj is NULL;",
-    //fails "SELECT count(*) FROM   Object o "
-    //   "INNER JOIN RefObjMatch o2t ON (o.objectIdObjTest = o2t.objectId) "
-    //   "INNER JOIN SimRefObject t ON (o2t.refObjectId = t.refObjectId) "
-    //   "WHERE  closestToObj = 1 OR closestToObj is NULL;",
-    //fails "SELECT * "
-    //   "FROM Source s1 CROSS JOIN Source s2 "
-    //   "WHERE s1.bar = s2.bar;",
+    "SELECT count(*) FROM   Object o "
+       "INNER JOIN RefObjMatch o2t ON (o.objectIdObjTest = o2t.objectId) "
+       "INNER JOIN SimRefObject t ON (o2t.refObjectId = t.refObjectId) "
+       "WHERE  closestToObj = 1 OR closestToObj is NULL;",
+    "SELECT * "
+       "FROM Source s1 CROSS JOIN Source s2 "
+       "WHERE s1.bar = s2.bar;",
     //fails "select objectId, sro.*, (sro.refObjectId-1)/2%pow(2,10), typeId "
     //   "from Source s join RefObjMatch rom using (objectId) "
     //   "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;",
@@ -497,8 +497,7 @@ static const std::vector< std::string > QUERIES = {
 
 
     // case01/queries/0013_groupedLogicalTerm.sql
-// TODO this needs to be fixed, by proper handling of nested statements in the where clause. This is implemented but not yet checked in.
-//    "select objectId, ra_PS from Object where ra_PS > 359.5 and (objectId = 417853073271391 or  objectId = 399294519599888)",
+    "select objectId, ra_PS from Object where ra_PS > 359.5 and (objectId = 417853073271391 or  objectId = 399294519599888)",
 
 };
 

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -288,8 +288,8 @@ static const std::vector< std::string > QUERIES = {
 
 
     // from unit tests
-    //fails "select sum(pm_declErr),chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
-    //fails "select chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0;",
+    "select sum(pm_declErr),chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    "select chunkId, avg(bMagF2) bmf2 from LSST.Object where bMagF > 20.0;",
     "select * from Object where objectIdObjTest between 386942193651347 and 386942193651349;",
     "select * from Object where someField between 386942193651347 and 386942193651349;",
     "select * from Object where objectIdObjTest between 38 and 40 and objectIdObjTest IN (10, 30, 70);",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -296,7 +296,7 @@ static const std::vector< std::string > QUERIES = {
     "select * from Object o, Source s where o.objectIdObjTest between 38 and 40 AND s.objectIdSourceTest IN (10, 30, 70);",
     "select chunkId as f1, pm_declErr AS f1 from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
     "select chunkId, CHUNKID from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
-    //fails "select sum(pm_declErr), chunkId as f1, chunkId AS f1, avg(pm_declErr) from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
+    "select sum(pm_declErr), chunkId as f1, chunkId AS f1, avg(pm_declErr) from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
     "select pm_declErr, chunkId, ra_Test from LSST.Object where bMagF > 20.0 GROUP BY chunkId;",
     "SELECT o1.objectId, o2.objectId, scisql_angSep(o1.ra_PS, o1.decl_PS, o2.ra_PS, o2.decl_PS) AS distance "
                "FROM Object o1, Object o2 "
@@ -361,7 +361,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT run FROM LSST.Science_Ccd_Exposure order by field limit 2;",
     "SELECT count(*) from Science_Ccd_Exposure group by visit;",
     //fails "select count(*) from Object group by flags having count(*) > 3;",
-    //fails "SELECT count(*), sum(Source.flux), flux2, Source.flux3 from Source where qserv_areaspec_box(0,0,1,1) and flux4=2 and Source.flux5=3;",
+    "SELECT count(*), sum(Source.flux), flux2, Source.flux3 from Source where qserv_areaspec_box(0,0,1,1) and flux4=2 and Source.flux5=3;",
     "SELECT count(*) FROM Object"
        " WHERE  qserv_areaspec_box(1,3,2,4) AND"
        "  scisql_fluxToAbMag(zFlux_PS) BETWEEN 21 AND 21.5;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -466,6 +466,8 @@ static const std::vector< std::string > QUERIES = {
        "WHERE qserv_areaspec_box(355, 0, 360, 20) AND filterName = 'g' "
        "ORDER BY objectId, taiMidPoint ASC;",
     "SELECT DISTINCT rFlux_PS FROM Object;",
+    "SELECT count(*) FROM   Object o "
+       "WHERE closestToObj is NULL;",
     //fails "SELECT count(*) FROM   Object o "
     //   "INNER JOIN RefObjMatch o2t ON (o.objectIdObjTest = o2t.objectId) "
     //   "INNER JOIN SimRefObject t ON (o2t.refObjectId = t.refObjectId) "

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -492,9 +492,14 @@ static const std::vector< std::string > QUERIES = {
        "< (0.08 + 0.42 * (scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) - 0.96)) "
        " OR scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) > 1.26 ) "
        "AND    scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) < 0.8;",
-    //fails "SELECT  COUNT(*) AS totalCount, "
+
+    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // per testQueryAnaGeneral: CASE in column spec is illegal.
+    //"SELECT  COUNT(*) AS totalCount, "
     //   "SUM(CASE WHEN (typeId=3) THEN 1 ELSE 0 END) AS galaxyCount "
     //   "FROM Object WHERE rFlux_PS > 10;",
+    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
+    // per testQueryAnaGeneral: CASE in column spec is illegal.
     //fails "SELECT scisql_fluxToAbMag(uFlux_PS) "
     //   "FROM   Object WHERE  (objectId % 100 ) = 40;",
 

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -324,6 +324,10 @@ static const std::vector< std::string > QUERIES = {
     "select o1.objectId, o2.objectI2, scisql_angSep(o1.ra_PS,o1.decl_PS,o2.ra_PS,o2.decl_PS) AS distance "
        "from LSST.Object as o1, LSST.Object as o2 "
        "where o1.foo <> o2.foo and o1.objectIdObjTest = o2.objectIdObjTest;",
+    // and != operator
+    "select o1.objectId, o2.objectI2, scisql_angSep(o1.ra_PS,o1.decl_PS,o2.ra_PS,o2.decl_PS) AS distance "
+        "from LSST.Object as o1, LSST.Object as o2 "
+        "where o1.foo != o2.foo and o1.objectIdObjTest = o2.objectIdObjTest;",
     "select count(*) from LSST.Object as o1, LSST.Object as o2;",
     "select count(*) from LSST.Object o1,LSST.Object o2 "
        "WHERE qserv_areaspec_box(5.5, 5.5, 6.1, 6.1) AND "

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -422,11 +422,11 @@ static const std::vector< std::string > QUERIES = {
        "FROM Object o JOIN Source2 s USING (objectIdObjTest) JOIN Source2 s2 USING (objectIdObjTest) "
        "WHERE o.objectId = 430209694171136;",
 
-    //fails "SELECT s.ra, s.decl, o.foo "
-    //   "FROM Object o "
-    //   "JOIN Source s ON s.objectIdSourceTest = Object.objectIdObjTest "
-    //   "JOIN Source s2 ON s.objectIdSourceTest = s2.objectIdSourceTest "
-    //   "WHERE LSST.Object.objectId = 430209694171136;",
+    "SELECT s.ra, s.decl, o.foo "
+       "FROM Object o "
+       "JOIN Source s ON s.objectIdSourceTest = Object.objectIdObjTest "
+       "JOIN Source s2 ON s.objectIdSourceTest = s2.objectIdSourceTest "
+       "WHERE LSST.Object.objectId = 430209694171136;",
 
     //fails "SELECT s1.foo, s2.foo AS s2_foo "
     //   "FROM Source s1 NATURAL LEFT JOIN Source s2 "

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -370,7 +370,7 @@ static const std::vector< std::string > QUERIES = {
        " WHERE  qserv_areaspec_box(1,3,2,4) AND"
        "  scisql_fluxToAbMag(zFlux_PS) BETWEEN 21 AND 21.5;",
     "SELECT f(one)/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
-    //fails "SELECT (1+f(one))/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
+    "SELECT (1+f(one))/f2(two) FROM  Object where qserv_areaspec_box(0,0,1,1);",
     // An example slow query from French Petasky colleagues
     //fails "SELECT objectId as id, COUNT(sourceId) AS c"
     //    " FROM Source GROUP BY objectId HAVING  c > 1000 LIMIT 10;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -375,16 +375,16 @@ static const std::vector< std::string > QUERIES = {
     "SELECT objectId as id, COUNT(sourceId) AS c"
         " FROM Source GROUP BY objectId HAVING  c > 1000 LIMIT 10;",
     // A query with some expressions
-    //fails "SELECT "
-    //   "ROUND(scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS), 0) AS UG, "
-    //   "ROUND(scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS), 0) AS GR "
-    //   "FROM Object "
-    //   "WHERE scisql_fluxToAbMag(gFlux_PS) < 0.2 "
-    //   "AND scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS) >=-0.27 "
-    //   "AND scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) >=-0.24 "
-    //   "AND scisql_fluxToAbMag(rFlux_PS)-scisql_fluxToAbMag(iFlux_PS) >=-0.27 "
-    //   "AND scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) >=-0.35 "
-    //   "AND scisql_fluxToAbMag(zFlux_PS)-scisql_fluxToAbMag(yFlux_PS) >=-0.40;",
+    "SELECT "
+       "ROUND(scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS), 0) AS UG, "
+       "ROUND(scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS), 0) AS GR "
+       "FROM Object "
+       "WHERE scisql_fluxToAbMag(gFlux_PS) < 0.2 "
+       "AND scisql_fluxToAbMag(uFlux_PS)-scisql_fluxToAbMag(gFlux_PS) >=-0.27 "
+       "AND scisql_fluxToAbMag(gFlux_PS)-scisql_fluxToAbMag(rFlux_PS) >=-0.24 "
+       "AND scisql_fluxToAbMag(rFlux_PS)-scisql_fluxToAbMag(iFlux_PS) >=-0.27 "
+       "AND scisql_fluxToAbMag(iFlux_PS)-scisql_fluxToAbMag(zFlux_PS) >=-0.35 "
+       "AND scisql_fluxToAbMag(zFlux_PS)-scisql_fluxToAbMag(yFlux_PS) >=-0.40;",
     // non-chunked query
     "SELECT DISTINCT foo FROM Filter f;",
     // chunked query
@@ -399,14 +399,14 @@ static const std::vector< std::string > QUERIES = {
     //fails "SELECT foo from Filter f limit 5; garbage query !#$%!#$",
 
     // DM-1784: Nested ValueExpr in function calls.
-    //fails "SELECT  o1.objectId "
-    //   "FROM Object o1 "
-    //   "WHERE ABS( (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) - (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) ) < 1;",
-    //fails "SELECT  o1.objectId, o2.objectId objectId2 "
-    //   "FROM Object o1, Object o2 "
-    //   "WHERE scisql_angSep(o1.ra_Test, o1.decl_Test, o2.ra_Test, o2.decl_Test) < 0.00001 "
-    //   "AND o1.objectId <> o2.objectId AND "
-    //   "ABS( (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) - (scisql_fluxToAbMag(o2.gFlux_PS)-scisql_fluxToAbMag(o2.rFlux_PS)) ) < 1;",
+    "SELECT  o1.objectId "
+       "FROM Object o1 "
+       "WHERE ABS( (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) - (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) ) < 1;",
+    "SELECT  o1.objectId, o2.objectId objectId2 "
+       "FROM Object o1, Object o2 "
+       "WHERE scisql_angSep(o1.ra_Test, o1.decl_Test, o2.ra_Test, o2.decl_Test) < 0.00001 "
+       "AND o1.objectId <> o2.objectId AND "
+       "ABS( (scisql_fluxToAbMag(o1.gFlux_PS)-scisql_fluxToAbMag(o1.rFlux_PS)) - (scisql_fluxToAbMag(o2.gFlux_PS)-scisql_fluxToAbMag(o2.rFlux_PS)) ) < 1;",
     "SELECT * FROM RefObjMatch;",
     "SELECT * FROM RefObjMatch WHERE "
                       "foo<>bar AND baz<3.14159;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -353,7 +353,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT rFlux FROM Object WHERE iFlux < 0.4 ;",
     "SELECT * FROM Object WHERE iRadius_SG between 0.02 AND 0.021 LIMIT 3;",
     "SELECT * from Science_Ccd_Exposure limit 3;",
-    //fails "SELECT table1.* from Science_Ccd_Exposure limit 3;",
+    "SELECT table1.* from Science_Ccd_Exposure limit 3;",
     "SELECT * from Science_Ccd_Exposure limit 1;",
     "select ra_PS ra1,decl_PS as dec1 from Object order by dec1;",
     "select o1.iflux_PS o1ps, o2.iFlux_PS o2ps, computeX(o1.one, o2.one) from Object o1, Object o2 order by o1.objectId;",

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -509,6 +509,7 @@ static const std::vector< std::string > QUERIES = {
 
 };
 
+
 // These queries are all marked "FIXME" in the integration tests, and we don't test them (yet).
 static const std::vector< std::string > FAIL_QUERIES = {
     "SELECT v.objectId, v.ra, v.decl FROM   Object v, Object o WHERE  o.objectId = :objectId AND spDist(v.ra, v.decl, o.ra, o.decl, :dist) AND v.variability > 0.8 AND o.extendedParameter > 0.8", // case01/queries/0006_transientVarObjNearGalaxy.sql.FIXME

--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -406,6 +406,7 @@ static const std::vector< std::string > QUERIES = {
     "SELECT * FROM RefObjMatch;",
     "SELECT * FROM RefObjMatch WHERE "
                       "foo<>bar AND baz<3.14159;",
+    // this is not supposed to produce a valid query TODO how to address this with antlr4, how to structure the test?
     //fails "LECT sce.filterName,sce.field "
     //   "FROM LSST.Science_Ccd_Exposure AS sce "
     //   "WHERE sce.field=535 AND sce.camcol LIKE '%' ",

--- a/core/modules/parser/QSMySqlLexer.g4
+++ b/core/modules/parser/QSMySqlLexer.g4
@@ -1022,7 +1022,8 @@ MOD:                                 M O D;
 // Literal Primitives
 
 // Makes the DEC_DIGIT after the decimal point optional
-REAL_LITERAL:                        (DEC_DIGIT+)? '.' (DEC_DIGIT+)?
+REAL_LITERAL:                        (DEC_DIGIT+) '.' (DEC_DIGIT+)?
+                                     | (DEC_DIGIT+)? '.' (DEC_DIGIT+)
                                      | DEC_DIGIT+ '.' EXPONENT_NUM_PART
                                      | (DEC_DIGIT+)? '.' (DEC_DIGIT+ EXPONENT_NUM_PART)
                                      | DEC_DIGIT+ EXPONENT_NUM_PART;

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1803,7 +1803,7 @@ public:
             auto starParExpr = std::make_shared<query::ValueExpr>();
             ValueExprFactory::addValueFactor(starParExpr, starFactor);
             funcExpr = query::FuncExpr::newArg1(_ctx->COUNT()->getText(), starParExpr);
-        } else if (_ctx->AVG() || _ctx->MAX() || _ctx->MIN() ) {
+        } else if (_ctx->AVG() || _ctx->MAX() || _ctx->MIN() || _ctx->SUM()) {
             auto param = std::make_shared<query::ValueExpr>();
             ASSERT_EXECUTION_CONDITION(nullptr != _valueFactor, "ValueFactor must be populated.", _ctx);
             ValueExprFactory::addValueFactor(param, _valueFactor);
@@ -1814,6 +1814,8 @@ public:
                 terminalNode = _ctx->MAX();
             } else if (_ctx->MIN()) {
                 terminalNode = _ctx->MIN();
+            } else if (_ctx->SUM()) {
+                terminalNode = _ctx->SUM();
             } else {
                 ASSERT_EXECUTION_CONDITION(false, "Unhandled function type", _ctx);
             }

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -147,6 +147,13 @@ if (false == (CONDITION)) { \
 } \
 
 
+// This macro is used to log (at the trace level) handle... calls, including the class and function name and
+// whatever object or stream of objects (e.g. `valueExpr`, or `valueExpr << " " << functionName` are passed
+// in to CALLBACK_INFO
+#define TRACE_CALLBACK_INFO(CALLBACK_INFO) \
+LOGS(_log, LOG_LVL_TRACE, name() << __FUNCTION__ << " " << CALLBACK_INFO);
+
+
 namespace lsst {
 namespace qserv {
 namespace parser {

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1248,7 +1248,7 @@ public:
         } else if ("<>" == _comparison) {
             compPredicate->op = SqlSQL2Tokens::NOT_EQUALS_OP;
         } else if ("!=" == _comparison) {
-            compPredicate->op = SqlSQL2Tokens::NOT_EQUALS_OP;
+            compPredicate->op = SqlSQL2Tokens::NOT_EQUALS_OP_ALT;
         } else {
             ASSERT_EXECUTION_CONDITION(false, "unhandled comparison operator type " << _comparison, _ctx);
         }

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -287,6 +287,11 @@ public:
     virtual void handleSelectSpec(bool distinct) = 0;
 };
 
+class SelectStarElementCBH : public BaseCBH {
+public:
+    virtual void handleSelectStarElement(shared_ptr<query::ValueExpr> const & valueExpr) = 0;
+};
+
 class SelectFunctionElementCBH: public BaseCBH {
 public:
     virtual void handleSelectFunctionElement(shared_ptr<query::ValueExpr> const & selectFunction) = 0;
@@ -682,6 +687,8 @@ public:
     }
 
     void onExit() override {
+        ASSERT_EXECUTION_CONDITION(_selectList != nullptr && _fromList != nullptr,
+                "No query was generated.", _ctx);
         lockedParent()->handleQuerySpecification(_selectList, _fromList, _whereClause, _orderByClause,
                 _limit, _groupByClause, _distinct);
     }
@@ -702,7 +709,8 @@ private:
 class SelectElementsAdapter :
         public AdapterT<SelectElementsCBH, QSMySqlParser::SelectElementsContext>,
         public SelectColumnElementCBH,
-        public SelectFunctionElementCBH {
+        public SelectFunctionElementCBH,
+        public SelectStarElementCBH {
 public:
     using AdapterT::AdapterT;
 
@@ -718,6 +726,10 @@ public:
 
     void handleSelectFunctionElement(shared_ptr<query::ValueExpr> const & selectFunction) override {
         SelectListFactory::addSelectAggFunction(_selectList, selectFunction);
+    }
+
+    void handleSelectStarElement(shared_ptr<query::ValueExpr> const & valueExpr) override {
+        SelectListFactory::addValueExpr(_selectList, valueExpr);
     }
 
     void onExit() override {
@@ -1415,6 +1427,28 @@ public:
     string name() const override { return getTypeName(this); }
 };
 
+
+class SelectStarElementAdapter :
+        public AdapterT<SelectStarElementCBH, QSMySqlParser::SelectStarElementContext>,
+        public FullIdCBH {
+public:
+    using AdapterT::AdapterT;
+
+    void handleFullId(vector<string> const & uidlist) override {
+        ASSERT_EXECUTION_CONDITION(nullptr == _valueExpr, "_valueExpr should only be set once.", _ctx);
+        ASSERT_EXECUTION_CONDITION(uidlist.size() == 1, "Star Elements must be 'tableName.*'", _ctx);
+        _valueExpr = make_shared<query::ValueExpr>();
+        ValueExprFactory::addValueFactor(_valueExpr, query::ValueFactor::newStarFactor(uidlist[0]));
+    }
+
+    void onExit() override {
+        lockedParent()->handleSelectStarElement(_valueExpr);
+    }
+
+    string name() const override { return getTypeName(this); }
+private:
+    shared_ptr<query::ValueExpr> _valueExpr;
+};
 
 
 // handles `functionCall (AS? uid)?` e.g. "COUNT AS object_count"
@@ -2739,7 +2773,7 @@ UNHANDLED(QuerySpecificationNointo)
 UNHANDLED(UnionParenthesis)
 UNHANDLED(UnionStatement)
 ENTER_EXIT_PARENT(SelectSpec)
-UNHANDLED(SelectStarElement)
+ENTER_EXIT_PARENT(SelectStarElement)
 ENTER_EXIT_PARENT(SelectFunctionElement)
 UNHANDLED(SelectExpressionElement)
 UNHANDLED(SelectIntoVariables)

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1298,6 +1298,10 @@ public:
             compPredicate->op = SqlSQL2Tokens::NOT_EQUALS_OP;
         } else if ("!=" == _comparison) {
             compPredicate->op = SqlSQL2Tokens::NOT_EQUALS_OP_ALT;
+        } else if ("<=" == _comparison) {
+            compPredicate->op = SqlSQL2Tokens::LESS_THAN_OR_EQUALS_OP;
+        } else if (">=" == _comparison) {
+            compPredicate->op = SqlSQL2Tokens::GREATER_THAN_OR_EQUALS_OP;
         } else {
             ASSERT_EXECUTION_CONDITION(false, "unhandled comparison operator type " << _comparison, _ctx);
         }
@@ -1970,11 +1974,11 @@ class FunctionArgsAdapter :
         public AdapterT<FunctionArgsCBH, QSMySqlParser::FunctionArgsContext>,
         public ConstantCBH,
         public FullColumnNameCBH,
-        public ScalarFunctionCallCBH{
+        public ScalarFunctionCallCBH,
+        public PredicateExpressionCBH {
 public:
     using AdapterT::AdapterT;
 
-    // ConstantCBH
     void handleConstant(string const & val) override {
         auto valueExpr = make_shared<query::ValueExpr>();
         ValueExprFactory::addValueFactor(valueExpr, query::ValueFactor::newConstFactor(val));
@@ -1990,6 +1994,15 @@ public:
     void handleScalarFunctionCall(shared_ptr<query::ValueFactor> const & valueFactor) {
         auto valueExpr = make_shared<query::ValueExpr>();
         ValueExprFactory::addValueFactor(valueExpr, valueFactor);
+        _args.push_back(valueExpr);
+    }
+
+    void handlePredicateExpression(shared_ptr<query::BoolFactor> const & boolFactor,
+            antlr4::ParserRuleContext* childCtx) override {
+        ASSERT_EXECUTION_CONDITION(false, "Unhandled PredicateExpression with BoolFactor.", _ctx);
+    }
+
+    void handlePredicateExpression(shared_ptr<query::ValueExpr> const & valueExpr) override {
         _args.push_back(valueExpr);
     }
 

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1428,9 +1428,8 @@ public:
     using AdapterT::AdapterT;
 
     void handleUid(string const & string) override {
-        // Uid is expected to be the aliasName in `functionCall AS aliasName`
+        // Uid is expected to be the aliasName in `functionCall AS aliasName` or `functionCall aliasName`
         ASSERT_EXECUTION_CONDITION(_asName.empty(), "Second call to handleUid.", _ctx);
-        ASSERT_EXECUTION_CONDITION(_ctx->AS() != nullptr, "Call to handleUid but AS is null.", _ctx);
         _asName = string;
     }
 

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1435,8 +1435,8 @@ public:
     using AdapterT::AdapterT;
 
     void onEnter() override {
-        ASSERT_EXECUTION_CONDITION(nullptr == _ctx->INNER() && nullptr == _ctx->CROSS(),
-                "INNER and CROSS join are not currently supported by the parser.", _ctx);
+        ASSERT_EXECUTION_CONDITION(nullptr == _ctx->CROSS(),
+                "CROSS join is not currently supported by the parser.", _ctx);
     }
 
     void handleAtomTableItem(shared_ptr<query::TableRef> const & tableRef) override {
@@ -1464,8 +1464,11 @@ public:
     void onExit() override {
         ASSERT_EXECUTION_CONDITION(_tableRef != nullptr, "TableRef was not set.", _ctx);
         auto joinSpec = make_shared<query::JoinSpec>(_using, _on);
-        // todo where does type get defined?
-        auto joinRef = make_shared<query::JoinRef>(_tableRef, query::JoinRef::DEFAULT, false, joinSpec);
+        auto joinType = query::JoinRef::DEFAULT;
+        if (_ctx->INNER()) {
+            joinType = query::JoinRef::INNER;
+        }
+        auto joinRef = make_shared<query::JoinRef>(_tableRef, joinType, false, joinSpec);
         lockedParent()->handleInnerJoin(joinRef);
     }
 

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1906,7 +1906,7 @@ public:
             auto starParExpr = std::make_shared<query::ValueExpr>();
             ValueExprFactory::addValueFactor(starParExpr, starFactor);
             funcExpr = query::FuncExpr::newArg1(_ctx->COUNT()->getText(), starParExpr);
-        } else if (_ctx->AVG() || _ctx->MAX() || _ctx->MIN() || _ctx->SUM()) {
+        } else if (_ctx->AVG() || _ctx->MAX() || _ctx->MIN() || _ctx->SUM() || _ctx->COUNT() ) {
             auto param = std::make_shared<query::ValueExpr>();
             ASSERT_EXECUTION_CONDITION(nullptr != _valueFactor, "ValueFactor must be populated.", _ctx);
             ValueExprFactory::addValueFactor(param, _valueFactor);
@@ -1919,6 +1919,8 @@ public:
                 terminalNode = _ctx->MIN();
             } else if (_ctx->SUM()) {
                 terminalNode = _ctx->SUM();
+            } else if (_ctx->COUNT()) {
+                terminalNode = _ctx->COUNT();
             } else {
                 ASSERT_EXECUTION_CONDITION(false, "Unhandled function type", _ctx);
             }

--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -1230,15 +1230,15 @@ public:
     // BinaryComparasionPredicateCBH
     void handleBinaryComparasionPredicate(
             shared_ptr<query::CompPredicate> const & comparisonPredicate) override {
-        _getBoolFactor()->addBoolFactorTerm(comparisonPredicate);
+        _boolFactorInstance()->addBoolFactorTerm(comparisonPredicate);
     }
 
     void handleBetweenPredicate(shared_ptr<query::BetweenPredicate> const & betweenPredicate) override {
-        _getBoolFactor()->addBoolFactorTerm(betweenPredicate);
+        _boolFactorInstance()->addBoolFactorTerm(betweenPredicate);
     }
 
     void handleInPredicate(shared_ptr<query::InPredicate> const & inPredicate) override {
-        _getBoolFactor()->addBoolFactorTerm(inPredicate);
+        _boolFactorInstance()->addBoolFactorTerm(inPredicate);
     }
 
     void handleExpressionAtomPredicate(shared_ptr<query::ValueExpr> const & valueExpr,
@@ -1256,11 +1256,11 @@ public:
     }
 
     void handleLikePredicate(shared_ptr<query::LikePredicate> const & likePredicate) override {
-        _getBoolFactor()->addBoolFactorTerm(likePredicate);
+        _boolFactorInstance()->addBoolFactorTerm(likePredicate);
     }
 
     void handleIsNullPredicate(shared_ptr<query::NullPredicate> const & nullPredicate) override {
-        _getBoolFactor()->addBoolFactorTerm(nullPredicate);
+        _boolFactorInstance()->addBoolFactorTerm(nullPredicate);
     }
 
     void onExit() {
@@ -1276,7 +1276,7 @@ public:
     string name() const override { return getTypeName(this); }
 
 private:
-    shared_ptr<query::BoolFactor> _getBoolFactor() {
+    shared_ptr<query::BoolFactor> _boolFactorInstance() {
         ASSERT_EXECUTION_CONDITION(nullptr == _valueExpr, "Can't use PredicateExpressionAdapter for " <<
                 "BoolFactor and ValueExpr at the same time.", _ctx);
         if (nullptr == _boolTerm) {

--- a/core/modules/qana/testPlugins.cc
+++ b/core/modules/qana/testPlugins.cc
@@ -145,11 +145,6 @@ static const std::vector<OrderByQueryAndExpectedColumns> ORDER_BY_QUERIES = {
         OrderByQueryAndExpectedColumns("SELECT foo ORDER BY bar",
                 {std::make_shared<query::ColumnRef>("", "", "bar")}),
 
-        // note, don't use the column name inside a function; it must be aliased to be usable.
-        OrderByQueryAndExpectedColumns("SELECT foo ORDER BY foo.bar, my_func(baz)",
-                {std::make_shared<query::ColumnRef>("", "foo", "bar"),
-                 std::make_shared<query::ColumnRef>("", "", "baz")}),
-
         OrderByQueryAndExpectedColumns("SELECT some_func(boz) as foo from my_table ORDER BY foo",
                 {std::make_shared<query::ColumnRef>("", "", "foo")}),
 

--- a/core/modules/query/BoolTerm.h
+++ b/core/modules/query/BoolTerm.h
@@ -269,12 +269,10 @@ public:
     BoolFactor() = default;
 
     BoolFactor(BoolFactorTerm::PtrVector const & terms)
-        : _terms(terms)
-    { }
+        : _terms(terms) {}
 
     BoolFactor(BoolFactorTerm::Ptr const & term)
-        : _terms({term})
-    { }
+        : _terms({term}) {}
 
     typedef std::shared_ptr<BoolFactor> Ptr;
     virtual char const* getName() const { return "BoolFactor"; }

--- a/core/modules/query/BoolTerm.h
+++ b/core/modules/query/BoolTerm.h
@@ -66,8 +66,8 @@ public:
     virtual std::ostream& putStream(std::ostream& os) const = 0;
     virtual void renderTo(QueryTemplate& qt) const = 0;
 
-    virtual void findValueExprs(ValueExprPtrVector& vector) {}
-    virtual void findColumnRefs(ColumnRef::Vector& vector) {}
+    virtual void findValueExprs(ValueExprPtrVector& vector) const {}
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const {}
 
     virtual bool operator==(const BoolFactorTerm& rhs) const = 0;
 
@@ -101,8 +101,8 @@ public:
 
     virtual OpPrecedence getOpPrecedence() const { return UNKNOWN_PRECEDENCE; }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector) {}
-    virtual void findColumnRefs(ColumnRef::Vector& vector) {}
+    virtual void findValueExprs(ValueExprPtrVector& vector) const {}
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const {}
 
     /// @return a mutable vector iterator for the contained terms
     virtual PtrVector::iterator iterBegin() { return PtrVector::iterator(); }
@@ -161,6 +161,22 @@ public:
         std::copy(terms.begin(), terms.end(), std::back_inserter(_terms));
     }
 
+    virtual void findValueExprs(ValueExprPtrVector& vector) const {
+        for (auto&& boolTerm : _terms) {
+            if (boolTerm) {
+                boolTerm->findValueExprs(vector);
+            }
+        }
+    }
+
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const {
+        for (auto&& boolTerm : _terms) {
+            if (boolTerm) {
+                boolTerm->findColumnRefs(vector);
+            }
+        }
+    }
+
     BoolTerm::PtrVector _terms;
 };
 
@@ -174,19 +190,6 @@ public:
 
     virtual char const* getName() const { return "OrTerm"; }
     virtual OpPrecedence getOpPrecedence() const { return OR_PRECEDENCE; }
-
-    virtual void findValueExprs(ValueExprPtrVector& vector) {
-        typedef BoolTerm::PtrVector::iterator Iter;
-        for (Iter i = _terms.begin(), e = _terms.end(); i != e; ++i) {
-            if (*i) { (*i)->findValueExprs(vector); }
-        }
-    }
-    virtual void findColumnRefs(ColumnRef::Vector& vector) {
-        typedef BoolTerm::PtrVector::iterator Iter;
-        for (Iter i = _terms.begin(), e = _terms.end(); i != e; ++i) {
-            if (*i) { (*i)->findColumnRefs(vector); }
-        }
-    }
 
     virtual PtrVector::iterator iterBegin() { return _terms.begin(); }
     virtual PtrVector::iterator iterEnd() { return _terms.end(); }
@@ -216,19 +219,6 @@ public:
 
     virtual char const* getName() const { return "AndTerm"; }
     virtual OpPrecedence getOpPrecedence() const { return AND_PRECEDENCE; }
-
-    virtual void findValueExprs(ValueExprPtrVector& vector) {
-        typedef BoolTerm::PtrVector::iterator Iter;
-        for (Iter i = _terms.begin(), e = _terms.end(); i != e; ++i) {
-            if (*i) { (*i)->findValueExprs(vector); }
-        }
-    }
-    virtual void findColumnRefs(ColumnRef::Vector& vector) {
-        typedef BoolTerm::PtrVector::iterator Iter;
-        for (Iter i = _terms.begin(), e = _terms.end(); i != e; ++i) {
-            if (*i) { (*i)->findColumnRefs(vector); }
-        }
-    }
 
     virtual PtrVector::iterator iterBegin() { return _terms.begin(); }
     virtual PtrVector::iterator iterEnd() { return _terms.end(); }
@@ -294,16 +284,19 @@ public:
         _terms.push_back(boolFactorTerm);
     }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector) {
-        typedef BoolFactorTerm::PtrVector::iterator Iter;
-        for (Iter i = _terms.begin(), e = _terms.end(); i != e; ++i) {
-            if (*i) { (*i)->findValueExprs(vector); }
+    virtual void findValueExprs(ValueExprPtrVector& vector) const {
+        for (auto&& boolFactorTerm : _terms) {
+            if (boolFactorTerm) {
+                boolFactorTerm->findValueExprs(vector);
+            }
         }
     }
-    virtual void findColumnRefs(ColumnRef::Vector& vector) {
-        typedef BoolFactorTerm::PtrVector::iterator Iter;
-        for (Iter i = _terms.begin(), e = _terms.end(); i != e; ++i) {
-            if (*i) { (*i)->findColumnRefs(vector); }
+
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const {
+        for (auto&& boolFactorTerm : _terms) {
+            if (boolFactorTerm) {
+                boolFactorTerm->findColumnRefs(vector);
+            }
         }
     }
 
@@ -388,10 +381,10 @@ public:
     virtual std::ostream& putStream(std::ostream& os) const;
     virtual void renderTo(QueryTemplate& qt) const;
 
-    virtual void findValueExprs(ValueExprPtrVector& vector) {
+    virtual void findValueExprs(ValueExprPtrVector& vector) const {
         if (_term) { _term->findValueExprs(vector); }
     }
-    virtual void findColumnRefs(ColumnRef::Vector& vector) {
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const {
         if (_term) { _term->findColumnRefs(vector); }
     }
 

--- a/core/modules/query/FuncExpr.cc
+++ b/core/modules/query/FuncExpr.cc
@@ -101,12 +101,9 @@ FuncExpr::setName(const std::string& val) {
 }
 
 void
-FuncExpr::findColumnRefs(ColumnRef::Vector& outputRefs) {
-    for(ValueExprPtrVector::iterator i=params.begin();
-        i != params.end(); ++i) {
-        if (*i) {
-            (**i).findColumnRefs(outputRefs);
-        }
+FuncExpr::findColumnRefs(ColumnRef::Vector& outputRefs) const {
+    for (auto&& valueExpr : params) {
+        valueExpr->findColumnRefs(outputRefs);
     }
 }
 

--- a/core/modules/query/FuncExpr.h
+++ b/core/modules/query/FuncExpr.h
@@ -70,7 +70,7 @@ public:
 
     void setName(const std::string& val);
 
-    void findColumnRefs(ColumnRef::Vector& outputRefs);
+    void findColumnRefs(ColumnRef::Vector& outputRefs) const;
     std::shared_ptr<FuncExpr> clone() const;
 
     // Fields

--- a/core/modules/query/GroupByClause.cc
+++ b/core/modules/query/GroupByClause.cc
@@ -129,9 +129,9 @@ std::shared_ptr<GroupByClause> GroupByClause::copySyntax() {
     return std::make_shared<GroupByClause>(*this);
 }
 
-void GroupByClause::findValueExprs(ValueExprPtrVector& list) {
-    for (List::iterator i = _terms->begin(), e = _terms->end(); i != e; ++i) {
-        list.push_back(i->getExpr());
+void GroupByClause::findValueExprs(ValueExprPtrVector& list) const {
+    for (auto&& groupByTerm : *_terms) {
+        list.push_back(groupByTerm.getExpr());
     }
 }
 

--- a/core/modules/query/GroupByClause.h
+++ b/core/modules/query/GroupByClause.h
@@ -93,7 +93,7 @@ public:
     std::shared_ptr<GroupByClause> clone() const;
     std::shared_ptr<GroupByClause> copySyntax();
 
-    void findValueExprs(ValueExprPtrVector& list);
+    void findValueExprs(ValueExprPtrVector& list) const;
 
     bool operator==(const GroupByClause& rhs) const;
 

--- a/core/modules/query/HavingClause.cc
+++ b/core/modules/query/HavingClause.cc
@@ -89,7 +89,7 @@ HavingClause::copySyntax() {
 }
 
 void
-HavingClause::findValueExprs(ValueExprPtrVector& list) {
+HavingClause::findValueExprs(ValueExprPtrVector& list) const {
     if (_tree) { _tree->findValueExprs(list); }
 }
 

--- a/core/modules/query/HavingClause.h
+++ b/core/modules/query/HavingClause.h
@@ -58,9 +58,8 @@ public:
     HavingClause() {}
     ~HavingClause() {}
 
-    HavingClause(std::shared_ptr<BoolTerm> tree)
-    : _tree(tree)
-    {}
+    HavingClause(std::shared_ptr<BoolTerm> const & tree)
+        : _tree(tree) {}
 
     std::string getGenerated() const;
     void renderTo(QueryTemplate& qt) const;

--- a/core/modules/query/HavingClause.h
+++ b/core/modules/query/HavingClause.h
@@ -58,6 +58,10 @@ public:
     HavingClause() {}
     ~HavingClause() {}
 
+    HavingClause(std::shared_ptr<BoolTerm> tree)
+    : _tree(tree)
+    {}
+
     std::string getGenerated() const;
     void renderTo(QueryTemplate& qt) const;
     std::shared_ptr<HavingClause> clone() const;

--- a/core/modules/query/HavingClause.h
+++ b/core/modules/query/HavingClause.h
@@ -65,7 +65,7 @@ public:
     void renderTo(QueryTemplate& qt) const;
     std::shared_ptr<HavingClause> clone() const;
     std::shared_ptr<HavingClause> copySyntax();
-    void findValueExprs(ValueExprPtrVector& list);
+    void findValueExprs(ValueExprPtrVector& list) const;
 
     bool operator==(const HavingClause& rhs) const;
 

--- a/core/modules/query/JoinSpec.h
+++ b/core/modules/query/JoinSpec.h
@@ -62,14 +62,14 @@ class JoinSpec {
 public:
     typedef std::shared_ptr<JoinSpec> Ptr;
 
-    JoinSpec(std::shared_ptr<BoolTerm> onTerm)
+    JoinSpec(std::shared_ptr<BoolTerm> const& onTerm)
         : _onTerm(onTerm) {}
 
     /// FIXME: not supporting join by multiple columns now
-    JoinSpec(std::shared_ptr<ColumnRef> ref)
+    JoinSpec(std::shared_ptr<ColumnRef> const& ref)
         : _usingColumn(ref) {}
 
-    JoinSpec(std::shared_ptr<ColumnRef> ref, std::shared_ptr<BoolTerm> onTerm)
+    JoinSpec(std::shared_ptr<ColumnRef> ref, std::shared_ptr<BoolTerm> const& onTerm)
         : _usingColumn(ref), _onTerm(onTerm) {}
 
     std::shared_ptr<ColumnRef> getUsing() { return _usingColumn; }

--- a/core/modules/query/JoinSpec.h
+++ b/core/modules/query/JoinSpec.h
@@ -69,6 +69,9 @@ public:
     JoinSpec(std::shared_ptr<ColumnRef> ref)
         : _usingColumn(ref) {}
 
+    JoinSpec(std::shared_ptr<ColumnRef> ref, std::shared_ptr<BoolTerm> onTerm)
+        : _usingColumn(ref), _onTerm(onTerm) {}
+
     std::shared_ptr<ColumnRef> getUsing() { return _usingColumn; }
     std::shared_ptr<ColumnRef const> getUsing() const { return _usingColumn; }
     std::shared_ptr<BoolTerm> getOn() { return _onTerm; }

--- a/core/modules/query/OrderByClause.cc
+++ b/core/modules/query/OrderByClause.cc
@@ -184,9 +184,9 @@ std::shared_ptr<OrderByClause> OrderByClause::copySyntax() {
     return std::make_shared<OrderByClause>(*this);
 }
 
-void OrderByClause::findValueExprs(ValueExprPtrVector& list) {
-    for (OrderByTermVector::iterator i = _terms->begin(), e = _terms->end(); i != e; ++i) {
-        list.push_back(i->getExpr());
+void OrderByClause::findValueExprs(ValueExprPtrVector& list) const {
+    for (auto&& orderByTerm : *_terms) {
+        list.push_back(orderByTerm.getExpr());
     }
 }
 

--- a/core/modules/query/OrderByClause.h
+++ b/core/modules/query/OrderByClause.h
@@ -103,7 +103,7 @@ public:
     std::shared_ptr<OrderByTermVector> getTerms() const { return _terms; }
     void addTerm(const OrderByTerm& term) { _terms->push_back(term); }
 
-    void findValueExprs(ValueExprPtrVector& list);
+    void findValueExprs(ValueExprPtrVector& list) const;
 
     bool operator==(const OrderByClause& rhs) const;
 

--- a/core/modules/query/Predicate.cc
+++ b/core/modules/query/Predicate.cc
@@ -53,31 +53,30 @@ std::ostream& operator<<(std::ostream& os, Predicate const& bt) {
 }
 
 
-void CompPredicate::findColumnRefs(ColumnRef::Vector& vector) {
+void CompPredicate::findColumnRefs(ColumnRef::Vector& vector) const {
     if (left) { left->findColumnRefs(vector); }
     if (right) { right->findColumnRefs(vector); }
 }
 
-void InPredicate::findColumnRefs(ColumnRef::Vector& vector) {
+void InPredicate::findColumnRefs(ColumnRef::Vector& vector) const {
     if (value) { value->findColumnRefs(vector); }
-    std::vector<std::shared_ptr<ValueExpr> >::iterator i;
-    for(i=cands.begin(); i != cands.end(); ++i) {
-        (**i).findColumnRefs(vector);
+    for(auto&& valueExpr : cands) {
+        valueExpr->findColumnRefs(vector);
     }
 }
 
-void BetweenPredicate::findColumnRefs(ColumnRef::Vector& vector) {
+void BetweenPredicate::findColumnRefs(ColumnRef::Vector& vector) const {
     if (value) { value->findColumnRefs(vector); }
     if (minValue) { minValue->findColumnRefs(vector); }
     if (maxValue) { maxValue->findColumnRefs(vector); }
 }
 
-void LikePredicate::findColumnRefs(ColumnRef::Vector& vector) {
+void LikePredicate::findColumnRefs(ColumnRef::Vector& vector) const {
     if (value) { value->findColumnRefs(vector); }
     if (charValue) { charValue->findColumnRefs(vector); }
 }
 
-void NullPredicate::findColumnRefs(ColumnRef::Vector& vector) {
+void NullPredicate::findColumnRefs(ColumnRef::Vector& vector) const {
     if (value) { value->findColumnRefs(vector); }
 }
 
@@ -149,28 +148,28 @@ void NullPredicate::renderTo(QueryTemplate& qt) const {
     qt.append("NULL");
 }
 
-void CompPredicate::findValueExprs(ValueExprPtrVector& vector) {
+void CompPredicate::findValueExprs(ValueExprPtrVector& vector) const {
     vector.push_back(left);
     vector.push_back(right);
 }
 
-void InPredicate::findValueExprs(ValueExprPtrVector& vector) {
+void InPredicate::findValueExprs(ValueExprPtrVector& vector) const {
     vector.push_back(value);
     vector.insert(vector.end(), cands.begin(), cands.end());
 }
 
-void BetweenPredicate::findValueExprs(ValueExprPtrVector& vector) {
+void BetweenPredicate::findValueExprs(ValueExprPtrVector& vector) const {
     vector.push_back(value);
     vector.push_back(minValue);
     vector.push_back(maxValue);
 }
 
-void LikePredicate::findValueExprs(ValueExprPtrVector& vector) {
+void LikePredicate::findValueExprs(ValueExprPtrVector& vector) const {
     vector.push_back(value);
     vector.push_back(charValue);
 }
 
-void NullPredicate::findValueExprs(ValueExprPtrVector& vector) {
+void NullPredicate::findValueExprs(ValueExprPtrVector& vector) const {
     vector.push_back(value);
 }
 

--- a/core/modules/query/Predicate.h
+++ b/core/modules/query/Predicate.h
@@ -209,7 +209,14 @@ class NullPredicate : public Predicate {
 public:
     typedef std::shared_ptr<NullPredicate> Ptr;
 
+    NullPredicate()
+    : hasNot(false) {}
+
+    NullPredicate(ValueExprPtr valueExpr, bool hasNotNull)
+    : value(valueExpr), hasNot(hasNotNull) {}
+
     virtual ~NullPredicate() {}
+
     virtual char const* getName() const { return "NullPredicate"; }
 
     virtual void findValueExprs(ValueExprPtrVector& vector);

--- a/core/modules/query/Predicate.h
+++ b/core/modules/query/Predicate.h
@@ -105,8 +105,8 @@ public:
 
     virtual char const* getName() const { return "CompPredicate"; }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector);
-    virtual void findColumnRefs(ColumnRef::Vector& vector);
+    virtual void findValueExprs(ValueExprPtrVector& vector) const;
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const;
 
     virtual std::ostream& putStream(std::ostream& os) const;
     virtual void renderTo(QueryTemplate& qt) const;
@@ -135,8 +135,8 @@ public:
 
     virtual char const* getName() const { return "InPredicate"; }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector);
-    virtual void findColumnRefs(ColumnRef::Vector& vector);
+    virtual void findValueExprs(ValueExprPtrVector& vector) const;
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const;
 
     virtual std::ostream& putStream(std::ostream& os) const;
     virtual void renderTo(QueryTemplate& qt) const;
@@ -165,8 +165,8 @@ public:
 
     virtual char const* getName() const { return "BetweenPredicate"; }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector);
-    virtual void findColumnRefs(ColumnRef::Vector& vector);
+    virtual void findValueExprs(ValueExprPtrVector& vector) const;
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const;
     virtual std::ostream& putStream(std::ostream& os) const;
     virtual void renderTo(QueryTemplate& qt) const;
     /// Deep copy this term.
@@ -193,8 +193,8 @@ public:
 
     virtual char const* getName() const { return "LikePredicate"; }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector);
-    virtual void findColumnRefs(ColumnRef::Vector& vector);
+    virtual void findValueExprs(ValueExprPtrVector& vector) const;
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const;
 
     virtual std::ostream& putStream(std::ostream& os) const;
     virtual void renderTo(QueryTemplate& qt) const;
@@ -225,8 +225,8 @@ public:
 
     virtual char const* getName() const { return "NullPredicate"; }
 
-    virtual void findValueExprs(ValueExprPtrVector& vector);
-    virtual void findColumnRefs(ColumnRef::Vector& vector);
+    virtual void findValueExprs(ValueExprPtrVector& vector) const;
+    virtual void findColumnRefs(ColumnRef::Vector& vector) const;
 
     virtual std::ostream& putStream(std::ostream& os) const;
     virtual void renderTo(QueryTemplate& qt) const;

--- a/core/modules/query/Predicate.h
+++ b/core/modules/query/Predicate.h
@@ -65,7 +65,8 @@ class Predicate : public BoolFactorTerm {
 public:
     typedef std::shared_ptr<Predicate> Ptr;
 
-    virtual ~Predicate() {}
+    virtual ~Predicate() = default;
+
     virtual char const* getName() const { return "Predicate"; }
 
     friend std::ostream& operator<<(std::ostream& os, Predicate const& bt);
@@ -84,7 +85,8 @@ class GenericPredicate : public Predicate {
 public:
     typedef std::shared_ptr<GenericPredicate> Ptr;
 
-    virtual ~GenericPredicate() {}
+    virtual ~GenericPredicate() = default;
+
     virtual char const* getName() const { return "GenericPredicate"; }
 
     virtual std::ostream& putStream(std::ostream& os) const = 0;
@@ -99,7 +101,8 @@ class CompPredicate : public Predicate {
 public:
     typedef std::shared_ptr<CompPredicate> Ptr;
 
-    virtual ~CompPredicate() {}
+    virtual ~CompPredicate() = default;
+
     virtual char const* getName() const { return "CompPredicate"; }
 
     virtual void findValueExprs(ValueExprPtrVector& vector);
@@ -128,7 +131,8 @@ class InPredicate : public Predicate {
 public:
     typedef std::shared_ptr<InPredicate> Ptr;
 
-    virtual ~InPredicate() {}
+    virtual ~InPredicate() = default;
+
     virtual char const* getName() const { return "InPredicate"; }
 
     virtual void findValueExprs(ValueExprPtrVector& vector);
@@ -157,7 +161,8 @@ public:
     : value(iValue), minValue(iMinValue), maxValue(iMaxValue) {}
     typedef std::shared_ptr<BetweenPredicate> Ptr;
 
-    virtual ~BetweenPredicate() {}
+    virtual ~BetweenPredicate() = default;
+
     virtual char const* getName() const { return "BetweenPredicate"; }
 
     virtual void findValueExprs(ValueExprPtrVector& vector);
@@ -184,7 +189,8 @@ class LikePredicate : public Predicate {
 public:
     typedef std::shared_ptr<LikePredicate> Ptr;
 
-    virtual ~LikePredicate() {}
+    virtual ~LikePredicate() = default;
+
     virtual char const* getName() const { return "LikePredicate"; }
 
     virtual void findValueExprs(ValueExprPtrVector& vector);
@@ -215,7 +221,7 @@ public:
     NullPredicate(ValueExprPtr valueExpr, bool hasNotNull)
     : value(valueExpr), hasNot(hasNotNull) {}
 
-    virtual ~NullPredicate() {}
+    virtual ~NullPredicate() = default;
 
     virtual char const* getName() const { return "NullPredicate"; }
 

--- a/core/modules/query/ValueExpr.cc
+++ b/core/modules/query/ValueExpr.cc
@@ -220,6 +220,16 @@ bool ValueExpr::isColumnRef() const {
     return false;
 }
 
+bool ValueExpr::isFunction() const {
+    if (_factorOps.size() == 1) {
+        ValueFactor const& factor = *_factorOps.front().factor;
+        if (factor.getType() == ValueFactor::FUNCTION) {
+            return true;
+        }
+    }
+    return false;
+}
+
 ValueExprPtr ValueExpr::clone() const {
     // First, make a shallow copy
     ValueExprPtr expr = std::make_shared<ValueExpr>(*this);

--- a/core/modules/query/ValueExpr.h
+++ b/core/modules/query/ValueExpr.h
@@ -111,6 +111,7 @@ public:
 
     // Convenience checkers
     bool isColumnRef() const;
+    bool isFunction() const;
 
     std::string sqlFragment() const;
 

--- a/core/modules/query/WhereClause.cc
+++ b/core/modules/query/WhereClause.cc
@@ -129,7 +129,7 @@ WhereClause::getRootAndTerm() {
     return std::dynamic_pointer_cast<AndTerm>(t);
 }
 
-void WhereClause::findValueExprs(ValueExprPtrVector& vector) {
+void WhereClause::findValueExprs(ValueExprPtrVector& vector) const {
     if (_tree) { _tree->findValueExprs(vector); }
 }
 

--- a/core/modules/query/WhereClause.h
+++ b/core/modules/query/WhereClause.h
@@ -78,7 +78,7 @@ public:
     std::shared_ptr<WhereClause> clone() const;
     std::shared_ptr<WhereClause> copySyntax();
 
-    void findValueExprs(ValueExprPtrVector& list);
+    void findValueExprs(ValueExprPtrVector& list) const;
 
     void resetRestrs();
     void prependAndTerm(std::shared_ptr<BoolTerm> t);


### PR DESCRIPTION
There were a few queries in other qserv unit tests that were intentionally invalid. These are included in the list of queries to execute but are commented out & have a note to be fixed in a ticket (that I'll be working on soon if not next).