### PR TITLE
DM-21043: Qserv log diet: use named context for query ID

### DIFF
--- a/admin/templates/configuration/etc/log4cxx.czar.properties
+++ b/admin/templates/configuration/etc/log4cxx.czar.properties
@@ -11,7 +11,7 @@ log4j.rootLogger=DEBUG, CONSOLE
 # message on stderr
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] %X %-5p %c{2} (%F:%L) - %m%n
 
 log4j.appender.FILE=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.FILE.File={{QSERV_LOG_DIR}}/qserv-czar.log
@@ -20,7 +20,7 @@ log4j.appender.FILE.DatePattern="'.'yyyy-MM-dd"
 log4j.appender.FILE.MaxBackupIndex=30
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 # Follow RFC3339 data format (see http://tools.ietf.org/html/rfc3339)
-log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} %X %-5p %c{2} (%F:%L) - %m%n
 
 # Tune log at the module level
 log4j.logger.lsst.qserv.qproc=DEBUG

--- a/admin/templates/configuration/etc/log4cxx.replication.properties
+++ b/admin/templates/configuration/etc/log4cxx.replication.properties
@@ -11,8 +11,8 @@ log4j.rootLogger=DEBUG, CONSOLE
 # message on stderr
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-#log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
-log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [LWP:%X{LWP}] %-5p - %m%n
+#log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] %X %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] %X %-5p - %m%n
 log4j.appender.FILE=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.FILE.File={{QSERV_LOG_DIR}}/qserv-czar.log
 log4j.appender.FILE.DatePattern="'.'yyyy-MM-dd"
@@ -20,8 +20,8 @@ log4j.appender.FILE.DatePattern="'.'yyyy-MM-dd"
 log4j.appender.FILE.MaxBackupIndex=30
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 # Follow RFC3339 data format (see http://tools.ietf.org/html/rfc3339)
-#log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
-log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} [LWP:%X{LWP}] %-5p - %m%n
+#log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} %X %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.FILE.layout.conversionPattern=%d{yyyy-MM-ddTHH:mm:ss.SSSZ} %X %-5p - %m%n
 
 # Tune log at the module level
 log4j.logger.lsst.qserv.replica=DEBUG

--- a/admin/templates/configuration/etc/log4cxx.worker.properties
+++ b/admin/templates/configuration/etc/log4cxx.worker.properties
@@ -7,4 +7,4 @@ log4j.rootLogger=DEBUG, CONSOLE
 # Appender for xrootd log file
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] [LWP:%X{LWP}] %-5p %c{2} (%F:%L) - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%d{yyyy-MM-ddTHH:mm:ss.SSSZ}] %X %-5p %c{2} (%F:%L) - %m%n

