### PR TITLE
Fix Qserv container builds after conda-ization of stack

### DIFF
--- a/admin/tools/docker/conf.sh
+++ b/admin/tools/docker/conf.sh
@@ -4,7 +4,7 @@ DEPS_TAG_PREFIX="deps"
 
 # Default version of Qserv dependencies image
 # Useful for travis-ci and local build
-DEPS_TAG_DEFAULT="deps_20200424_0157"
+DEPS_TAG_DEFAULT="deps_20200603_2019"
 
 # This file contains tag of latest locally built image
 # useful for lsst-dm-ci

--- a/admin/tools/docker/deps/Dockerfile
+++ b/admin/tools/docker/deps/Dockerfile
@@ -1,16 +1,10 @@
-FROM lsstsqre/centos:7-stackbase-devtoolset-8
-
-# Provide newer git for newinstall and eupspkg
-#
-RUN yum install -y rh-git218 devtoolset-8-toolchain lsof && \
-    yum clean all && \
-    echo ". /opt/rh/rh-git218/enable" > "/etc/profile.d/rh-git218.sh"
-
+FROM lsstdm/scipipe-base:7
 
 # Install Qserv prerequisites
 #
 RUN yum install -y \
         initscripts \
+        lsof \
     && yum clean all
 
 RUN groupadd qserv && \

--- a/admin/tools/docker/deps/scripts/newinstall.sh
+++ b/admin/tools/docker/deps/scripts/newinstall.sh
@@ -36,4 +36,4 @@ mkdir /home/qserv/.conda
 mkdir "$STACK_DIR"
 cd "$STACK_DIR"
 curl -OL https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh
-bash newinstall.sh -bt
+LSST_SPLENV_REF=91cab1a bash newinstall.sh -bt


### PR DESCRIPTION
- Base Qserv containers off lsstdm/scipipe-base:7

- Set Qserv-specific conda env ref (91cab1a) before invoking
newinstall when building qserv deps container

- Update default deps container docker tag to :deps_20200602_0306,
which includes new conda environment