### PR TITLE
Tickets/dm 22220

### DIFF
--- a/admin/templates/configuration/etc/my.cnf
+++ b/admin/templates/configuration/etc/my.cnf
@@ -27,6 +27,12 @@ use_stat_tables='preferably'
 # looking for the best query execution plan
 optimizer_use_condition_selectivity=3
 
+# Extend read and write connection timeouts that can be triggerd
+# by large result sets on the workers.
+net_read_timeout=900
+net_write_timeout=900
+
+
 #
 # Advanced logging
 #

--- a/core/modules/wdb/QueryRunner.cc
+++ b/core/modules/wdb/QueryRunner.cc
@@ -194,11 +194,6 @@ bool QueryRunner::runQuery() {
 MYSQL_RES* QueryRunner::_primeResult(std::string const& query) {
         bool queryOk = _mysqlConn->queryUnbuffered(query);
         if (!queryOk) {
-            /* &&&
-            util::Error error(_mysqlConn->getErrno(), _mysqlConn->getError());
-            _multiError.push_back(error);
-            return nullptr;
-            */
             sql::SqlErrorObject errObj;
             errObj.setErrNo(_mysqlConn->getErrno());
             errObj.addErrMsg("primeResult error " + _mysqlConn->getError());
@@ -465,16 +460,9 @@ bool QueryRunner::_dispatchChannel() {
             for(auto const& query : queries) {
                 util::Timer sqlTimer;
                 sqlTimer.start();
-                MYSQL_RES* res = _primeResult(query); // This runs the SQL query. throws SqlErrorObj on failure.
+                MYSQL_RES* res = _primeResult(query); // This runs the SQL query, throws SqlErrorObj on failure.
                 sqlTimer.stop();
                 LOGS(_log, LOG_LVL_DEBUG, " fragment time=" << sqlTimer.getElapsed() << " query=" << query);
-                /* &&&
-                if (!res) {
-                    // &&& this appears to be wrong, erred is never checked in a meaningful way.  sql::SqlErrorObject or _multiError.push_back?
-                    erred = true;
-                    continue;
-                }
-                */
                 if (firstResult) {
                     firstResult = false;
                     _fillSchema(res);


### PR DESCRIPTION
Really, a lot of refactoring should happen with sql, but that's beyond the scope of this ticket. QueryRunner is now checking for errors when calling mysql_fetch_row and the network read and write timeouts in mysql have been extended to 15 minutes, which should prevent the errors.