### PR TITLE
DM-33350: add support for templated entrypoint command options

### DIFF
--- a/admin/local/docker/compose/docker-compose.yml
+++ b/admin/local/docker/compose/docker-compose.yml
@@ -92,7 +92,7 @@ services:
           entrypoint worker-xrootd
           --db-uri mysql://qsmaster@127.0.0.1:3306
           --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306
-          --vnid-config "@/usr/local/lib64/libreplica.so mysql://qsmaster@127.0.0.1:3306/qservw_worker 0 0"
+          --vnid-config "@/usr/local/lib64/libreplica.so {{db_uri}}/qservw_worker 0 0"
           --cmsd-manager-name manager-xrootd
           --cmsd-manager-count 1
           --mysql-monitor-password CHANGEME_MONITOR
@@ -171,12 +171,13 @@ services:
         << : *worker-xrootd
         command: >
           entrypoint --log-level DEBUG worker-xrootd
-          --db-uri mysql://qsmaster@127.0.0.1:3306?socket=/qserv/mariadb/run/mysqld.sock
-          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306?socket=/qserv/mariadb/run/mysqld.sock
+          --db-uri mysql://qsmaster@127.0.0.1:3306?socket={{db_socket}}
+          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306?socket={{db_socket}}
           --vnid-config "@/usr/local/lib64/libreplica.so mysql://root:CHANGEME@localhost:3306/qservw_worker 0 0"
           --cmsd-manager-name manager-xrootd
           --cmsd-manager-count 1
           --mysql-monitor-password CHANGEME_MONITOR
+          --targs db_socket=/qserv/mariadb/run/mysqld.sock
         environment:
             << : *log-environment
         volumes:
@@ -306,8 +307,9 @@ services:
         init: true
         command: >
           entrypoint --log-level DEBUG proxy
-          --db-uri mysql://qsmaster@127.0.0.1:3306?socket=/qserv/mariadb/run/mysqld.sock
-          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306?socket=/qserv/mariadb/run/mysqld.sock
+          --db-uri mysql://qsmaster@127.0.0.1:3306?socket={{db_socket}}
+          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306?socket={{db_socket}}
+          --targs db_socket=/qserv/mariadb/run/mysqld.sock
           --xrootd-manager manager-xrootd
         environment:
             << : *log-environment

--- a/src/admin/python/lsst/qserv/admin/cli/entrypoint.py
+++ b/src/admin/python/lsst/qserv/admin/cli/entrypoint.py
@@ -30,7 +30,7 @@ from functools import partial
 import logging
 import os
 import sys
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from click.decorators import pass_context
 
@@ -65,6 +65,7 @@ from .options import (
     xrootd_manager_option,
 )
 from . import utils
+from .render_targs import render_targs
 from . import script
 from ..watcher import watch
 
@@ -426,35 +427,22 @@ def delete_database(repl_ctrl_uri: str, database: str, admin: bool) -> None:
 @targs_options()
 @cmd_options()
 @options_file_option()
-def proxy(
-    ctx: click.Context,
-    db_uri: str,
-    db_admin_uri: str,
-    mysql_monitor_password: str,
-    repl_ctl_dn: str,
-    xrootd_manager: str,
-    proxy_backend_address: str,
-    proxy_cfg_file: str,
-    proxy_cfg_path: str,
-    czar_cfg_file: str,
-    czar_cfg_path: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    cmd: str,
-) -> None:
+def proxy(ctx: click.Context, **kwargs: Any) -> None:
     """Start as a qserv-proxy node.
     """
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_proxy(
-        targs=utils.targs(ctx),
-        db_uri=db_uri,
-        db_admin_uri=db_admin_uri,
-        repl_ctl_dn=repl_ctl_dn,
-        proxy_backend_address=proxy_backend_address,
-        proxy_cfg_file=proxy_cfg_file,
-        proxy_cfg_path=proxy_cfg_path,
-        czar_cfg_file=czar_cfg_file,
-        czar_cfg_path=czar_cfg_path,
-        cmd=cmd,
+        targs=targs,
+        db_uri=targs["db_uri"],
+        db_admin_uri=targs["db_admin_uri"],
+        repl_ctl_dn=targs["repl_ctl_dn"],
+        proxy_backend_address=targs["proxy_backend_address"],
+        proxy_cfg_file=targs["proxy_cfg_file"],
+        proxy_cfg_path=targs["proxy_cfg_path"],
+        czar_cfg_file=targs["czar_cfg_file"],
+        czar_cfg_path=targs["czar_cfg_path"],
+        cmd=targs["cmd"],
     )
 
 
