### PR TITLE
DM-16218: verify QSMySQLListener adapters handle or throw grammar possibilities

### DIFF
--- a/core/modules/ccontrol/testCControl.cc
+++ b/core/modules/ccontrol/testCControl.cc
@@ -430,9 +430,6 @@ static const std::vector< std::string > QUERIES = {
        "FROM Source s1 NATURAL RIGHT JOIN Source s2 "
        "WHERE s1.bar = s2.bar;",
     "SELECT s1.foo, s2.foo AS s2_foo "
-       "FROM Source s1 NATURAL LEFT OUTER JOIN Source s2 "
-       "WHERE s1.bar = s2.bar;",
-    "SELECT s1.foo, s2.foo AS s2_foo "
        "FROM Source s1 NATURAL JOIN Source s2 "
        "WHERE s1.bar = s2.bar;",
     "SELECT * "
@@ -668,7 +665,7 @@ static const std::vector< ParseErrorQueryInfo > PARSE_ERROR_QUERIES = {
         "select objectId, sro.*, (sro.refObjectId-1)/2%pow(2,10), typeId "
             "from Source s join RefObjMatch rom using (objectId) "
             "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;",
-        "ParseException:Error parsing query, near \"%\""),
+        "ParseException:Error parsing query, near \"%\", Unhandled operator type:%"),
 
     ParseErrorQueryInfo(
         "LECT sce.filterName,sce.field "
@@ -683,11 +680,6 @@ static const std::vector< ParseErrorQueryInfo > PARSE_ERROR_QUERIES = {
            "SUM(CASE WHEN (typeId=3) THEN 1 ELSE 0 END) AS galaxyCount "
            "FROM Object WHERE rFlux_PS > 10;",
        "ParseException:qserv can not parse query, near \"CASE WHEN (typeId=3) THEN 1 ELSE 0 END\""),
-
-    // per testQueryAnaGeneral: CASE in column spec is illegal.
-    ParseErrorQueryInfo(
-        "SELECT scisql_fluxToAbMag(uFlux_PS) FROM   Object WHERE  (objectId % 100 ) = 40;",
-        "ParseException:Error parsing query, near \"%\""),
 };
 
 

--- a/core/modules/qproc/testQueryAnaGeneral.cc
+++ b/core/modules/qproc/testQueryAnaGeneral.cc
@@ -1012,7 +1012,7 @@ BOOST_AUTO_TEST_CASE(Case01_1083) {
         "from Source s join RefObjMatch rom using (objectId) "
         "join SimRefObject sro using (refObjectId) where isStar =1 limit 10;";
     // % is not valid for arithmetic in SQL92
-    char const expectedErr[] = "ParseException:Error parsing query, near \"%\"";
+    char const expectedErr[] = "ParseException:Error parsing query, near \"%\", Unhandled operator type:%";
     auto qs = queryAnaHelper.buildQuerySession(qsTest, stmt, SelectParser::ANTLR4);
     BOOST_CHECK_EQUAL(qs->getError(), expectedErr);
 #if 0 // FIXME
@@ -1067,7 +1067,7 @@ BOOST_AUTO_TEST_CASE(Case01_2006) {
     std::string stmt = "SELECT scisql_fluxToAbMag(uFlux_PS) "
         "FROM   Object WHERE  (objectId % 100 ) = 40;";
     // % is not a valid arithmetic operator in SQL92.
-    char const expectedErr[] = "ParseException:Error parsing query, near \"%\"";
+    char const expectedErr[] = "ParseException:Error parsing query, near \"%\", Unhandled operator type:%";
     auto qs = queryAnaHelper.buildQuerySession(qsTest, stmt, SelectParser::ANTLR4);
     BOOST_CHECK_EQUAL(qs->getError(), expectedErr);
 #if 0 // FIXME


### PR DESCRIPTION
adds a required function to Adapter called checkContext where subclasses
can/should check the context to be sure that non-context members are
either expected or null (or throw) so that unexpected tokens do not get
silently ignored. Members that return a context subclass typically do
not need to be checked because there will be a child adpater to handle
that context that will get called by the parse tree walker.