### PR TITLE
DM-32946: add error codes and exception safety to qhttp

### DIFF
--- a/src/qhttp/Response.h
+++ b/src/qhttp/Response.h
@@ -24,6 +24,7 @@
 #define LSST_QSERV_QHTTP_RESPONSE_H
 
 // System headers
+#include <atomic>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -81,6 +82,7 @@ private:
 
     std::shared_ptr<boost::asio::ip::tcp::socket> _socket;
     boost::asio::streambuf _responsebuf;
+    std::atomic_flag _transmissionStarted;
 
     DoneCallback _doneCallback;
 

--- a/src/qhttp/Server.cc
+++ b/src/qhttp/Server.cc
@@ -24,6 +24,7 @@
 #include "qhttp/Server.h"
 
 // System headers
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -39,11 +40,13 @@
 namespace asio = boost::asio;
 namespace ip = boost::asio::ip;
 
+using namespace std::literals;
+
 namespace lsst {
 namespace qserv {
 namespace qhttp {
 
-#define DEFAULT_REQUEST_TIMEOUT_MSECS 300000 // 5 minutes
+#define DEFAULT_REQUEST_TIMEOUT 5min
 
 
 Server::Ptr Server::create(asio::io_service& io_service, unsigned short port, int backlog)
@@ -64,7 +67,7 @@ Server::Server(asio::io_service& io_service, unsigned short port, int backlog)
     _backlog(backlog),
     _acceptorEndpoint(ip::tcp::v4(), port),
     _acceptor(io_service),
-    _requestTimeout(std::chrono::milliseconds(DEFAULT_REQUEST_TIMEOUT_MSECS))
+    _requestTimeout(DEFAULT_REQUEST_TIMEOUT)
 {
 }
 

--- a/src/qhttp/Server.cc
+++ b/src/qhttp/Server.cc
@@ -96,9 +96,12 @@ void Server::addHandlers(std::initializer_list<HandlerSpec> handlers)
 }
 
 
-void Server::addStaticContent(std::string const& pattern, std::string const& rootDirectory)
+void Server::addStaticContent(
+    std::string const& pattern,
+    std::string const& rootDirectory,
+    boost::system::error_code& ec)
 {
-    StaticContent::add(*this, pattern, rootDirectory);
+    StaticContent::add(*this, pattern, rootDirectory, ec);
 }
 
 
@@ -147,13 +150,17 @@ void Server::_accept()
 }
 
 
-void Server::start()
+void Server::start(boost::system::error_code& ec)
 {
-    _acceptor.open(_acceptorEndpoint.protocol());
-    _acceptor.set_option(ip::tcp::acceptor::reuse_address(true));
-    _acceptor.bind(_acceptorEndpoint);
+    _acceptor.open(_acceptorEndpoint.protocol(), ec);
+    if (ec) return;
+    _acceptor.set_option(ip::tcp::acceptor::reuse_address(true), ec);
+    if (ec) return;
+    _acceptor.bind(_acceptorEndpoint, ec);
+    if (ec) return;
     _acceptorEndpoint.port(_acceptor.local_endpoint().port()); // preserve assigned port
-    _acceptor.listen(_backlog);
+    _acceptor.listen(_backlog, ec);
+    if (ec) return;
     _accept();
 }
 

--- a/src/qhttp/Server.h
+++ b/src/qhttp/Server.h
@@ -53,7 +53,9 @@ public:
     using Ptr = std::shared_ptr<Server>;
 
     //----- The server dispatches incoming HTTP requests to Handlers.  A Handler is a callable that receives
-    //      shared ptrs to Request and Response objects.
+    //      shared ptrs to Request and Response objects.  Exceptions thrown from handlers will be caught by
+    //      the server and translated to appropriate HTTP error responses (typically 500 Internal Server
+    //      Error).
 
     using Handler = std::function<void(Request::Ptr, Response::Ptr)>;
 

--- a/src/qhttp/Server.h
+++ b/src/qhttp/Server.h
@@ -93,7 +93,12 @@ public:
     //      header files for details.  Convenience functions are provided here to instantiate and install
     //      these.
 
-    void addStaticContent(std::string const& path, std::string const& rootDirectory);
+    void addStaticContent(
+        std::string const& path,
+        std::string const& rootDirectory,
+        boost::system::error_code& ec
+    );
+
     AjaxEndpoint::Ptr addAjaxEndpoint(std::string const& path);
 
     //----- setRequestTimeout() allows the user to override the default 5 minute start-of-request to
@@ -106,7 +111,7 @@ public:
     //      Server execution may be halted either calling stop(), or by calling asio::io_service::stop()
     //      on the associated asio::io_service.
 
-    void start();
+    void start(boost::system::error_code& ec);
 
     //----- stop() shuts down the server by closing all active sockets, including the server listening
     //      socket.  No new connections will be accepted, and handlers in progress will err out the next

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -29,46 +29,6 @@
 
 namespace fs = boost::filesystem;
 
-namespace {
-
-// Utility function used to expand and canonicalize a boost filesystem path.
-// Similar to fs::canonical(), but doesn't blow up if the tail
-// of the path doesn't exist on disk right now.  Used below to disallow serving
-// static content above/outside of root location.
-
-fs::path normalize(fs::path const& path) {
-    fs::path result;
-
-    // Start by transforming to an absolute path.
-    auto absPath = fs::absolute(path);
-
-    // Walk existing part of the path, then call canonical() on it.  This removes any
-    // symlinks, ".", or ".." from existing part, correctly handling the fiddly details
-    // about ".." in the possible presence of symlinks.
-    auto it = absPath.begin();
-    for (; exists(result / *it) && it != absPath.end(); ++it) {
-        result /= *it;
-    }
-    result = fs::canonical(result);
-
-    // Existing part is now absolute, expanded, and symlink free.  Now we can walk and
-    // add any remainder, snapping any "." or ".." by simple relative motion within
-    // the accumulating result.
-    for (; it != absPath.end(); ++it) {
-        if (*it == "..") {
-            result = result.parent_path();
-        } else if (*it == ".") {
-            continue;
-        } else {
-            result /= *it;
-        }
-    }
-
-    return result;
-}
-
-} // anon. namespace
-
 namespace lsst {
 namespace qserv {
 namespace qhttp {
@@ -103,10 +63,10 @@ void StaticContent::add(
 
         // Defend against relative paths attempting to traverse above root directory.
         fs::path requestPath = rootPath;
-        requestPath /= request->path;
-        requestPath = normalize(requestPath);
+        requestPath /= request->params["0"];
+        requestPath = fs::weakly_canonical(requestPath);
         if (!boost::starts_with(requestPath, rootPath)) {
-            response->sendStatus(401);
+            response->sendStatus(403);
             return;
         }
 
@@ -121,6 +81,14 @@ void StaticContent::add(
             requestPath /= "index.htm";
         }
 
+        // Handle the oft-expected 404 case here explicitly, rather than as an exception.
+        if (!fs::exists(requestPath)) {
+            response->sendStatus(404);
+            return;
+        }
+
+        // Other error cases are unexpected/unusual; Response::sendFile() can throw an exceptions to be caught
+        // by top-level handler in Server::_dispatchRequest() if anything else goes wrong.
         response->sendFile(requestPath);
     });
 }

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -53,9 +53,9 @@ void StaticContent::add(
 
     server.addHandler("GET", pattern, [rootPath](Request::Ptr request, Response::Ptr response) {
 
-        // Don't let resource paths with embedded nulls past this point, since boost::filesystem
-        // does not treat them consistently.  Assume we aren't intentionally serving any static
-        // content with embedded nulls in the path, and just return a 404 if we find any.
+        // Don't let resource paths with embedded nulls past this point, since boost::filesystem does not
+        // treat them consistently.  Assume we aren't intentionally serving any static content with embedded
+        // nulls in the path, and just return a 404 if we find any.
         if (request->path.find('\0') != std::string::npos) {
             response->sendStatus(404);
             return;
@@ -70,8 +70,7 @@ void StaticContent::add(
             return;
         }
 
-        // Redirect directory paths without trailing "/", and default to "index.html"
-        // within directory paths otherwise.
+        // Redirect directory paths without trailing "/", and default to "index.html" within directory paths.
         if (fs::is_directory(requestPath)) {
             if (!boost::ends_with(request->path, "/")) {
                 response->headers["Location"] = request->path + "/";

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -71,6 +71,8 @@ void StaticContent::add(
         }
 
         // Redirect directory paths without trailing "/", and default to "index.html" within directory paths.
+        // Note: according to boost documentation, fs:is_directory() returns false and does not throw on a
+        // file not found condition; in that case we will fall through to the next block below.
         if (fs::is_directory(requestPath)) {
             if (!boost::ends_with(request->path, "/")) {
                 response->headers["Location"] = request->path + "/";

--- a/src/qhttp/StaticContent.h
+++ b/src/qhttp/StaticContent.h
@@ -26,6 +26,9 @@
 // System headers
 #include <string>
 
+// Third-party headers
+#include "boost/system/error_code.hpp"
+
 // Local headers
 #include "qhttp/Server.h"
 
@@ -46,7 +49,12 @@ public:
     //      list of these.)  Note that the Server::addStaticContent() convenience method would typically be
     //      called in preference to calling the add() method here directly.
 
-    static void add(Server& server, std::string const& path, std::string const& rootDirectory);
+    static void add(
+        Server& server,
+        std::string const& path,
+        std::string const& rootDirectory,
+        boost::system::error_code& ec
+    );
 
 };
 

--- a/src/qhttp/StaticContent.h
+++ b/src/qhttp/StaticContent.h
@@ -43,11 +43,11 @@ public:
     //----- StaticContent is a specialized Handler to handle the common case of serving a tree of static
     //      content rooted beneath a single file system directory.  add() will add an instance to the
     //      specified Server which will responding to GET requests on URL's that prefix match the pattern
-    //      specified in the "path" argument and postfix match paths to existing files under rootDirectory
-    //      in the local filesystem.  Content-Type of responses is inferred from the file extension for
-    //      several common file extensions (see the file type map near the top of Response.cc for a complete
-    //      list of these.)  Note that the Server::addStaticContent() convenience method would typically be
-    //      called in preference to calling the add() method here directly.
+    //      specified in the "path" argument and postfix match paths to existing files under rootDirectory in
+    //      the local filesystem.  Content-Type of responses is inferred from the file extension for several
+    //      common file extensions (see the file type map near the top of Response.cc for a complete list of
+    //      these.)  Note that the Server::addStaticContent() convenience method would typically be called in
+    //      preference to calling the add() method here directly.
 
     static void add(
         Server& server,

--- a/src/qhttp/testqhttp.cc
+++ b/src/qhttp/testqhttp.cc
@@ -33,6 +33,7 @@
 
 #include "boost/asio.hpp"
 #include "boost/algorithm/string/join.hpp"
+#include "boost/format.hpp"
 #include "boost/range/adaptors.hpp"
 #include "curl/curl.h"
 
@@ -591,10 +592,55 @@ BOOST_FIXTURE_TEST_CASE(relative_url_containment, QhttpFixture)
 
     //----- test relative path containment
 
-    content = asioHttpGet("/..", 401, "text/html");
-    BOOST_TEST(content.find("401") != std::string::npos);
-    content = asioHttpGet("/css/../..", 401, "text/html");
-    BOOST_TEST(content.find("401") != std::string::npos);
+    content = asioHttpGet("/..", 403, "text/html");
+    BOOST_TEST(content.find("403") != std::string::npos);
+    content = asioHttpGet("/css/../..", 403, "text/html");
+    BOOST_TEST(content.find("403") != std::string::npos);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(exception_handling, QhttpFixture)
+{
+    boost::system::error_code ec;
+    std::string content;
+
+    server->addStaticContent("/etc/*", "/etc/", ec);
+    BOOST_TEST(!ec);
+
+    server->addHandler("GET", "/throw/:errno", [](qhttp::Request::Ptr req, qhttp::Response::Ptr resp){
+        int ev = std::stoi(req->params["errno"]); // will throw if can't parse int
+        throw(boost::system::system_error(ev, boost::system::generic_category()));
+    });
+
+    server->addHandler("GET", "/throw-after-send", [](qhttp::Request::Ptr req, qhttp::Response::Ptr resp){
+        resp->sendStatus(200);
+        throw std::runtime_error("test");
+    });
+
+    start();
+
+    // Test EACCESS thrown from static file handler
+
+    content = asioHttpGet("/etc/shadow", 403, "text/html");
+    BOOST_TEST(content.find("403") != std::string::npos);
+
+    // Test exceptions thrown from user handler
+
+    content = asioHttpGet((boost::format("/throw/%1%") % EACCES).str(), 403, "text/html");
+    BOOST_TEST(content.find("403") != std::string::npos);
+
+    content = asioHttpGet((boost::format("/throw/%1%") % ENOENT).str(), 500, "text/html");
+    BOOST_TEST(content.find("500") != std::string::npos);
+
+    content = asioHttpGet("/throw/make-stoi-throw-invalid-argument", 500, "text/html");
+    BOOST_TEST(content.find("500") != std::string::npos);
+
+    // Test exception thrown in user handler after calling a request send() method.  This would be a user
+    // programming error, but we defend against it anyway.  From the point of view of the HTTP client, the
+    // response provided by the handler before the exception goes through.
+
+    content = asioHttpGet("/throw-after-send", 200, "text/html");
+    BOOST_TEST(content.find("200") != std::string::npos);
 }
 
 

--- a/src/replica/HttpProcessor.cc
+++ b/src/replica/HttpProcessor.cc
@@ -607,7 +607,12 @@ void HttpProcessor::registerServices() {
                     context_ + "a value of the httpRoot parameter '"
                     + self->_processorConfig.httpRoot + "' doesn't refer to a folder."); 
         }
-        httpServer()->addStaticContent("/*", self->_processorConfig.httpRoot);
+        httpServer()->addStaticContent("/*", self->_processorConfig.httpRoot, ec);
+        if (ec.value() != 0) {
+            throw runtime_error(
+                    context_+ "failed to install static handler for httpRoot parameter '"
+                    + self->_processorConfig.httpRoot + "', error: " + ec.message());
+        }
     }
 
 }

--- a/src/replica/HttpSvc.cc
+++ b/src/replica/HttpSvc.cc
@@ -75,7 +75,9 @@ void HttpSvc::run() {
     // any BOOST ASIO threads. This will prevent threads from finishing due to a lack of
     // work to be done.
     registerServices();
-    _httpServer->start();
+
+    boost::system::error_code ec;
+    _httpServer->start(ec);
 
     // Launch all threads in a dedicated pool.
     auto const self = shared_from_this();

--- a/src/replica/QhttpTestApp.cc
+++ b/src/replica/QhttpTestApp.cc
@@ -187,7 +187,8 @@ int QhttpTestApp::runImpl() {
 
     // Make sure the service started before launching any BOOST ASIO threads.
     // This will prevent threads from finishing due to a lack of work to be done.
-    httpServer->start();
+    boost::system::error_code ec;
+    httpServer->start(ec);
 
     // Launch all threads in the pool
     vector<shared_ptr<thread>> threads(_numThreads);


### PR DESCRIPTION
Add error codes to qhttp API calls which could err.  Add exception handler to server to catch exceptions that may occur in user handler code.

NOTE: logging to be added in subsequent ticket