@@ -479,22 +467,16 @@ def proxy(
 @targs_options()
 @cmd_options()
 @options_file_option()
-def cmsd_manager(
-    ctx: click.Context,
-    cms_delay_servers: int,
-    cmsd_manager_cfg_file: str,
-    cmsd_manager_cfg_path: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    cmd: str,
-) -> None:
+def cmsd_manager(ctx: click.Context, **kwargs: Any) -> None:
     """Start as a cmsd manager node.
     """
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_manager_cmsd(
-        targs=utils.targs(ctx),
-        cmsd_manager_cfg_file=cmsd_manager_cfg_file,
-        cmsd_manager_cfg_path=cmsd_manager_cfg_path,
-        cmd=cmd,
+        targs=targs,
+        cmsd_manager_cfg_file=targs["cmsd_manager_cfg_file"],
+        cmsd_manager_cfg_path=targs["cmsd_manager_cfg_path"],
+        cmd=targs["cmd"],
     )
 
 
@@ -517,23 +499,16 @@ def cmsd_manager(
 @targs_options()
 @cmd_options()
 @options_file_option()
-def xrootd_manager(
-    ctx: click.Context,
-    cmsd_manager_name: str,
-    cmsd_manager_count: str,
-    xrootd_manager_cfg_file: str,
-    xrootd_manager_cfg_path: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    cmd: str,
-) -> None:
+def xrootd_manager(ctx: click.Context, **kwargs: Any) -> None:
     """Start as an xrootd manager node.
     """
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_xrootd_manager(
-        targs=utils.targs(ctx),
-        xrootd_manager_cfg_file=xrootd_manager_cfg_file,
-        xrootd_manager_cfg_path=xrootd_manager_cfg_path,
-        cmd=cmd,
+        targs=targs,
+        xrootd_manager_cfg_file=targs["xrootd_manager_cfg_file"],
+        xrootd_manager_cfg_path=targs["xrootd_manager_cfg_path"],
+        cmd=targs["cmd"],
     )
 
 
@@ -551,30 +526,18 @@ def xrootd_manager(
 @targs_options()
 @cmd_options()
 @options_file_option()
-def worker_cmsd(
-    ctx: click.Context,
-    cmsd_manager_name: str,
-    cmsd_manager_count: str,
-    vnid_config: str,
-    debug_port: Optional[int],
-    db_uri: str,
-    cmsd_worker_cfg_file: str,
-    cmsd_worker_cfg_path: str,
-    xrdssi_cfg_file: str,
-    xrdssi_cfg_path: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    cmd: str,
-) -> None:
+def worker_cmsd(ctx: click.Context, **kwargs: Any) -> None:
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_worker_cmsd(
-        targs=utils.targs(ctx),
-        debug_port=debug_port,
-        db_uri=db_uri,
-        cmsd_worker_cfg_file=cmsd_worker_cfg_file,
-        cmsd_worker_cfg_path=cmsd_worker_cfg_path,
-        xrdssi_cfg_file=xrdssi_cfg_file,
-        xrdssi_cfg_path=xrdssi_cfg_path,
-        cmd=cmd,
+        targs=targs,
+        debug_port=targs["debug_port"],
+        db_uri=targs["db_uri"],
+        cmsd_worker_cfg_file=targs["cmsd_worker_cfg_file"],
+        cmsd_worker_cfg_path=targs["cmsd_worker_cfg_path"],
+        xrdssi_cfg_file=targs["xrdssi_cfg_file"],
+        xrdssi_cfg_path=targs["xrdssi_cfg_path"],
+        cmd=targs["cmd"],
     )
 
 
@@ -596,39 +559,23 @@ def worker_cmsd(
 @targs_options()
 @cmd_options()
 @options_file_option()
-def worker_xrootd(
-    ctx: click.Context,
-    debug_port: Optional[int],
-    db_uri: str,
-    db_admin_uri: str,
-    vnid_config: str,
-    cmsd_manager_name: str,
-    cmsd_manager_count: int,
-    repl_ctl_dn: str,
-    mysql_monitor_password: str,
-    db_qserv_user: str,
-    cmsd_worker_cfg_file: str,
-    cmsd_worker_cfg_path: str,
-    xrdssi_cfg_file: str,
-    xrdssi_cfg_path: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    cmd: str,
-) -> None:
+def worker_xrootd(ctx: click.Context, **kwargs: Any) -> None:
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_worker_xrootd(
-        targs=utils.targs(ctx),
-        debug_port=debug_port,
-        db_uri=db_uri,
-        db_admin_uri=db_admin_uri,
-        vnid_config=vnid_config,
-        repl_ctl_dn=repl_ctl_dn,
-        mysql_monitor_password=mysql_monitor_password,
-        db_qserv_user=db_qserv_user,
-        cmsd_worker_cfg_file=cmsd_worker_cfg_file,
-        cmsd_worker_cfg_path=cmsd_worker_cfg_path,
-        xrdssi_cfg_file=xrdssi_cfg_file,
-        xrdssi_cfg_path=xrdssi_cfg_path,
-        cmd=cmd,
+        targs=targs,
+        debug_port=targs["debug_port"],
+        db_uri=targs["db_uri"],
+        db_admin_uri=targs["db_admin_uri"],
+        vnid_config=targs["vnid_config"],
+        repl_ctl_dn=targs["repl_ctl_dn"],
+        mysql_monitor_password=targs["mysql_monitor_password"],
+        db_qserv_user=targs["db_qserv_user"],
+        cmsd_worker_cfg_file=targs["cmsd_worker_cfg_file"],
+        cmsd_worker_cfg_path=targs["cmsd_worker_cfg_path"],
+        xrdssi_cfg_file=targs["xrdssi_cfg_file"],
+        xrdssi_cfg_path=targs["xrdssi_cfg_path"],
+        cmd=targs["cmd"],
     )
 
 
@@ -654,24 +601,15 @@ def worker_xrootd(
 @targs_options()
 @run_option()
 @options_file_option()
-def worker_repl(
-    ctx: click.Context,
-    db_admin_uri: str,
-    repl_connection: str,
-    debug_port: Optional[int],
-    cmd: str,
-    config: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    run: bool,
-) -> None:
+def worker_repl(ctx: click.Context, **kwargs: Any) -> None:
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_worker_repl(
-        targs=utils.targs(ctx),
-        db_admin_uri=db_admin_uri,
-        repl_connection=repl_connection,
-        debug_port=debug_port,
-        cmd=cmd,
-        run=run,
+        db_admin_uri=targs["db_admin_uri"],
+        repl_connection=targs["repl_connection"],
+        debug_port=targs["debug_port"],
+        cmd=targs["cmd"],
+        run=targs["run"],
     )
 
 
@@ -718,29 +656,17 @@ def worker_repl(
 @targs_options()
 @run_option()
 @options_file_option()
-def replication_controller(
-    ctx: click.Context,
-    db_uri: str,
-    db_admin_uri: str,
-    workers: List[str],
-    xrootd_manager: str,
-    log_cfg_file: str,
-    cmd: str,
-    http_root: str,
-    qserv_czar_db: str,
-    targs: Dict[str, str],
-    targs_file: str,
-    run: bool,
-) -> None:
+def replication_controller(ctx: click.Context, **kwargs: Any) -> None:
     """Start as a replication controller node."""
+    targs = utils.targs(ctx)
+    targs = render_targs(targs)
     script.enter_replication_controller(
-        targs=utils.targs(ctx),
-        db_uri=db_uri,
-        db_admin_uri=db_admin_uri,
-        workers=workers,
-        log_cfg_file=log_cfg_file,
-        cmd=cmd,
-        run=run,
+        db_uri=targs["db_uri"],
+        db_admin_uri=targs["db_admin_uri"],
+        workers=targs["workers"],
+        log_cfg_file=targs["log_cfg_file"],
+        cmd=targs["cmd"],
+        run=targs["run"],
     )
 
 

--- a/src/admin/python/lsst/qserv/admin/cli/render_targs.py
+++ b/src/admin/python/lsst/qserv/admin/cli/render_targs.py
@@ -1,0 +1,81 @@
+# This file is part of qserv.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+
+"""This module contains functions for rendering jinja template
+values in values passed into the `entrypoint` command line."""
+
+
+from copy import copy
+import jinja2
+
+from .utils import Targs
+
+
+class UnresolvableTemplate(RuntimeError):
+    """Exception class used by `render` when a template value can not be
+    resolved."""
+    pass
+
+
+def render_targs(targs: Targs) -> Targs:
+    """Go through a dict whose values may contain jinja templates that are
+    other keys in the dict, and resolve the values.
+
+    Will raise if any template value(s) can not be resolved. Causes include:
+    * the key is not present
+    * there is a circular reference where 2 or more keys refer to eachother.
+
+    Parameters
+    ----------
+    targs :
+        The dict to resolve.
+
+    Returns
+    -------
+    resolved_targs :
+        The dict, resolved.
+
+    Raises
+    ------
+    UnresolvableTemplate
+        If a value in the template can not be resolved.
+    """
+    rendered = copy(targs)
+    while True:
+        changed = False
+        for k, v in rendered.items():
+            if not isinstance(v, str):
+                continue
+            if "{{" in v:
+                t = jinja2.Template(v, undefined=jinja2.StrictUndefined)
+                try:
+                    rendered[k] = t.render(rendered)
+                    changed = True
+                except jinja2.exceptions.UndefinedError as e:
+                    raise UnresolvableTemplate(f"Missing template value: {str(e)}")
+        if not changed:
+            break
+    if any([isinstance(v, str) and "{{" in v for v in rendered.values()]):
+        raise UnresolvableTemplate(
+           "Could not resolve inputs: "
+           f"{', '.join([f'{k}={targs[k]}' for k, v in rendered.items() if '{{' in v])}"
+        )
+    return rendered

--- a/src/admin/python/lsst/qserv/admin/cli/utils.py
+++ b/src/admin/python/lsst/qserv/admin/cli/utils.py
@@ -27,14 +27,14 @@ import copy
 import logging
 import os
 import traceback
-from typing import cast, Dict, List, Sequence, Tuple, Union
+from typing import Any, cast, Dict, List, Sequence, Tuple, Union
 import yaml
 
 
 _log = logging.getLogger(__name__)
 
 
-Targs = Dict[str, Union[str, Sequence[str]]]
+Targs = Dict[str, Any]
 
 
 def split_kv(values: Sequence[str]) -> Dict[str, str]:

--- a/src/admin/tests/test_render_targs.py
+++ b/src/admin/tests/test_render_targs.py
@@ -1,0 +1,83 @@
+# This file is part of qserv.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+
+import unittest
+
+from lsst.qserv.admin.cli.render_targs import render_targs, UnresolvableTemplate
+
+
+class RenderTargsTestCase(unittest.TestCase):
+
+    def testMutualReference(self):
+        """Test for failure when targs refer directly to each other."""
+        with self.assertRaises(UnresolvableTemplate) as r:
+            render_targs({"a": "{{b}}", "b": "{{a}}"})
+        self.assertIn("a={{b}}, b={{a}}", str(r.exception))
+
+    def testCircularReference(self):
+        """Test for failure when there is a circular reference in targs."""
+        with self.assertRaises(UnresolvableTemplate) as r:
+            render_targs({"a": "{{b}}", "b": "{{c}}", "c": "{{a}}"})
+        self.assertIn("a={{b}}, b={{c}}, c={{a}}", str(r.exception))
+
+    def testSelfReference(self):
+        """Test for failure when a targ refers to itself."""
+        with self.assertRaises(UnresolvableTemplate) as r:
+            render_targs({"a": "{{a}}"})
+        self.assertIn("a={{a}}", str(r.exception))
+
+    def testMissingValue(self):
+        """Test for failure when a template value is not provided."""
+        with self.assertRaises(UnresolvableTemplate) as r:
+            render_targs({"a": "{{b}}"})
+        self.assertIn("Missing template value:", str(r.exception))
+
+    def testList(self):
+        """Verify that lists can be used as values and manipulated by the template."""
+        self.assertEqual(
+            render_targs({"a": "{{b|join(' ')}}", "b": ["foo", "bar"]}),
+            {"a": "foo bar", "b": ["foo", "bar"]}
+        )
+
+    def testResolves(self):
+        """Verify that a dict with legal values resolves correctly."""
+        self.assertEqual(
+            render_targs({"a": "{{b}}", "b": "{{c}}", "c": "d"}),
+            {"a": "d", "b": "d", "c": "d"}
+        )
+
+    def testNone(self):
+        """Test that a dict with None as a value resolves correctly."""
+        self.assertEqual(
+            render_targs({"a": None}),
+            {"a": None}
+        )
+
+    def testBool(self):
+        """Test that a dict with a bool as a value resolves correctly."""
+        self.assertEqual(
+            render_targs({"a": True}),
+            {"a": True}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves templates in all arguments in entrypoint.py, before
forwarding work on to script (implementation) fucntions.
This allows code in impl fucntions to be simpler, and
also fails early if a template can not be resolved.