### PR TITLE
Restore Lua to eups table file

### DIFF
--- a/ups/qserv.table
+++ b/ups/qserv.table
@@ -1,6 +1,7 @@
 setupRequired(antlr4)
 setupRequired(db)
 setupRequired(log)
+setupRequired(lua)
 setupRequired(mariadb)
 setupRequired(mysqlproxy)
 setupRequired(partition)


### PR DESCRIPTION
We need to return to building Lua ourselves via eups, since the
conda-provided version has dynamic plugin loading disabled.