### PR TITLE
Disable tarballs for Qserv container builds

### DIFF
--- a/admin/tools/docker/conf.sh
+++ b/admin/tools/docker/conf.sh
@@ -4,7 +4,7 @@ DEPS_TAG_PREFIX="deps"
 
 # Default version of Qserv dependencies image
 # Useful for travis-ci and local build
-DEPS_TAG_DEFAULT="deps_20200604_0327"
+DEPS_TAG_DEFAULT="deps_20200619_0632"
 
 # This file contains tag of latest locally built image
 # useful for lsst-dm-ci

--- a/admin/tools/docker/deps/scripts/newinstall.sh
+++ b/admin/tools/docker/deps/scripts/newinstall.sh
@@ -36,4 +36,4 @@ mkdir /home/qserv/.conda
 mkdir "$STACK_DIR"
 cd "$STACK_DIR"
 curl -OL https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh
-LSST_SPLENV_REF=ceb6bb6 bash newinstall.sh -bt
+LSST_SPLENV_REF=ceb6bb6 bash newinstall.sh -b

--- a/admin/tools/docker/replication/container/dev/Dockerfile
+++ b/admin/tools/docker/replication/container/dev/Dockerfile
@@ -6,6 +6,6 @@ USER 0
 ENV STACK_DIR /stack
 RUN bash -lc "mkdir $STACK_DIR && cd $STACK_DIR && \
              curl -OL https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh && \
-             LSST_SPLENV_REF=d3c8cdc bash newinstall.sh -bt"
+             LSST_SPLENV_REF=ceb6bb6 bash newinstall.sh -b"
 ENV EUPS_TAG qserv-dev
 RUN /bin/bash -lc ". $STACK_DIR/loadLSST.bash && eups distrib install qserv_distrib -t $EUPS_TAG"


### PR DESCRIPTION
Use of tarballs results in broken paths being baked into configured
containers for by the Qserv configuration system for such things as
mariadb.  Disable tarballs for now.

Additionally, update outdated env ref for replication container to
latest (ceb6bb6).