### PR TITLE
DM-17092: look into 'group by question'

### DIFF
--- a/core/modules/ccontrol/testAntlr4GeneratedIR.cc
+++ b/core/modules/ccontrol/testAntlr4GeneratedIR.cc
@@ -81,9 +81,9 @@ BOOST_AUTO_TEST_SUITE(Suite)
  * @param container The container to push objects into.
  * @param first The object to push into the container.
  */
-template <template <typename... Args> class Container, typename... Types, typename T, typename... TArgs>
-void pusher(Container<Types...>& container, T first) {
-    container.push_back(first);
+template <typename Container, typename T>
+void pusher(Container& container, T&& first) {
+    container.push_back(std::forward<T>(first));
 }
 
 
@@ -100,10 +100,10 @@ void pusher(Container<Types...>& container, T first) {
  * @param first The object to push into the container.
  * @param args The rest of the objects to push into the container.
  */
-template <template <typename... Args> class Container, typename... Types, typename T, typename... TArgs>
-void pusher(Container<Types...>& container, T first, TArgs... args) {
-    container.push_back(first);
-    pusher(container, args...);
+template <typename Container, typename T, typename... TArgs>
+void pusher(Container& container, T&& first, TArgs&&... args) {
+    container.push_back(std::forward<T>(first));
+    pusher(container, std::forward<TArgs>(args)...);
 }
 
 

--- a/core/modules/parser/SelectParser.cc
+++ b/core/modules/parser/SelectParser.cc
@@ -391,7 +391,7 @@ void SelectParser::setup() {
     _aParser->setup();
     _aParser->run();
     _selectStmt = _aParser->getStatement();
-    LOGS(_log, LOG_LVL_TRACE, "Generated intermediate representation:" << _selectStmt);
+    LOGS(_log, LOG_LVL_TRACE, "Generated intermediate representation:" << *_selectStmt);
 }
 
 }}} // namespace lsst::qserv::parser

--- a/core/modules/query/GroupByClause.cc
+++ b/core/modules/query/GroupByClause.cc
@@ -106,13 +106,9 @@ std::string GroupByClause::getGenerated() {
 
 
 void GroupByClause::renderTo(QueryTemplate& qt) const {
-    if (_terms.get() && _terms->size() > 0) {
+    if (nullptr != _terms && _terms->size() > 0) {
         ValueExpr::render vr(qt, true);
-        int count = 0;
-        for (auto& term : *_terms) {
-            if (count++ > 0) {
-                qt.append(",");
-            }
+        for (auto&& term : *_terms) {
             vr.applyToQT(term.getExpr());
         }
     }

--- a/core/modules/query/GroupByClause.h
+++ b/core/modules/query/GroupByClause.h
@@ -94,6 +94,9 @@ public:
     typedef std::deque<GroupByTerm> List;
 
     GroupByClause() : _terms(std::make_shared<List>()) {}
+
+    GroupByClause(std::shared_ptr<List> const& terms) : _terms(terms) {}
+
     ~GroupByClause() {}
 
     std::string getGenerated();


### PR DESCRIPTION
the bug was that an extra comma when the IR was reserialzied to a string, so `GROUP BY a, b` became `GROUP BY a,,b`. 

no need to mannualy add commas, the inserter does it automatically.

also extends the antlr4 expected-value-construction unit test to support
the GroupByClause and a deque in addition to vectors in the pusher
function.