### PR TITLE
Fix xrootd startup script pidfile issue

### DIFF
--- a/admin/templates/configuration/etc/init.d/xrootd
+++ b/admin/templates/configuration/etc/init.d/xrootd
@@ -68,21 +68,7 @@ export LSST_LOG_CONFIG="${QSERV_RUN_DIR}/etc/log4cxx.worker.properties"
 # method to guess pid file name,
 # takes single argument - program name
 pid_file_name() {
-    local pidfile=${PID_DIR}/$1.pid
-    test "${1}${NODE_TYPE}" = "cmsdmaster" && pidfile=${PID_DIR}/$1.mangr.pid
-    test "${1}${NODE_TYPE}" = "cmsdmaster-shared" && pidfile=${PID_DIR}/$1.mangr.pid
-    echo $pidfile
-}
-
-# Environment variables can vary from on container session to another and making them 
-# reliably consistent is difficult. Instead, use "mangr.pid" version if that file exists,
-# otherwise use the ".pid" file version.
-pid_file_name_check() {
-    local pf=${PID_DIR}/$1.mangr.pid
-    if [ ! -f "$pf" ]; then
-        pf=${PID_DIR}/$1.pid
-    fi
-    echo $pf
+    echo ${PID_DIR}/$1.pid
 }
 
 echo "node_type=$NODE_TYPE" >> $XRLOG
@@ -124,7 +110,7 @@ stop_service() {
 
     prog=${1##*/}
 
-    pidfile=$(pid_file_name_check $prog)
+    pidfile=$(pid_file_name $prog)
     lockfile=${QSERV_RUN_DIR}/var/lock/subsys/${prog}
 
     stop -p $pidfile -l $lockfile $prog
@@ -159,7 +145,7 @@ status_all () {
 	for service in $XRD_SERVICES
 	do
         DAEMON="${XROOTD_DIR}/bin/${service}"
-		pidfile=$(pid_file_name_check $service)
+		pidfile=$(pid_file_name $service)
 		status_of_proc -p $pidfile "$DAEMON" "$service" || ret_val=1
 	done
 	return "$ret_val"


### PR DESCRIPTION
Since update to XrootD 5.0, cmsd pidfile no longer has ".mangr"
element.  Remove legacy special plumbing for this in xrootd
init.d script.