### PR TITLE
Fix crash/hang in qhttp unit test teardown

### DIFF
--- a/core/modules/qhttp/Server.cc
+++ b/core/modules/qhttp/Server.cc
@@ -129,12 +129,15 @@ void Server::_accept()
     _acceptor.async_accept(
         *socket,
         [self, socket](boost::system::error_code const& ec) {
-            self->_accept(); // start accept for the next incoming connection
+            if (!self->_acceptor.is_open() || ec == asio::error::operation_aborted) {
+                return;
+            }
             if (!ec) {
                 boost::system::error_code ignore;
                 socket->set_option(ip::tcp::no_delay(true), ignore);
                 self->_readRequest(socket);
             }
+            self->_accept(); // start accept for the next incoming connection
         }
     );
 }

--- a/core/modules/qhttp/testqhttp.cc
+++ b/core/modules/qhttp/testqhttp.cc
@@ -274,7 +274,10 @@ struct QhttpFixture
     {
         server->start();
         urlPrefix = "http://localhost:" + std::to_string(server->getPort()) + "/";
-        serviceThread = std::thread([this](){ service.run(); });
+        serviceThread = std::thread([this](){ 
+            asio::io_service::work work(service);
+            service.run();
+        });
     }
 
     ~QhttpFixture()


### PR DESCRIPTION
This addresses the intermittent fail in the qhttp unit test.  Two changes were needed:

- check for acceptor shutting down condition in accept_handler chain and tail out appropriately
- add io_service::work in qhttp test fixture, so io_service thread doesn't exit between Server::stop() and Server::start()