### PR TITLE
Fix for Qserv container builds

### DIFF
--- a/admin/tools/docker/latest/Dockerfile
+++ b/admin/tools/docker/latest/Dockerfile
@@ -45,6 +45,11 @@ RUN bash -lc "mkdir $STACK_DIR && cd $STACK_DIR && \
               https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh && \
               bash newinstall.sh -bt"
 
+RUN bash -lc ". $STACK_DIR/loadLSST.bash && eups distrib install pytest -t '$EUPS_TAG'"
+
+RUN bash -lc ". $STACK_DIR/loadLSST.bash && \
+              curl -sSL https://raw.githubusercontent.com/lsst/shebangtron/master/shebangtron | python"
+
 RUN bash -lc ". $STACK_DIR/loadLSST.bash && eups distrib install qserv_distrib -t '$EUPS_TAG'"
 
 COPY scripts/*.sh /qserv/scripts/


### PR DESCRIPTION
When/if we get binary installs in CI, the "shebangatron" script
needs to be run to fix up shebang lines in varios scripts/tools
after installation.  Notably for the Qserv containers, this
includes pytest.

Qserv base Dockerfile now installs pytest, then runs shebangatron,
then installs qserv and dependencies.  This works around an
intermittent fail when the db component trys to run pytest in
an environment that may have recieved some binary tarballs..