--- a/core/modules/ccontrol/MergingHandler.cc
+++ b/core/modules/ccontrol/MergingHandler.cc
@@ -123,24 +123,23 @@ bool MergingHandler::flush(int bLen, bool& last, bool& largeResult) {
     case MsgState::RESULT_WAIT:
         {
             auto jobQuery = getJobQuery().lock();
-            auto jobId = (jobQuery != nullptr) ? jobQuery->getIdStr() : "?";
             if (!_verifyResult()) { return false; }
             if (!_setResult()) { return false; } // set _response->result
             largeResult = _response->result.largeresult();
-            LOGS(_log, LOG_LVL_DEBUG, jobId << " From:" << _wName << " _mBuf "
+            LOGS(_log, LOG_LVL_DEBUG, "From:" << _wName << " _mBuf "
                     << util::prettyCharList(_mBuf.getBuffer(), 5));
             _mBuf.zero(); // not needed after _response->result set.
             bool msgContinues = _response->result.continues();
             _state = MsgState::RESULT_RECV;
             if (msgContinues) {
-                LOGS(_log, LOG_LVL_DEBUG, jobId << " Message continues, waiting for next header.");
+                LOGS(_log, LOG_LVL_DEBUG, "Message continues, waiting for next header.");
                 _state = MsgState::RESULT_EXTRA;
                 _mBuf.setTargetSize(proto::ProtoHeaderWrap::PROTO_HEADER_SIZE);
             } else {
-                LOGS(_log, LOG_LVL_DEBUG, jobId << " Message ends, setting last=true");
+                LOGS(_log, LOG_LVL_DEBUG, "Message ends, setting last=true");
                 last = true;
             }
-            LOGS(_log, LOG_LVL_DEBUG, jobId << " Flushed msgContinues=" << msgContinues
+            LOGS(_log, LOG_LVL_DEBUG, "Flushed msgContinues=" << msgContinues
                  << " last=" << last << " for tableName=" << _tableName);
 
             auto success = _merge();

--- a/core/modules/ccontrol/UserQueryFactory.cc
+++ b/core/modules/ccontrol/UserQueryFactory.cc
@@ -109,6 +109,10 @@ UserQueryFactory::UserQueryFactory(czar::CzarConfig const& czarConfig,
     // to avoid confusion. Note that when/if clean czar restart is implemented
     // we'll need a new logic to restart query processing.
     _impl->queryMetadata->cleanup(_impl->qMetaCzarId);
+
+    // Add logging context with czar ID
+    qmeta::CzarId qMetaCzarId = _impl->qMetaCzarId;
+    LOG_MDC_INIT([qMetaCzarId]() { LOG_MDC("CZID", std::to_string(qMetaCzarId)); });
 }
 
 

--- a/core/modules/ccontrol/UserQuerySelect.cc
+++ b/core/modules/ccontrol/UserQuerySelect.cc
@@ -79,6 +79,7 @@
 #include "ccontrol/TmpTableName.h"
 #include "ccontrol/UserQueryError.h"
 #include "global/constants.h"
+#include "global/LogContext.h"
 #include "global/MsgReceiver.h"
 #include "proto/worker.pb.h"
 #include "proto/ProtoImporter.h"
@@ -310,6 +311,8 @@ void UserQuerySelect::submit() {
                  &chunkSpec, &queryTemplates,
                  &chunks, &chunksMtx, &ttn,
                  &taskMsgFactory, &addTimeSum](util::CmdData*) {
+
+            QSERV_LOGCONTEXT_QUERY(_qMetaQueryId);
 
             auto startbuildQSJ = std::chrono::system_clock::now(); // TEMPORARY-timing
             qproc::ChunkQuerySpec::Ptr cs;
@@ -562,6 +565,8 @@ void UserQuerySelect::qMetaRegister(std::string const& resultLocation, std::stri
     // register query, save its ID
     _qMetaQueryId = _queryMetadata->registerQuery(qInfo, tableNames);
     _queryIdStr = QueryIdHelper::makeIdStr(_qMetaQueryId);
+    // Add logging context with query ID
+    QSERV_LOGCONTEXT_QUERY(_qMetaQueryId);
     LOGS(_log, LOG_LVL_DEBUG, getQueryIdString() << " UserQuery registered " << _qSession->getOriginal());
 
     // update #QID# with actual query ID

--- a/core/modules/ccontrol/UserQuerySelect.cc
+++ b/core/modules/ccontrol/UserQuerySelect.cc
@@ -353,13 +353,13 @@ void UserQuerySelect::submit() {
     { // TEMPORARY-timing
         std::lock_guard<std::mutex> sumLock(_executive->sumMtx);
         LOGS(_log, LOG_LVL_DEBUG, "QSJ Total=" <<  timeDiff(startAllQSJ, endAllQSJ)
-             << "\nQSJ **sequence=" << sequence
-             << "\nQSJ   addTimeSum      =" << addTimeSum
-             << "\nQSJ     cancelLockQSEASum =" << _executive->cancelLockQSEASum
-             << "\nQSJ     jobQueryQSEASum   =" << _executive->jobQueryQSEASum
-             << "\nQSJ     addJobQSEASum     =" << _executive->addJobQSEASum
-             << "\nQSJ     trackQSEASum      =" << _executive->trackQSEASum
-             << "\nQSJ     endQSEASum        =" << _executive->endQSEASum );
+             << ", **sequence=" << sequence
+             << ", addTimeSum=" << addTimeSum
+             << ", cancelLockQSEASum=" << _executive->cancelLockQSEASum
+             << ", jobQueryQSEASum=" << _executive->jobQueryQSEASum
+             << ", addJobQSEASum=" << _executive->addJobQSEASum
+             << ", trackQSEASum=" << _executive->trackQSEASum
+             << ", endQSEASum=" << _executive->endQSEASum );
     }
 
     // we only care about per-chunk info for ASYNC queries

--- a/core/modules/czar/Czar.cc
+++ b/core/modules/czar/Czar.cc
@@ -157,7 +157,6 @@ Czar::submitQuery(std::string const& query,
         std::lock_guard<std::mutex> lock(_mutex);
         uq = _uqFactory->newUserQuery(query, defaultDb, getQdispPool(), userQueryId, msgTableName, resultDb);
     }
-    auto queryIdStr = uq->getQueryIdString();
 
     // Add logging context with query ID
     QSERV_LOGCONTEXT_QUERY(uq->getQueryId());
@@ -165,7 +164,7 @@ Czar::submitQuery(std::string const& query,
     // check for errors
     auto error = uq->getError();
     if (not error.empty()) {
-        result.errorMessage = queryIdStr + " Failed to instantiate query: " + error;
+        result.errorMessage = uq->getQueryIdString() + " Failed to instantiate query: " + error;
         return result;
     }
 
@@ -176,7 +175,7 @@ Czar::submitQuery(std::string const& query,
     auto finalizer = [uq, msgTable]() mutable {
         // Add logging context with query ID
         QSERV_LOGCONTEXT_QUERY(uq->getQueryId());
-        LOGS(_log, LOG_LVL_DEBUG, uq->getQueryIdString() << " submitting new query");
+        LOGS(_log, LOG_LVL_DEBUG, "submitting new query");
         uq->submit();
         uq->join();
         try {
@@ -185,11 +184,10 @@ Czar::submitQuery(std::string const& query,
         } catch (std::exception const& exc) {
             // TODO? if this fails there is no way to notify client, and client
             // will likely hang because table may still be locked.
-            LOGS(_log, LOG_LVL_ERROR, uq->getQueryIdString()
-                 << " Query finalization failed (client likely hangs): " << exc.what());
+            LOGS(_log, LOG_LVL_ERROR, "Query finalization failed (client likely hangs): " << exc.what());
         }
     };
-    LOGS(_log, LOG_LVL_DEBUG, queryIdStr << " starting finalizer thread for query");
+    LOGS(_log, LOG_LVL_DEBUG, "starting finalizer thread for query");
     std::thread finalThread(finalizer);
     finalThread.detach();
 
@@ -224,7 +222,7 @@ Czar::submitQuery(std::string const& query,
             result.resultQuery = resultQuery;
         }
     }
-    LOGS(_log, LOG_LVL_DEBUG, queryIdStr << " returning result to proxy: resultTable="
+    LOGS(_log, LOG_LVL_DEBUG, "returning result to proxy: resultTable="
          << result.resultTable << " messageTable=" << result.messageTable
          << " resultQuery=" << result.resultQuery);
 
@@ -333,14 +331,14 @@ Czar::_updateQueryHistory(std::string const& clientId,
     // remember query (weak pointer) in case we want to kill query
     if (uq->getQueryId() != QueryId(0)) {
         _idToQuery.insert(std::make_pair(uq->getQueryId(), uq));
-        LOGS(_log, LOG_LVL_DEBUG, uq->getQueryIdString() << " Remembering query ID: "
+        LOGS(_log, LOG_LVL_DEBUG, "Remembering query ID: "
              << uq->getQueryId() << " (new map size: "
              << _idToQuery.size() << ")");
     }
     if (not clientId.empty() and threadId >= 0) {
         ClientThreadId ctId(clientId, threadId);
         _clientToQuery.insert(std::make_pair(ctId, uq));
-        LOGS(_log, LOG_LVL_DEBUG, uq->getQueryIdString() << " Remembering query: ("
+        LOGS(_log, LOG_LVL_DEBUG, "Remembering query: ("
              << clientId << ", " << threadId << ") (new map size: "
              << _clientToQuery.size() << ")");
     }

--- a/core/modules/global/LogContext.h
+++ b/core/modules/global/LogContext.h
@@ -1,0 +1,36 @@
+/*
+ * LSST Data Management System
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_QSERV_LOGCONTEXT_H
+#define LSST_QSERV_LOGCONTEXT_H
+
+#include <string>
+#include <tuple>
+
+#include "lsst/log/Log.h"
+
+#include "global/intTypes.h"
+
+// helper macro to reduce boilerplate whe generating logging context for Query ID and Job ID
+#define QSERV_LOGCONTEXT_QUERY(qid) LOG_MDC_SCOPE("QID", qid == 0 ? "" : std::to_string(qid))
+#define QSERV_LOGCONTEXT_QUERY_JOB(qid, jobid) LOG_MDC_SCOPE("QID", qid == 0 ? "" : std::to_string(qid) + "#" + std::to_string(jobid))
+
+#endif // LSST_QSERV_LOGCONTEXT_H

--- a/core/modules/mysql/LocalInfile.cc
+++ b/core/modules/mysql/LocalInfile.cc
@@ -165,8 +165,8 @@ std::string LocalInfile::Mgr::prepareSrc(MYSQL_RES* result) {
 }
 
 
-std::string LocalInfile::Mgr::prepareSrc(std::shared_ptr<RowBuffer> const& rowBuffer, std::string const& qId) {
-    LOGS(_log, LOG_LVL_DEBUG, qId << "rowBuffer=" << rowBuffer->dump());
+std::string LocalInfile::Mgr::prepareSrc(std::shared_ptr<RowBuffer> const& rowBuffer) {
+    LOGS(_log, LOG_LVL_DEBUG, "rowBuffer=" << rowBuffer->dump());
     return insertBuffer(rowBuffer);
 }
 

--- a/core/modules/mysql/LocalInfile.h
+++ b/core/modules/mysql/LocalInfile.h
@@ -114,7 +114,7 @@ public:
     /// Prepare a local infile from a RowBuffer and link it to an
     /// auto-generated filename.
     /// @return generated filename
-    std::string prepareSrc(std::shared_ptr<RowBuffer> const& rowbuffer, std::string const& qId);
+    std::string prepareSrc(std::shared_ptr<RowBuffer> const& rowbuffer);
 
     // mysql_local_infile_handler interface ////////////////////////////////
     // These function pointers are needed to attach a handler

--- a/core/modules/qana/DuplSelectExprPlugin.cc
+++ b/core/modules/qana/DuplSelectExprPlugin.cc
@@ -119,7 +119,7 @@ DuplSelectExprPlugin::getDuplicateSelectErrors(query::SelectStmt const& stmt) co
     query::ValueExprPtrVector valueExprList = *(selectList.getValueExprList());
 
     if (LOG_CHECK_LVL(_log, LOG_LVL_TRACE)) {
-        LOGS(_log, LOG_LVL_TRACE, "Input stmt:\n" << selectList);
+        LOGS(_log, LOG_LVL_TRACE, "Input stmt: " << selectList);
     }
 
     StringVector selectExprNormalizedNames;

--- a/core/modules/qdisp/Executive.cc
+++ b/core/modules/qdisp/Executive.cc
@@ -59,6 +59,7 @@
 // Qserv headers
 #include "ccontrol/msgCode.h"
 #include "global/Bug.h"
+#include "global/LogContext.h"
 #include "global/ResourceUnit.h"
 #include "qdisp/JobQuery.h"
 #include "qdisp/MessageStore.h"
@@ -141,6 +142,8 @@ JobQuery::Ptr Executive::add(JobDescription::Ptr const& jobDesc) {
         jobQuery = JobQuery::create(thisPtr, jobDesc, jobStatus, mcf, _id);
         jobQueryQSEA = std::chrono::system_clock::now(); // TEMPORARY-timing
 
+        QSERV_LOGCONTEXT_QUERY_JOB(jobQuery->getQueryId(), jobQuery->getIdInt());
+
         {
             std::lock_guard<std::recursive_mutex> lock(_cancelled.getMutex());
             cancelLockQSEA = std::chrono::system_clock::now(); // // TEMPORARY-timing
@@ -168,6 +171,9 @@ JobQuery::Ptr Executive::add(JobDescription::Ptr const& jobDesc) {
         }
         ++_requestCount;
     }
+
+    QSERV_LOGCONTEXT_QUERY_JOB(jobQuery->getQueryId(), jobQuery->getIdInt());
+
     std::string msg = "Executive::add " + jobQuery->getIdStr() + " with path=" + jobDesc->resource().path();
     LOGS(_log, LOG_LVL_DEBUG, msg);
     //_messageStore->addMessage(jobDesc.resource().chunk(), ccontrol::MSG_MGR_ADD, msg); TODO: maybe relocate.

--- a/core/modules/qdisp/JobQuery.cc
+++ b/core/modules/qdisp/JobQuery.cc
@@ -32,6 +32,7 @@
 #include "lsst/log/Log.h"
 
 // Qserv headers
+#include "global/LogContext.h"
 #include "qdisp/Executive.h"
 #include "qdisp/QueryRequest.h"
 
@@ -64,6 +65,7 @@ JobQuery::~JobQuery() {
  * @return - false if it can not setup the job or the maximum number of attempts has been reached.
  */
 bool JobQuery::runJob() {
+    QSERV_LOGCONTEXT_QUERY_JOB(getQueryId(), getIdInt());
     LOGS(_log, LOG_LVL_DEBUG, _idStr << " runJob " << *this);
     auto executive = _executive.lock();
     if (executive == nullptr) {
@@ -118,6 +120,7 @@ bool JobQuery::runJob() {
 
 /// Cancel response handling. Return true if this is the first time cancel has been called.
 bool JobQuery::cancel() {
+    QSERV_LOGCONTEXT_QUERY_JOB(getQueryId(), getIdInt());
     LOGS(_log, LOG_LVL_DEBUG, _idStr << " JobQuery::cancel()");
     if (_cancelled.exchange(true) == false) {
         std::lock_guard<std::recursive_mutex> lock(_rmutex);
@@ -158,6 +161,7 @@ bool JobQuery::cancel() {
 /// cancelling all the jobs that it makes a difference. If either the executive,
 /// or the job has cancelled, proceeding is probably not a good idea.
 bool JobQuery::isQueryCancelled() {
+    QSERV_LOGCONTEXT_QUERY_JOB(getQueryId(), getIdInt());
     auto exec = _executive.lock();
     if (exec == nullptr) {
         LOGS(_log, LOG_LVL_WARN, _idStr << " _executive == nullptr");

--- a/core/modules/qdisp/JobQuery.h
+++ b/core/modules/qdisp/JobQuery.h
@@ -63,6 +63,7 @@ public:
     virtual ~JobQuery();
     virtual bool runJob();
 
+    QueryId getQueryId() const {return _qid; }
     int getIdInt() const { return _jobDescription->id(); }
     std::string const& getIdStr() const { return _idStr; }
     JobDescription::Ptr getDescription() { return _jobDescription; }

--- a/core/modules/qdisp/QueryRequest.h
+++ b/core/modules/qdisp/QueryRequest.h
@@ -165,6 +165,8 @@ private:
     bool _cancelled {false}; ///< true if cancelled, protected by _finishStatusMutex.
 
     std::shared_ptr<QueryRequest> _keepAlive; ///< Used to keep this object alive during race condition.
+    QueryId _qid = 0;   // for logging
+    int _jobid = -1;     // for logging
     std::string _jobIdStr {QueryIdHelper::makeIdStr(0, 0, true)}; ///< for debugging only.
     util::InstanceCount _instC{"QueryRequest"};
 

--- a/core/modules/qmeta/QMetaMysql.cc
+++ b/core/modules/qmeta/QMetaMysql.cc
@@ -311,7 +311,6 @@ QMetaMysql::registerQuery(QInfo const& qInfo,
 
     // return value of the auto-increment column
     QueryId queryId = static_cast<QueryId>(_conn->getInsertId());
-    std::string qIdStr = QueryIdHelper::makeIdStr(queryId);
 
     // register all tables, first remove all duplicates from a list
     TableNames uniqueTables = tables;
@@ -325,15 +324,15 @@ QMetaMysql::registerQuery(QInfo const& qInfo,
         query += _conn->escapeString(itr->second);
         query += "')";
 
-        LOGS(_log, LOG_LVL_DEBUG, qIdStr << " Executing query: " << query);
+        LOGS(_log, LOG_LVL_DEBUG, "Executing query: " << query);
         if (not _conn->runQuery(query, errObj)) {
-            LOGS(_log, LOG_LVL_ERROR, qIdStr << " SQL query failed: " << query);
+            LOGS(_log, LOG_LVL_ERROR, "SQL query failed: " << query);
             throw SqlError(ERR_LOC, errObj);
         }
     }
 
     trans->commit();
-    LOGS(_log, LOG_LVL_DEBUG, qIdStr << " assigned to UserQuery:" << qInfo.queryText());
+    LOGS(_log, LOG_LVL_DEBUG, "assigned to UserQuery:" << qInfo.queryText());
 
     return queryId;
 }

--- a/core/modules/qproc/QuerySession.cc
+++ b/core/modules/qproc/QuerySession.cc
@@ -145,7 +145,7 @@ void QuerySession::analyzeQuery(std::string const& sql, std::shared_ptr<query::S
         _generateConcrete();
         _applyConcretePlugins();
 
-        LOGS(_log, LOG_LVL_TRACE, "Query Plugins applied:\n " << *this);
+        LOGS(_log, LOG_LVL_TRACE, "Query Plugins applied: " << *this);
         LOGS(_log, LOG_LVL_TRACE, "ORDER BY clause for result query: " << getResultOrderBy());
 
     } catch(QueryProcessingBug& b) {
@@ -391,17 +391,17 @@ void QuerySession::print(std::ostream& os) const {
     if (_stmtMerge != nullptr) {
          mer = _stmtMerge->getQueryTemplate();
     }
-    os << "QuerySession description:\n";
-    os << "  original: " << this->_original << "\n";
-    os << "  has chunks: " << this->hasChunks() << "\n";
-    os << "  chunks: " << util::printable(this->_chunks) << "\n";
-    os << "  needs merge: " << this->needsMerge() << "\n";
-    os << "  1st parallel statement: " << par << "\n";
-    os << "  merge statement: " << mer << "\n";
+    os << "QuerySession description:";
+    os << "  original: \"" << this->_original << "\"";
+    os << "  has chunks: " << this->hasChunks();
+    os << "  chunks: " << util::printable(this->_chunks);
+    os << "  needs merge: " << this->needsMerge();
+    os << "  1st parallel statement: \"" << par << "\"";
+    os << "  merge statement: \"" << mer << "\"";
     os << "  scanRating:" << _context->scanInfo.scanRating;
     for (auto const& tbl : _context->scanInfo.infoTables) {
         os << "  ScanTable: " << tbl.db << "." << tbl.table
-           << " lock=" << tbl.lockInMemory << " rating=" << tbl.scanRating << "\n";
+           << " lock=" << tbl.lockInMemory << " rating=" << tbl.scanRating;
     }
 }
 

--- a/core/modules/wbase/Task.cc
+++ b/core/modules/wbase/Task.cc
@@ -109,7 +109,7 @@ Task::Task(Task::TaskMsgPtr const& t, SendChannel::Ptr const& sc)
     timestr[0] = '\0';
 
     allIds.add(std::to_string(_qId) + "_" + std::to_string(_jId));
-    LOGS(_log, LOG_LVL_DEBUG, "Task(...) " << _idStr << " this=" << this << " : " << allIds);
+    LOGS(_log, LOG_LVL_DEBUG, "Task(...) " << "this=" << this << " : " << allIds);
 
     // Determine which major tables this task will use.
     int const size = msg->scantable_size();
@@ -123,7 +123,7 @@ Task::Task(Task::TaskMsgPtr const& t, SendChannel::Ptr const& sc)
 
 Task::~Task() {
     allIds.remove(std::to_string(_qId) + "_" + std::to_string(_jId));
-    LOGS(_log, LOG_LVL_DEBUG, "~Task() " << _idStr << ": " << allIds);
+    LOGS(_log, LOG_LVL_DEBUG, "~Task() : " << allIds);
 }
 
 
@@ -205,7 +205,7 @@ std::chrono::milliseconds Task::finished(std::chrono::system_clock::time_point c
     if (duration.count() < 1) {
         duration = std::chrono::milliseconds{1};
     }
-    LOGS(_log, LOG_LVL_DEBUG, _idStr << " processing millisecs=" << duration.count());
+    LOGS(_log, LOG_LVL_DEBUG, "processing millisecs=" << duration.count());
     return duration;
 }
 
@@ -234,11 +234,11 @@ void Task::waitForMemMan() {
     if (_memMan != nullptr) {
         if (_memMan->lock(_memHandle, true)) {
             int errorCode = (errno == EAGAIN ? ENOMEM : errno);
-            LOGS(_log, LOG_LVL_WARN, _idStr << " mlock err=" << errorCode <<
+            LOGS(_log, LOG_LVL_WARN, "mlock err=" << errorCode <<
                     " " <<_memMan->getStatistics().logString() <<
                     " " << _memMan->getStatus(_memHandle).logString());
         }
-        LOGS(_log, LOG_LVL_DEBUG, _idStr << " waitForMemMan " <<_memMan->getStatistics().logString() <<
+        LOGS(_log, LOG_LVL_DEBUG, "waitForMemMan " <<_memMan->getStatistics().logString() <<
                                   " " << _memMan->getStatus(_memHandle).logString());
     }
     _safeToMoveRunning = true;

--- a/core/modules/wdb/QueryRunner.cc
+++ b/core/modules/wdb/QueryRunner.cc
@@ -52,6 +52,7 @@
 #include "global/constants.h"
 #include "global/DbTable.h"
 #include "global/debugUtil.h"
+#include "global/LogContext.h"
 #include "global/UnsupportedError.h"
 #include "mysql/MySqlConfig.h"
 #include "mysql/MySqlConnection.h"
@@ -131,6 +132,7 @@ util::TimerHistogram memWaitHisto("memWait Hist", {1, 5, 10, 20, 40});
 
 
 bool QueryRunner::runQuery() {
+    QSERV_LOGCONTEXT_QUERY_JOB(_task->getQueryId(), _task->getJobId());
     LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " QueryRunner::runQuery()");
 
     // Make certain our Task knows that this object is no longer in use when this function exits.

--- a/core/modules/wdb/QueryRunner.cc
+++ b/core/modules/wdb/QueryRunner.cc
@@ -111,7 +111,7 @@ bool QueryRunner::_initConnection() {
     _mysqlConn.reset(new mysql::MySqlConnection(localMySqlConfig));
 
     if (not _mysqlConn->connect()) {
-        LOGS(_log, LOG_LVL_ERROR, _task->getIdStr() << " Unable to connect to MySQL: " << localMySqlConfig);
+        LOGS(_log, LOG_LVL_ERROR, "Unable to connect to MySQL: " << localMySqlConfig);
         util::Error error(-1, "Unable to connect to MySQL; " + localMySqlConfig.toString());
         _multiError.push_back(error);
         return false;
@@ -133,7 +133,7 @@ util::TimerHistogram memWaitHisto("memWait Hist", {1, 5, 10, 20, 40});
 
 bool QueryRunner::runQuery() {
     QSERV_LOGCONTEXT_QUERY_JOB(_task->getQueryId(), _task->getJobId());
-    LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " QueryRunner::runQuery()");
+    LOGS(_log, LOG_LVL_DEBUG, "QueryRunner::runQuery()");
 
     // Make certain our Task knows that this object is no longer in use when this function exits.
     class Release {
@@ -147,7 +147,7 @@ bool QueryRunner::runQuery() {
     Release release(_task, this);
 
     if (_task->getCancelled()) {
-        LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " runQuery, task was cancelled before it started.");
+        LOGS(_log, LOG_LVL_DEBUG, "runQuery, task was cancelled before it started.");
         return false;
     }
 
@@ -160,12 +160,12 @@ bool QueryRunner::runQuery() {
     LOGS(_log, LOG_LVL_INFO, logMsg);
 
     if (_task->getCancelled()) {
-        LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " runQuery, task was cancelled after locking tables.");
+        LOGS(_log, LOG_LVL_DEBUG, "runQuery, task was cancelled after locking tables.");
         return false;
     }
 
     _setDb();
-    LOGS(_log, LOG_LVL_DEBUG,  _task->getIdStr() << " Exec in flight for Db=" << _dbName);
+    LOGS(_log, LOG_LVL_DEBUG,  "Exec in flight for Db=" << _dbName);
     bool connOk = _initConnection();
     if (!connOk) {
         // Transmit the mysql connection error to the czar, which should trigger a re-try.
@@ -187,7 +187,7 @@ bool QueryRunner::runQuery() {
     } else {
         throw UnsupportedError(_task->getIdStr() + " QueryRunner: Expected protocol > 1 in TaskMsg");
     }
-    LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " QueryRunner::runQuery() END");
+    LOGS(_log, LOG_LVL_DEBUG, "QueryRunner::runQuery() END");
     return false;
 }
 
@@ -259,7 +259,7 @@ bool QueryRunner::_fillRows(MYSQL_RES* result, int numFields, uint& rowCount, si
                 LOGS_ERROR("Message single row too large to send using protobuffer");
                 return false;
             }
-            LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " Large message size=" << tSize
+            LOGS(_log, LOG_LVL_DEBUG, "Large message size=" << tSize
                  << ", splitting message rowCount=" << rowCount);
             _transmit(false, rowCount, tSize);
             rowCount = 0;
@@ -290,7 +290,7 @@ util::TimerHistogram transmitHisto("transmit Hist", {0.1, 1, 5, 10, 20, 40});
 /// If 'last' is true, this is the last message in the result set
 /// and flags are set accordingly.
 void QueryRunner::_transmit(bool last, uint rowCount, size_t tSize) {
-    LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " _transmit last=" << last
+    LOGS(_log, LOG_LVL_DEBUG, "_transmit last=" << last
          << " rowCount=" << rowCount << " tSize=" << tSize);
     std::string resultString;
     _result->set_queryid(_task->getQueryId());
@@ -310,7 +310,7 @@ void QueryRunner::_transmit(bool last, uint rowCount, size_t tSize) {
     _result.reset(); // don't need it anymore and a new one will be made when needed..
 
     _transmitHeader(resultString);
-    LOGS(_log, LOG_LVL_DEBUG, "_transmit last=" << last << " " << _task->getIdStr()
+    LOGS(_log, LOG_LVL_DEBUG, "_transmit last=" << last
          << " resultString=" << util::prettyCharList(resultString, 5));
 
     if (!_cancelled) {
@@ -328,14 +328,14 @@ void QueryRunner::_sendBuf(xrdsvc::StreamBuffer::Ptr& streamBuf, bool last,
                            util::TimerHistogram& histo, std::string const& note) {
     bool sent = _task->sendChannel->sendStream(streamBuf, last);
     if (!sent) {
-        LOGS(_log, LOG_LVL_ERROR, _task->getIdStr() << " Failed to transmit " << note << "!");
+        LOGS(_log, LOG_LVL_ERROR, "Failed to transmit " << note << "!");
         _cancelled = true;
     } else {
         util::Timer t;
         t.start();
-        LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " _sendbuf wait start");
+        LOGS(_log, LOG_LVL_DEBUG, "_sendbuf wait start");
         streamBuf->waitForDoneWithThis(); // Block until this buffer has been sent.
-        LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " _sendbuf wait end");
+        LOGS(_log, LOG_LVL_DEBUG, "_sendbuf wait end");
         t.stop();
         auto logMsg = histo.addTime(t.getElapsed(), _task->getIdStr());
         LOGS(_log, LOG_LVL_DEBUG, logMsg);
@@ -366,7 +366,7 @@ void QueryRunner::_transmitHeader(std::string& msg) {
         xrdsvc::StreamBuffer::Ptr streamBuf(xrdsvc::StreamBuffer::createWithMove(msgBuf)); // invalidates msgBuf
         _sendBuf(streamBuf, false, transHeaderHisto, "header");
     } else {
-        LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " _transmitHeader cancelled");
+        LOGS(_log, LOG_LVL_DEBUG, "_transmitHeader cancelled");
     }
 }
 
@@ -454,8 +454,7 @@ bool QueryRunner::_dispatchChannel() {
                 sqlTimer.start();
                 MYSQL_RES* res = _primeResult(query); // This runs the SQL query.
                 sqlTimer.stop();
-                LOGS(_log, LOG_LVL_DEBUG, _task->getIdStr() << " fragment time=" << sqlTimer.getElapsed()
-                                                            << " query=" << query);
+                LOGS(_log, LOG_LVL_DEBUG, " fragment time=" << sqlTimer.getElapsed() << " query=" << query);
                 if (!res) {
                     erred = true;
                     continue;

--- a/core/modules/wpublish/ChunkInventory.cc
+++ b/core/modules/wpublish/ChunkInventory.cc
@@ -386,7 +386,7 @@ void ChunkInventory::_rebuild(SqlConnection& sc) {
     };
 
     for (auto const& query: queries) {
-        LOGS(_log, LOG_LVL_DEBUG, "Launching query:\n" << query);
+        LOGS(_log, LOG_LVL_DEBUG, "Launching query: " << query);
 
         SqlErrorObject seo;
         if (not sc.runQuery(query, seo)) {

--- a/core/modules/wsched/BlendScheduler.cc
+++ b/core/modules/wsched/BlendScheduler.cc
@@ -421,7 +421,7 @@ void BlendScheduler::_logChunkStatus() {
         {
             lock_guard<mutex> lg(_schedMtx);
             for (auto const& sched : _schedulers) {
-                if (sched != nullptr) str += sched->chunkStatusStr() + "\n";
+                if (sched != nullptr) str += sched->chunkStatusStr() + " ";
             }
         }
         LOGS(_log, LOG_LVL_DEBUG, str);

--- a/core/modules/wsched/BlendScheduler.cc
+++ b/core/modules/wsched/BlendScheduler.cc
@@ -44,6 +44,7 @@
 
 // Qserv headers
 #include "global/Bug.h"
+#include "global/LogContext.h"
 #include "proto/worker.pb.h"
 #include "util/EventThread.h"
 #include "util/Timer.h"
@@ -147,6 +148,9 @@ void BlendScheduler::queCmd(util::Command::Ptr const& cmd) {
         notify(true);
         return;
     }
+
+    QSERV_LOGCONTEXT_QUERY_JOB(task->getQueryId(), task->getJobId());
+
     if (task->msg == nullptr) {
         throw Bug("BlendScheduler::queCmd task with null message!");
     }
@@ -217,6 +221,8 @@ void BlendScheduler::commandStart(util::Command::Ptr const& cmd) {
         return;
     }
 
+    QSERV_LOGCONTEXT_QUERY_JOB(t->getQueryId(), t->getJobId());
+
     LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::commandStart " << t->getIdStr());
     wcontrol::Scheduler::Ptr s = dynamic_pointer_cast<wcontrol::Scheduler>(t->getTaskScheduler());
     if (s != nullptr) {
@@ -235,6 +241,9 @@ void BlendScheduler::commandFinish(util::Command::Ptr const& cmd) {
         LOGS(_log, LOG_LVL_WARN, "BlendScheduler::commandFinish cmd failed conversion");
         return;
     }
+
+    QSERV_LOGCONTEXT_QUERY_JOB(t->getQueryId(), t->getJobId());
+
     wcontrol::Scheduler::Ptr s = dynamic_pointer_cast<wcontrol::Scheduler>(t->getTaskScheduler());
     LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::commandFinish " << t->getIdStr());
     if (s != nullptr) {

--- a/core/modules/wsched/BlendScheduler.cc
+++ b/core/modules/wsched/BlendScheduler.cc
@@ -154,7 +154,7 @@ void BlendScheduler::queCmd(util::Command::Ptr const& cmd) {
     if (task->msg == nullptr) {
         throw Bug("BlendScheduler::queCmd task with null message!");
     }
-    LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::queCmd " << task->getIdStr());
+    LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::queCmd");
 
     util::LockGuardTimed guard(util::CommandQueue::_mx, "BlendScheduler::queCmd b");
     // Check for scan tables
@@ -200,14 +200,14 @@ void BlendScheduler::queCmd(util::Command::Ptr const& cmd) {
         if (s == nullptr) {
             // Task wasn't assigned with a scheduler, assuming it is terribly slow.
             // Assign it to the slowest scheduler so it does the least damage to other queries.
-            LOGS_WARN(task->getIdStr() << " Task had unexpected scanRating="
+            LOGS_WARN("Task had unexpected scanRating="
                       << scanPriority << " adding to scanSnail");
             s = _scanSnail;
         }
     }
     task->setTaskScheduler(s);
 
-    LOGS(_log, LOG_LVL_DEBUG, "Blend queCmd " << task->getIdStr());
+    LOGS(_log, LOG_LVL_DEBUG, "Blend queCmd");
     s->queCmd(task);
     _queries->queuedTask(task);
     _infoChanged = true;
@@ -223,12 +223,12 @@ void BlendScheduler::commandStart(util::Command::Ptr const& cmd) {
 
     QSERV_LOGCONTEXT_QUERY_JOB(t->getQueryId(), t->getJobId());
 
-    LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::commandStart " << t->getIdStr());
+    LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::commandStart");
     wcontrol::Scheduler::Ptr s = dynamic_pointer_cast<wcontrol::Scheduler>(t->getTaskScheduler());
     if (s != nullptr) {
         s->commandStart(t);
     } else {
-        LOGS(_log, LOG_LVL_ERROR, "BlendScheduler::commandStart scheduler not found " << t ->getIdStr());
+        LOGS(_log, LOG_LVL_ERROR, "BlendScheduler::commandStart scheduler not found");
     }
 
     _queries->startedTask(t);
@@ -245,11 +245,11 @@ void BlendScheduler::commandFinish(util::Command::Ptr const& cmd) {
     QSERV_LOGCONTEXT_QUERY_JOB(t->getQueryId(), t->getJobId());
 
     wcontrol::Scheduler::Ptr s = dynamic_pointer_cast<wcontrol::Scheduler>(t->getTaskScheduler());
-    LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::commandFinish " << t->getIdStr());
+    LOGS(_log, LOG_LVL_DEBUG, "BlendScheduler::commandFinish");
     if (s != nullptr) {
         s->commandFinish(t);
     } else {
-        LOGS(_log, LOG_LVL_ERROR, "BlendScheduler::commandFinish scheduler not found " << t->getIdStr());
+        LOGS(_log, LOG_LVL_ERROR, "BlendScheduler::commandFinish scheduler not found");
     }
     _infoChanged = true;
     _logChunkStatus();
@@ -479,7 +479,7 @@ int BlendScheduler::moveUserQuery(QueryId qId, SchedulerBase::Ptr const& source,
     // not tasks that were running.
     for (auto const& task : taskList) {
         // Change the scheduler to the new scheduler as normally this is done in BlendScheduler::queCmd
-        LOGS(_log, LOG_LVL_DEBUG, task->getIdStr() << " moving to " << destination->getName());
+        LOGS(_log, LOG_LVL_DEBUG, "moving to " << destination->getName());
         task->setTaskScheduler(destination);
         destination->queCmd(task);
         ++count;

--- a/core/modules/wsched/ChunkTasksQueue.cc
+++ b/core/modules/wsched/ChunkTasksQueue.cc
@@ -299,8 +299,7 @@ void ChunkTasks::queTask(wbase::Task::Ptr const& a) {
         state = "ACTIVE";
     }
     LOGS(_log, LOG_LVL_DEBUG,
-         "ChunkTasks queue "
-         << a->getIdStr()
+         "ChunkTasks queue"
          << " chunkId=" << _chunkId
          << " state=" << state
          << " active.sz=" << _activeTasks._tasks.size()

--- a/core/modules/wsched/GroupScheduler.cc
+++ b/core/modules/wsched/GroupScheduler.cc
@@ -119,8 +119,7 @@ void GroupScheduler::queCmd(util::Command::Ptr const& cmd) {
         _queue.push_back(group);
     }
     auto uqCount = _incrCountForUserQuery(t->getQueryId());
-    LOGS(_log, LOG_LVL_WARN, getName() << " queCmd " << t->getIdStr()
-         << " uqCount=" << uqCount);
+    LOGS(_log, LOG_LVL_WARN, getName() << " queCmd uqCount=" << uqCount);
     util::CommandQueue::_cv.notify_all();
 }
 

--- a/core/modules/wsched/GroupScheduler.cc
+++ b/core/modules/wsched/GroupScheduler.cc
@@ -42,6 +42,7 @@
 
 // Qserv headers
 #include "global/Bug.h"
+#include "global/LogContext.h"
 #include "proto/worker.pb.h"
 
 namespace {
@@ -102,6 +103,7 @@ void GroupScheduler::queCmd(util::Command::Ptr const& cmd) {
         LOGS(_log, LOG_LVL_WARN, getName() << " queCmd could not be converted to Task or was nullptr");
         return;
     }
+    QSERV_LOGCONTEXT_QUERY_JOB(t->getQueryId(), t->getJobId());
     std::lock_guard<std::mutex> lock(util::CommandQueue::_mx);
     // Start at the front of the queue looking for a group to accept the task.
     bool queued = false;

--- a/core/modules/xrdsvc/SsiRequest.cc
+++ b/core/modules/xrdsvc/SsiRequest.cc
@@ -35,6 +35,7 @@
 #include "lsst/log/Log.h"
 
 // Qserv headers
+#include "global/LogContext.h"
 #include "global/ResourceUnit.h"
 #include "proto/FrameBuffer.h"
 #include "proto/worker.pb.h"
@@ -121,6 +122,8 @@ void SsiRequest::execute(XrdSsiRequest& req) {
                             " chunkId=" + std::to_string(ru.chunk()));
                 return;
             }
+
+            QSERV_LOGCONTEXT_QUERY_JOB(taskMsg->queryid(), taskMsg->jobid());
 
             if (!taskMsg->has_db() || !taskMsg->has_chunkid()
                 || (ru.db()    != taskMsg->db())


### PR DESCRIPTION
Switch to using MDC for some context information instead of adding explicit info to each message.