### PR TITLE
DM-17037: qserv_areaspec functions need to return something

### DIFF
--- a/core/modules/parser/QSMySqlListener.cc
+++ b/core/modules/parser/QSMySqlListener.cc
@@ -3988,6 +3988,9 @@ ENTER_EXIT_PARENT(FunctionArgs)
 ENTER_EXIT_PARENT(FunctionArg)
 UNHANDLED(IsExpression)
 ENTER_EXIT_PARENT(NotExpression)
+// The grammar allows for an equals operator with a decimal literal on either side of the
+// QservFunctionSpecExpression to allow qserv to be compatible with libraries that generate SQL. However, the
+// equals operator and decimal literal are ignored by qserv, and may be omitted.
 IGNORED(QservFunctionSpecExpression)
 ENTER_EXIT_PARENT(LogicalExpression)
 UNHANDLED(SoundsLikePredicate)

--- a/core/modules/parser/QSMySqlParser.g4
+++ b/core/modules/parser/QSMySqlParser.g4
@@ -19,22 +19,24 @@ expression
     | expression logicalOperator expression                         #logicalExpression
     | predicate IS NOT? testValue=(TRUE | FALSE | UNKNOWN)          #isExpression
     | predicate                                                     #predicateExpression
-    | qservFunctionSpec                                             #qservFunctionSpecExpression
+    | ((DECIMAL_LITERAL EQUAL_SYMBOL qservFunctionSpec) |
+       (qservFunctionSpec EQUAL_SYMBOL DECIMAL_LITERAL) |
+        qservFunctionSpec)                                           #qservFunctionSpecExpression
     ;
-    
+
 qservFunctionSpec
-	: (	QSERV_AREASPEC_BOX | QSERV_AREASPEC_CIRCLE  
-	  | QSERV_AREASPEC_ELLIPSE | QSERV_AREASPEC_POLY   	
+	: (	QSERV_AREASPEC_BOX | QSERV_AREASPEC_CIRCLE
+	  | QSERV_AREASPEC_ELLIPSE | QSERV_AREASPEC_POLY
 	  | QSERV_AREASPEC_HULL) '(' constants ')'
-	;  	
- 
+	;
+
 // same as MySqlParser except:
 // * adds (val, min, max) keywords to betweenPredicate
 predicate
    : predicate NOT? IN '(' (selectStatement | expressions) ')'     #inPredicate
    | predicate IS nullNotnull                                      #isNullPredicate
    | left=predicate comparisonOperator right=predicate             #binaryComparasionPredicate
-   | predicate comparisonOperator 
+   | predicate comparisonOperator
      quantifier=(ALL | ANY | SOME) '(' selectStatement ')'         #subqueryComparasionPredicate
    | val=predicate NOT? BETWEEN min=predicate AND max=predicate    #betweenPredicate
    | predicate SOUNDS LIKE predicate                               #soundsLikePredicate
@@ -42,7 +44,7 @@ predicate
    | predicate NOT? regex=(REGEXP | RLIKE) predicate               #regexpPredicate
    | (LOCAL_ID VAR_ASSIGN)? expressionAtom                         #expressionAtomPredicate
    ;
- 
+
  decimalLiteral
     : MINUS? DECIMAL_LITERAL | ZERO_DECIMAL | ONE_DECIMAL | TWO_DECIMAL
     ;


### PR DESCRIPTION
pretend qserv function resturns a decimal literal

some of the web apis we are developing to use with qserv insist on
putting "= something" before or after the qserv function (as would be
normal with any other user defined functions in the where clause).