### PR TITLE
DM-33088: qhttp logging

### DIFF
--- a/src/qhttp/AjaxEndpoint.cc
+++ b/src/qhttp/AjaxEndpoint.cc
@@ -24,23 +24,31 @@
 #include "qhttp/AjaxEndpoint.h"
 
 // Local headers
+#include "lsst/log/Log.h"
+#include "qhttp/LogHelpers.h"
 #include "qhttp/Request.h"
 #include "qhttp/Response.h"
 #include "qhttp/Server.h"
+
+namespace {
+    LOG_LOGGER _log = LOG_GET("lsst.qserv.qhttp");
+}
 
 namespace lsst {
 namespace qserv {
 namespace qhttp {
 
 
-AjaxEndpoint::AjaxEndpoint()
+AjaxEndpoint::AjaxEndpoint(std::shared_ptr<Server> server)
+:
+    _server(server)
 {
 }
 
 
 AjaxEndpoint::Ptr AjaxEndpoint::add(Server& server, std::string const& path)
 {
-    auto aep = std::shared_ptr<AjaxEndpoint>(new AjaxEndpoint);
+    auto aep = std::shared_ptr<AjaxEndpoint>(new AjaxEndpoint(std::shared_ptr<Server>(&server)));
     server.addHandler("GET", path, [aep](Request::Ptr request, Response::Ptr response) {
         std::lock_guard<std::mutex> lock{aep->_pendingResponsesMutex};
         aep->_pendingResponses.push_back(response);

--- a/src/qhttp/AjaxEndpoint.cc
+++ b/src/qhttp/AjaxEndpoint.cc
@@ -20,6 +20,9 @@
  * see <https://www.lsstcorp.org/LegalNotices/>.
  */
 
+// System headers
+#include <utility>
+
 // Class-header
 #include "qhttp/AjaxEndpoint.h"
 
@@ -39,16 +42,16 @@ namespace qserv {
 namespace qhttp {
 
 
-AjaxEndpoint::AjaxEndpoint(std::shared_ptr<Server> server)
+AjaxEndpoint::AjaxEndpoint(std::shared_ptr<Server> const server)
 :
-    _server(server)
+    _server(std::move(server))
 {
 }
 
 
 AjaxEndpoint::Ptr AjaxEndpoint::add(Server& server, std::string const& path)
 {
-    auto aep = std::shared_ptr<AjaxEndpoint>(new AjaxEndpoint(std::shared_ptr<Server>(&server)));
+    auto const aep = std::shared_ptr<AjaxEndpoint>(new AjaxEndpoint(std::shared_ptr<Server>(&server)));
     server.addHandler("GET", path, [aep](Request::Ptr request, Response::Ptr response) {
         std::lock_guard<std::mutex> lock{aep->_pendingResponsesMutex};
         aep->_pendingResponses.push_back(response);

--- a/src/qhttp/AjaxEndpoint.h
+++ b/src/qhttp/AjaxEndpoint.h
@@ -58,9 +58,9 @@ public:
 
 private:
 
-    AjaxEndpoint(std::shared_ptr<Server> server);
+    AjaxEndpoint(std::shared_ptr<Server> const server);
 
-    std::shared_ptr<Server> _server;
+    std::shared_ptr<Server> const _server;
 
     std::vector<Response::Ptr> _pendingResponses;
     std::mutex _pendingResponsesMutex;

--- a/src/qhttp/AjaxEndpoint.h
+++ b/src/qhttp/AjaxEndpoint.h
@@ -58,7 +58,9 @@ public:
 
 private:
 
-    AjaxEndpoint();
+    AjaxEndpoint(std::shared_ptr<Server> server);
+
+    std::shared_ptr<Server> _server;
 
     std::vector<Response::Ptr> _pendingResponses;
     std::mutex _pendingResponsesMutex;

--- a/src/qhttp/CMakeLists.txt
+++ b/src/qhttp/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(qhttp PRIVATE
 )
 
 target_link_libraries(qhttp PUBLIC
+    log
     Boost::filesystem
     Boost::regex
     Boost::system

--- a/src/qhttp/LogHelpers.h
+++ b/src/qhttp/LogHelpers.h
@@ -1,0 +1,89 @@
+/*
+ * LSST Data Management System
+ * Copyright 2022 AURA/LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_QSERV_QHTTP_LOGHELPERS_H
+#define LSST_QSERV_QHTTP_LOGHELPERS_H
+
+// System headers
+#include <iostream>
+#include <memory>
+
+// Local headers
+#include "qhttp/AjaxEndpoint.h"
+#include "qhttp/Server.h"
+
+// Third-party headers
+#include "boost/asio.hpp"
+
+namespace lsst {
+namespace qserv {
+namespace qhttp {
+
+//
+//----- Helper ouput stream manipulators for logging.  These let you say things like:
+//      logger(self) << logger(sock) << "log message..." in logger macro calls
+//
+
+struct ServerLogger
+{
+    Server const* server;
+    ServerLogger(Server const* server) : server(server) {};
+};
+
+inline std::ostream& operator<<(std::ostream& str, ServerLogger const& logger) {
+    return str << "srv=" << logger.server << " ";
+}
+
+inline ServerLogger logger(Server const* server) { return ServerLogger(server); }
+inline ServerLogger logger(Server::Ptr const& server) { return ServerLogger(server.get()); }
+
+struct SocketLogger
+{
+    boost::asio::detail::socket_type sockno;
+    SocketLogger(boost::asio::ip::tcp::socket* socket) : sockno(socket->native_handle()) {};
+};
+
+inline std::ostream& operator<<(std::ostream& str, SocketLogger const& logger) {
+    return str << "sock=" << logger.sockno << " ";
+}
+
+inline SocketLogger logger(std::shared_ptr<boost::asio::ip::tcp::socket> socket)
+{
+    return SocketLogger(socket.get());
+}
+
+struct AjaxLogger
+{
+    AjaxEndpoint const* aep;
+    AjaxLogger(AjaxEndpoint const* aep) : aep(aep) {};
+};
+
+inline std::ostream& operator<<(std::ostream& str, AjaxLogger const& logger) {
+    return str << "ajax=" << logger.aep << " ";
+}
+
+inline AjaxLogger logger(AjaxEndpoint const* aep) { return AjaxLogger(aep); }
+inline AjaxLogger logger(AjaxEndpoint::Ptr const& aep) { return AjaxLogger(aep.get()); }
+
+}}} // namespace lsst::qserv::qhttp
+
+#endif // !defined(LSST_QSERV_QHTTP_LOGHELPERS_H)

--- a/src/qhttp/LogHelpers.h
+++ b/src/qhttp/LogHelpers.h
@@ -26,6 +26,7 @@
 // System headers
 #include <iostream>
 #include <memory>
+#include <string>
 
 // Local headers
 #include "qhttp/AjaxEndpoint.h"
@@ -83,6 +84,32 @@ inline std::ostream& operator<<(std::ostream& str, AjaxLogger const& logger) {
 
 inline AjaxLogger logger(AjaxEndpoint const* aep) { return AjaxLogger(aep); }
 inline AjaxLogger logger(AjaxEndpoint::Ptr const& aep) { return AjaxLogger(aep.get()); }
+
+//
+//----- Ouput stream manipulator that translates embedded control characters to "caret notation".  Used for
+//      logging suspect inputs that fail the legal input parsing regexps.
+//
+
+struct CtrlQuoter
+{
+    std::string const& toquote;
+    CtrlQuoter(std::string const& toquote) : toquote(toquote) {}
+};
+
+inline std::ostream& operator<<(std::ostream& str, CtrlQuoter const& quoter) {
+    for(char const& c: quoter.toquote) {
+        if (c < 0x20) {
+            str << "^" << (char)(c+0x40);
+        } else if (c == 0x7F) {
+            str << "^?";
+        } else {
+            str << c;
+        }
+    }
+    return str;
+}
+
+inline CtrlQuoter ctrlquote(std::string const& toquote) { return CtrlQuoter(toquote); }
 
 }}} // namespace lsst::qserv::qhttp
 

--- a/src/qhttp/README.md
+++ b/src/qhttp/README.md
@@ -9,8 +9,9 @@ and monitoring.  It was endeavored to keep the code size small and code complexi
 toward that end:
 
 * Leverages boost::asio's event proactor for a fully asyncrhonous server, so multiple simultaneous connections
-  are supported robustly even when run in a single thread.  Running single-threaded can significantly reduce
-  synchronization complications in handler codes, though throughput scaling may be limited in this case.
+  are supported robustly even when run in a single thread.  The option to run single-threaded can
+  significantly reduce synchronization complications in handler codes, though throughput scaling may be
+  limited in this case.
 
 * Express and Martini style "middlewares" were not implemented to keep complexity low.  This could be added at
   a later time if desired.  For now, perceived-to-be-commonly-used functionalities are wired directly into the
@@ -88,7 +89,7 @@ Response object provides methods for simple numeric status responses (which will
 HTML body) or the sending of strings or files.
 
 The server attempts to be exception-safe, since unhandled exceptions ocurring in asio service threads could be
-problematic for a hosting applications.  In particular, any exceptions thrown from user-handler code are be
+problematic for a hosting applications.  In particular, any exceptions thrown from user-handler code are
 caught by the server and translated to approprate HTTP responses (typically, 500 Internal Server Error).
 
 To install an AJAX endpoint:

--- a/src/qhttp/README.md
+++ b/src/qhttp/README.md
@@ -45,10 +45,9 @@ A simple web server, serving static content from a single directory:
 int main(int argc, char *argv[])
 {
     boost::asio::io_service service;
-    boost::system::error_code ec;
     qhttp::Server::Ptr server = qhttp::Server::create(service, 80);
-    server->addStaticContent("/*", "/path/to/web/content/dir", ec);
-    server->start(ec);
+    server->addStaticContent("/*", "/path/to/web/content/dir");
+    server->start();
     service.run();
     return 0;
 }

--- a/src/qhttp/Request.cc
+++ b/src/qhttp/Request.cc
@@ -102,7 +102,7 @@ std::string Request::_percentDecode(std::string const& encoded, bool exceptPathD
 
         // If decoding a path, leave any encoded slashes encoded (but ensure lower case), so they don't
         // become confused with path-element-delimiting slashes. We elsewhere make sure that intra-element
-        // slashes within the matchers are lower-case percent-encoded as well (see Path.cc).
+        // slashes within the matchers are lowercase percent-encoded as well (see Path.cc).
         if (exceptPathDelimeters && (codepoint == '/')) {
             decoded.append("%2f");
         }

--- a/src/qhttp/Request.cc
+++ b/src/qhttp/Request.cc
@@ -25,6 +25,7 @@
 
 // System headers
 #include <cstdlib>
+#include <utility>
 
 // Third-party headers
 #include "boost/regex.hpp"
@@ -43,11 +44,11 @@ namespace lsst {
 namespace qserv {
 namespace qhttp {
 
-Request::Request(std::shared_ptr<Server> server, std::shared_ptr<ip::tcp::socket> socket)
+Request::Request(std::shared_ptr<Server> const server, std::shared_ptr<ip::tcp::socket> const socket)
 :
     content(&_requestbuf),
-    _server(server),
-    _socket(socket)
+    _server(std::move(server)),
+    _socket(std::move(socket))
 {
     boost::system::error_code ignore;
     localAddr = _socket->local_endpoint(ignore);

--- a/src/qhttp/Request.h
+++ b/src/qhttp/Request.h
@@ -40,6 +40,8 @@ namespace lsst {
 namespace qserv {
 namespace qhttp {
 
+class Server;
+
 class Request : public std::enable_shared_from_this<Request>
 {
 public:
@@ -78,14 +80,18 @@ private:
     Request(Request const&) = delete;
     Request& operator=(Request const&) = delete;
 
-    explicit Request(std::shared_ptr<boost::asio::ip::tcp::socket> socket);
+    explicit Request(
+        std::shared_ptr<Server> server,
+        std::shared_ptr<boost::asio::ip::tcp::socket> socket
+    );
 
-    void _parseHeader();
-    void _parseUri();
-    void _parseBody();
+    bool _parseHeader();
+    bool _parseUri();
+    bool _parseBody();
 
-    std::string _percentDecode(std::string const& encoded, bool exceptPathDelimeters=false);
+    std::string _percentDecode(std::string const& encoded, bool exceptPathDelimeters, bool& hasNULs);
 
+    std::shared_ptr<Server> _server;
     std::shared_ptr<boost::asio::ip::tcp::socket> _socket;
     boost::asio::streambuf _requestbuf;
 

--- a/src/qhttp/Request.h
+++ b/src/qhttp/Request.h
@@ -81,8 +81,8 @@ private:
     Request& operator=(Request const&) = delete;
 
     explicit Request(
-        std::shared_ptr<Server> server,
-        std::shared_ptr<boost::asio::ip::tcp::socket> socket
+        std::shared_ptr<Server> const server,
+        std::shared_ptr<boost::asio::ip::tcp::socket> const socket
     );
 
     bool _parseHeader();
@@ -91,8 +91,8 @@ private:
 
     std::string _percentDecode(std::string const& encoded, bool exceptPathDelimeters, bool& hasNULs);
 
-    std::shared_ptr<Server> _server;
-    std::shared_ptr<boost::asio::ip::tcp::socket> _socket;
+    std::shared_ptr<Server> const _server;
+    std::shared_ptr<boost::asio::ip::tcp::socket> const _socket;
     boost::asio::streambuf _requestbuf;
 
 };

--- a/src/qhttp/Response.cc
+++ b/src/qhttp/Response.cc
@@ -142,7 +142,6 @@ void Response::sendFile(fs::path const& path)
 {
     auto ct = contentTypesByExtension.find(path.extension().string());
     headers["Content-Type"] = (ct != contentTypesByExtension.end()) ? ct->second : "text/plain";
-
     headers["Content-Length"] = std::to_string(fs::file_size(path));
 
     // Try to open the file for streaming input. Throw if we hit a snag; exception expected to be caught by

--- a/src/qhttp/Response.cc
+++ b/src/qhttp/Response.cc
@@ -29,6 +29,7 @@
 #include <string>
 #include <sstream>
 #include <string>
+#include <utility>
 
 // Third-party headers
 #include "boost/asio.hpp"
@@ -98,12 +99,12 @@ namespace qserv {
 namespace qhttp {
 
 Response::Response(
-    std::shared_ptr<Server> server,
-    std::shared_ptr<ip::tcp::socket> socket,
-    DoneCallback const &doneCallback)
+    std::shared_ptr<Server> const server,
+    std::shared_ptr<ip::tcp::socket> const socket,
+    DoneCallback const& doneCallback)
 :
-    _server(server),
-    _socket(socket),
+    _server(std::move(server)),
+    _socket(std::move(socket)),
     _doneCallback(doneCallback)
 {
     _transmissionStarted.clear();

--- a/src/qhttp/Response.cc
+++ b/src/qhttp/Response.cc
@@ -35,11 +35,17 @@
 #include "boost/filesystem.hpp"
 #include "boost/filesystem/fstream.hpp"
 
+// Local headers
+#include "lsst/log/Log.h"
+#include "qhttp/LogHelpers.h"
+
 namespace asio = boost::asio;
 namespace ip = boost::asio::ip;
 namespace fs = boost::filesystem;
 
 namespace {
+
+LOG_LOGGER _log = LOG_GET("lsst.qserv.qhttp");
 
 std::map<unsigned int, const std::string> responseStringsByCode = {
     {100, "Continue"},                          {101, "Switching Protocols"},
@@ -92,9 +98,11 @@ namespace qserv {
 namespace qhttp {
 
 Response::Response(
+    std::shared_ptr<Server> server,
     std::shared_ptr<ip::tcp::socket> socket,
     DoneCallback const &doneCallback)
 :
+    _server(server),
     _socket(socket),
     _doneCallback(doneCallback)
 {

--- a/src/qhttp/Response.h
+++ b/src/qhttp/Response.h
@@ -76,17 +76,17 @@ private:
     )>;
 
     Response(
-        std::shared_ptr<Server> server,
-        std::shared_ptr<boost::asio::ip::tcp::socket> socket,
+        std::shared_ptr<Server> const server,
+        std::shared_ptr<boost::asio::ip::tcp::socket> const socket,
         DoneCallback const& doneCallback
     );
 
     std::string _headers() const;
     void _write();
 
-    std::shared_ptr<Server> _server;
+    std::shared_ptr<Server> const _server;
 
-    std::shared_ptr<boost::asio::ip::tcp::socket> _socket;
+    std::shared_ptr<boost::asio::ip::tcp::socket> const _socket;
     boost::asio::streambuf _responsebuf;
     std::atomic_flag _transmissionStarted;
 

--- a/src/qhttp/Response.h
+++ b/src/qhttp/Response.h
@@ -39,6 +39,8 @@ namespace lsst {
 namespace qserv {
 namespace qhttp {
 
+class Server;
+
 class Response : public std::enable_shared_from_this<Response>
 {
 public:
@@ -74,11 +76,14 @@ private:
     )>;
 
     Response(
+        std::shared_ptr<Server> server,
         std::shared_ptr<boost::asio::ip::tcp::socket> socket,
         DoneCallback const& doneCallback
     );
 
     std::string _headers() const;
+
+    std::shared_ptr<Server> _server;
 
     std::shared_ptr<boost::asio::ip::tcp::socket> _socket;
     boost::asio::streambuf _responsebuf;

--- a/src/qhttp/Response.h
+++ b/src/qhttp/Response.h
@@ -82,6 +82,7 @@ private:
     );
 
     std::string _headers() const;
+    void _write();
 
     std::shared_ptr<Server> _server;
 

--- a/src/qhttp/Server.cc
+++ b/src/qhttp/Server.cc
@@ -237,7 +237,7 @@ void Server::_readRequest(std::shared_ptr<ip::tcp::socket> socket)
 
     auto startTime = chrono::steady_clock::now();
     auto reuseSocket = std::make_shared<bool>(false);
-    auto response = std::shared_ptr<Response>(new Response(
+    auto const response = std::shared_ptr<Response>(new Response(
         self, socket,
         [self, socket, startTime, reuseSocket](boost::system::error_code const& ec, std::size_t sent) {
             chrono::duration<double, std::milli> elapsed = chrono::steady_clock::now() - startTime;
@@ -257,7 +257,7 @@ void Server::_readRequest(std::shared_ptr<ip::tcp::socket> socket)
 
     // Create Request object for this request, and initiate header read.
 
-    auto request = std::shared_ptr<Request>(new Request(self, socket));
+    auto const request = std::shared_ptr<Request>(new Request(self, socket));
     asio::async_read_until(
         *socket, request->_requestbuf, "\r\n\r\n",
         [self, socket, reuseSocket, request, response, timer](

--- a/src/qhttp/Server.cc
+++ b/src/qhttp/Server.cc
@@ -132,6 +132,7 @@ void Server::_accept()
         _activeSockets.erase(removed, _activeSockets.end());
         _activeSockets.push_back(socket);
     }
+
     auto self = shared_from_this();
     _acceptor.async_accept(
         *socket,
@@ -144,7 +145,7 @@ void Server::_accept()
                 socket->set_option(ip::tcp::no_delay(true), ignore);
                 self->_readRequest(socket);
             }
-            self->_accept(); // start accept for the next incoming connection
+            self->_accept(); // start accept again for the next incoming connection
         }
     );
 }

--- a/src/qhttp/Server.cc
+++ b/src/qhttp/Server.cc
@@ -25,7 +25,9 @@
 
 // System headers
 #include <chrono>
+#include <iostream>
 #include <memory>
+#include <ratio>
 #include <string>
 
 // Third-party headers
@@ -40,9 +42,13 @@
 #include "qhttp/StaticContent.h"
 
 namespace asio = boost::asio;
+namespace errc = boost::system::errc;
 namespace ip = boost::asio::ip;
+namespace chrono = std::chrono;
 
 using namespace std::literals;
+
+#define DEFAULT_REQUEST_TIMEOUT 5min
 
 namespace {
     LOG_LOGGER _log = LOG_GET("lsst.qserv.qhttp");
@@ -51,8 +57,6 @@ namespace {
 namespace lsst {
 namespace qserv {
 namespace qhttp {
-
-#define DEFAULT_REQUEST_TIMEOUT 5min
 
 
 Server::Ptr Server::create(asio::io_service& io_service, unsigned short port, int backlog)
@@ -117,7 +121,7 @@ AjaxEndpoint::Ptr Server::addAjaxEndpoint(const std::string& pattern)
 }
 
 
-void Server::setRequestTimeout(std::chrono::milliseconds const& timeout)
+void Server::setRequestTimeout(chrono::milliseconds const& timeout)
 {
     _requestTimeout = timeout;
 }
@@ -135,8 +139,13 @@ void Server::_accept()
                 return weakSocket.expired();
             }
         );
-        _activeSockets.erase(removed, _activeSockets.end());
+        auto numExpired = _activeSockets.end() - removed;
+        if (numExpired != 0) {
+            LOGLS_DEBUG(_log, logger(this) << "purging tracking for " << numExpired << " expired socket(s)");
+            _activeSockets.erase(removed, _activeSockets.end());
+        }
         _activeSockets.push_back(socket);
+        LOGLS_DEBUG(_log, logger(this) << "tracking new socket");
     }
 
     auto self = shared_from_this();
@@ -144,12 +153,17 @@ void Server::_accept()
         *socket,
         [self, socket](boost::system::error_code const& ec) {
             if (!self->_acceptor.is_open() || ec == asio::error::operation_aborted) {
+                LOGLS_DEBUG(_log, logger(self) << "accept chain exiting");
                 return;
             }
             if (!ec) {
+                LOGLS_INFO(_log, logger(self) << logger(socket)
+                    << "connect from " << socket->remote_endpoint());
                 boost::system::error_code ignore;
                 socket->set_option(ip::tcp::no_delay(true), ignore);
                 self->_readRequest(socket);
+            } else {
+                LOGLS_ERROR(_log, logger(self) << "accept failed: " << ec.message());
             }
             self->_accept(); // start accept again for the next incoming connection
         }
@@ -174,12 +188,15 @@ void Server::start(boost::system::error_code& ec)
 
 void Server::stop()
 {
+    LOGLS_DEBUG(_log, logger(this) << "shutting down");
     boost::system::error_code ignore;
     _acceptor.close(ignore);
     std::lock_guard<std::mutex> lock(_activeSocketsMutex);
+    LOGLS_DEBUG(_log, logger(this) << "purging tracking for " << _activeSockets.size() << " socket(s)");
     for(auto& weakSocket : _activeSockets) {
         auto socket = weakSocket.lock();
         if (socket) {
+            LOGLS_DEBUG(_log, logger(this) << logger(socket) << "closing");
             socket->lowest_layer().shutdown(ip::tcp::socket::shutdown_both, ignore);
             socket->lowest_layer().close(ignore);
         }
@@ -190,69 +207,109 @@ void Server::stop()
 
 void Server::_readRequest(std::shared_ptr<ip::tcp::socket> socket)
 {
+    auto self = shared_from_this();
+
+    // Set up a timer and handler to timeout requests that take too long to arrive.
+
     auto timer = std::make_shared<asio::steady_timer>(_io_service);
     timer->expires_from_now(_requestTimeout);
     timer->async_wait(
-        [socket](boost::system::error_code const& ec) {
+        [self, socket](boost::system::error_code const& ec) {
             if (!ec) {
+                LOGLS_WARN(_log, logger(self) << logger(socket) << "read timed out, closing");
+                boost::system::error_code ignore;
+                socket->lowest_layer().shutdown(ip::tcp::socket::shutdown_both, ignore);
+                socket->lowest_layer().close(ignore);
+            } else if (ec == asio::error::operation_aborted) {
+                LOGLS_DEBUG(_log, logger(self) << logger(socket) << "read timeout timer canceled");
+            } else {
+                LOGLS_ERROR(_log, logger(self) << logger(socket) << "read timeout timer: " << ec.message());
+            }
+        }
+    );
+
+    // Create Response object for this request. Completion handler will log total request + response
+    // time, then either turn-around or close the client socket as appropriate.
+
+    auto startTime = chrono::steady_clock::now();
+    auto reuseSocket = std::make_shared<bool>(false);
+    auto response = std::shared_ptr<Response>(new Response(
+        self, socket,
+        [self, socket, startTime, reuseSocket](boost::system::error_code const& ec, std::size_t sent) {
+            chrono::duration<double, std::milli> elapsed = chrono::steady_clock::now() - startTime;
+            LOGLS_INFO(_log, logger(self) << logger(socket)
+                << "request duration " << elapsed.count() << "ms");
+            if (!ec && *reuseSocket) {
+                LOGLS_DEBUG(_log, logger(self) << logger(socket) << "lingering");
+                self->_readRequest(socket);
+            } else {
+                LOGLS_DEBUG(_log, logger(self) << logger(socket) << "closing");
                 boost::system::error_code ignore;
                 socket->lowest_layer().shutdown(ip::tcp::socket::shutdown_both, ignore);
                 socket->lowest_layer().close(ignore);
             }
         }
-    );
-
-    auto self = shared_from_this();
-    auto reuseSocket = std::make_shared<bool>(false);
-    auto request = std::shared_ptr<Request>(new Request(socket));
-    auto response = std::shared_ptr<Response>(new Response(
-        socket,
-        [self, socket, reuseSocket](boost::system::error_code const& ec, std::size_t sent) {
-            if (!ec && *reuseSocket) {
-                self->_readRequest(socket);
-            }
-        }
     ));
 
+    // Create Request object for this request, and initiate header read.
+
+    auto request = std::shared_ptr<Request>(new Request(socket));
     asio::async_read_until(
         *socket, request->_requestbuf, "\r\n\r\n",
         [self, socket, reuseSocket, request, response, timer](
             boost::system::error_code const& ec, size_t bytesRead)
         {
-            if (!ec) {
-                size_t bytesBuffered = request->_requestbuf.size() - bytesRead;
-                request->_parseHeader();
-                request->_parseUri();
-                if (request->version == "HTTP/1.1") {
-                    // Temporary disable this option due to a bug in the implementation
-                    // causing disconnect if running the service within the Docker environment.
-                    // See: DM-27396
-                    //*reuseSocket = true;
-                }
-                if (request->header.count("Content-Length") > 0) {
-                    asio::async_read(
-                        *socket, request->_requestbuf,
-                        asio::transfer_exactly(
-                            stoull(request->header["Content-Length"]) - bytesBuffered
-                        ),
-                        [self, socket, request, response, timer](
-                            boost::system::error_code const& ec, size_t)
-                        {
-                            timer->cancel();
-                            if (!ec) {
-                                if (request->header["Content-Type"] == "application/x-www-form-urlencoded") {
-                                    request->_parseBody();
-                                }
-                                self->_dispatchRequest(request, response);
-                            }
-                        }
-                    );
-                } else {
-                    timer->cancel();
-                    self->_dispatchRequest(request, response);
-                }
-            } else {
+            if (ec == asio::error::operation_aborted) {
+                LOGLS_ERROR(_log, logger(self) << logger(socket) << "header read canceled");
                 timer->cancel();
+                return;
+            } else if (ec) {
+                LOGLS_ERROR(_log, logger(self) << logger(socket) << "header read failed: " << ec.message());
+                timer->cancel();
+                return;
+            }
+
+            size_t bytesBuffered = request->_requestbuf.size() - bytesRead;
+            request->_parseHeader();
+            request->_parseUri();
+
+            if (request->version == "HTTP/1.1") {
+                // Temporary disable this option due to a bug in the implementation
+                // causing disconnect if running the service within the Docker environment.
+                // See: DM-27396
+                //*reuseSocket = true;
+            }
+
+            if (request->header.count("Content-Length") > 0) {
+                std::size_t bytesToRead = stoull(request->header["Content-Length"]) - bytesBuffered;
+                LOGLS_INFO(_log, logger(self) << logger(socket)
+                    << request->method << " " << request->target << " " << request->version
+                    << " + " << bytesToRead << " bytes");
+                asio::async_read(*socket, request->_requestbuf, asio::transfer_exactly(bytesToRead),
+                    [self, socket, request, response, timer](
+                        boost::system::error_code const& ec, size_t)
+                    {
+                        timer->cancel();
+                        if (ec == asio::error::operation_aborted) {
+                            LOGLS_ERROR(_log, logger(self) << logger(socket)
+                                << "request body read canceled");
+                            return;
+                        } else if (ec) {
+                            LOGLS_ERROR(_log, logger(self) << logger(socket)
+                                << "request body read failed: " << ec.message());
+                            return;
+                        }
+                        if (request->header["Content-Type"] == "application/x-www-form-urlencoded") {
+                            request->_parseBody();
+                        }
+                        self->_dispatchRequest(request, response);
+                    }
+                );
+            } else {
+                LOGLS_INFO(_log, logger(self) << logger(socket)
+                    << request->method << " " << request->target << " " << request->version);
+                timer->cancel();
+                self->_dispatchRequest(request, response);
             }
         }
     );
@@ -267,12 +324,16 @@ void Server::_dispatchRequest(Request::Ptr request, Response::Ptr response)
         for(auto& pathHandler : pathHandlersIt->second) {
             if (boost::regex_match(request->path, pathMatch, pathHandler.path.regex)) {
                 pathHandler.path.updateParamsFromMatch(request, pathMatch);
+                LOGLS_DEBUG(_log, logger(this) << logger(request->_socket)
+                    << "invoking handler for " << pathHandler.path.regex);
                 try {
                     pathHandler.handler(request, response);
                 }
                 catch(boost::system::system_error const& e) {
+                    LOGLS_WARN(_log, logger(this) << logger(request->_socket)
+                        << "exception thrown from handler: " << e.what());
                     switch(e.code().value()) {
-                    case boost::system::errc::permission_denied:
+                    case errc::permission_denied:
                         response->sendStatus(403);
                         break;
                     default:
@@ -281,12 +342,15 @@ void Server::_dispatchRequest(Request::Ptr request, Response::Ptr response)
                     }
                 }
                 catch(std::exception const& e) {
+                    LOGLS_WARN(_log, logger(this) << logger(request->_socket)
+                        << "exception thrown from handler: " << e.what());
                     response->sendStatus(500);
                 }
                 return;
             }
         }
     }
+    LOGLS_DEBUG(_log, logger(this) << logger(request->_socket) << "no handler found");
     response->sendStatus(404);
 }
 

--- a/src/qhttp/Server.cc
+++ b/src/qhttp/Server.cc
@@ -34,13 +34,19 @@
 #include "boost/regex.hpp"
 
 // Local headers
+#include "lsst/log/Log.h"
 #include "qhttp/AjaxEndpoint.h"
+#include "qhttp/LogHelpers.h"
 #include "qhttp/StaticContent.h"
 
 namespace asio = boost::asio;
 namespace ip = boost::asio::ip;
 
 using namespace std::literals;
+
+namespace {
+    LOG_LOGGER _log = LOG_GET("lsst.qserv.qhttp");
+}
 
 namespace lsst {
 namespace qserv {

--- a/src/qhttp/Server.h
+++ b/src/qhttp/Server.h
@@ -142,6 +142,7 @@ private:
     std::unordered_map<std::string, std::vector<PathHandler>> _pathHandlersByMethod;
 
     boost::asio::io_service& _io_service;
+
     int const _backlog;
     boost::asio::ip::tcp::endpoint _acceptorEndpoint;
     boost::asio::ip::tcp::acceptor _acceptor;

--- a/src/qhttp/Server.h
+++ b/src/qhttp/Server.h
@@ -95,12 +95,7 @@ public:
     //      header files for details.  Convenience functions are provided here to instantiate and install
     //      these.
 
-    void addStaticContent(
-        std::string const& path,
-        std::string const& rootDirectory,
-        boost::system::error_code& ec
-    );
-
+    void addStaticContent(std::string const& path, std::string const& rootDirectory);
     AjaxEndpoint::Ptr addAjaxEndpoint(std::string const& path);
 
     //----- setRequestTimeout() allows the user to override the default 5 minute start-of-request to
@@ -113,7 +108,7 @@ public:
     //      Server execution may be halted either calling stop(), or by calling asio::io_service::stop()
     //      on the associated asio::io_service.
 
-    void start(boost::system::error_code& ec);
+    void start();
 
     //----- stop() shuts down the server by closing all active sockets, including the server listening
     //      socket.  No new connections will be accepted, and handlers in progress will err out the next

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -94,5 +94,4 @@ void StaticContent::add(
     });
 }
 
-
 }}} // namespace lsst::qserv::qhttp

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -63,14 +63,6 @@ void StaticContent::add(Server& server, std::string const& pattern, std::string 
 
     server.addHandler("GET", pattern, [rootPath](Request::Ptr request, Response::Ptr response) {
 
-        // Don't let resource paths with embedded nulls past this point, since boost::filesystem does not
-        // treat them consistently.  Assume we aren't intentionally serving any static content with embedded
-        // nulls in the path, and just return a 404 if we find any.
-        if (request->path.find('\0') != std::string::npos) {
-            response->sendStatus(404);
-            return;
-        }
-
         // Defend against relative paths attempting to traverse above root directory.
         fs::path requestPath = rootPath;
         requestPath /= request->params["0"];

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -27,7 +27,15 @@
 #include "boost/filesystem.hpp"
 #include "boost/algorithm/string.hpp"
 
+// Local headers
+#include "lsst/log/Log.h"
+#include "qhttp/LogHelpers.h"
+
 namespace fs = boost::filesystem;
+
+namespace {
+    LOG_LOGGER _log = LOG_GET("lsst.qserv.qhttp");
+}
 
 namespace lsst {
 namespace qserv {

--- a/src/qhttp/StaticContent.h
+++ b/src/qhttp/StaticContent.h
@@ -49,12 +49,7 @@ public:
     //      these.)  Note that the Server::addStaticContent() convenience method would typically be called in
     //      preference to calling the add() method here directly.
 
-    static void add(
-        Server& server,
-        std::string const& path,
-        std::string const& rootDirectory,
-        boost::system::error_code& ec
-    );
+    static void add(Server& server, std::string const& path, std::string const& rootDirectory);
 
 };
 

--- a/src/qhttp/testqhttp.cc
+++ b/src/qhttp/testqhttp.cc
@@ -265,6 +265,7 @@ namespace qserv {
 //
 //----- The test fixture instantiates a qhttp server and a boost::asio::io_service to run it,
 //      manages a thread that runs the io_service, and handles global init and cleanup of libcurl.
+//
 
 struct QhttpFixture
 {

--- a/src/qhttp/testqhttp.cc
+++ b/src/qhttp/testqhttp.cc
@@ -578,11 +578,11 @@ BOOST_FIXTURE_TEST_CASE(static_content, QhttpFixture)
 
     //----- test resource path with embedded null
 
-    curl.setup("GET", urlPrefix + "/%00/", "").perform().validate(404, "text/html");
-    BOOST_TEST(curl.recdContent.find("404") != std::string::npos);
+    curl.setup("GET", urlPrefix + "/%00/", "").perform().validate(400, "text/html");
+    BOOST_TEST(curl.recdContent.find("400") != std::string::npos);
 
-    std::string content = asioHttpGet(std::string("/\0/", 3), 404, "text/html");
-    BOOST_TEST(content.find("404") != std::string::npos);
+    std::string content = asioHttpGet(std::string("/\0/", 3), 400, "text/html");
+    BOOST_TEST(content.find("400") != std::string::npos);
 }
 
 

--- a/src/replica/HttpProcessor.cc
+++ b/src/replica/HttpProcessor.cc
@@ -607,12 +607,7 @@ void HttpProcessor::registerServices() {
                     context_ + "a value of the httpRoot parameter '"
                     + self->_processorConfig.httpRoot + "' doesn't refer to a folder."); 
         }
-        httpServer()->addStaticContent("/*", self->_processorConfig.httpRoot, ec);
-        if (ec.value() != 0) {
-            throw runtime_error(
-                    context_+ "failed to install static handler for httpRoot parameter '"
-                    + self->_processorConfig.httpRoot + "', error: " + ec.message());
-        }
+        httpServer()->addStaticContent("/*", self->_processorConfig.httpRoot);
     }
 
 }

--- a/src/replica/HttpSvc.cc
+++ b/src/replica/HttpSvc.cc
@@ -76,12 +76,7 @@ void HttpSvc::run() {
     // any BOOST ASIO threads. This will prevent threads from finishing due to a lack of
     // work to be done.
     registerServices();
-
-    boost::system::error_code ec;
-    _httpServer->start(ec);
-    if (ec.value() != 0) {
-        throw runtime_error(context_+ "failed to start the service, error: " + ec.message());
-    }
+    _httpServer->start();
 
     // Launch all threads in a dedicated pool.
     auto const self = shared_from_this();

--- a/src/replica/QhttpTestApp.cc
+++ b/src/replica/QhttpTestApp.cc
@@ -185,13 +185,7 @@ int QhttpTestApp::runImpl() {
 
     // Make sure the service started before launching any BOOST ASIO threads.
     // This will prevent threads from finishing due to a lack of work to be done.
-    boost::system::error_code ec;
-    httpServer->start(ec);
-    if (ec.value() != 0) {
-        throw runtime_error(
-                "QhttpTestApp::" + string(__func__) + " failed to start the service, error: "
-                + ec.message());
-    }
+    httpServer->start();
 
     // Launch all threads in the pool
     vector<shared_ptr<thread>> threads(_numThreads);


### PR DESCRIPTION
This `qhttp` PR: 

* adds logging (`lsst::log`)
* reverts library API to exceptions (logged with details at point of occurrence) instead of error codes
* follows RFCs 7230 and 3986 more closely with respect to allowed inputs, and rejects invalid requests with a 400 early rather than deferring to handlers

It may be easiest to review by commit.  To see examples of the new log messages, try:

`build/src/qhttp/testqhttp -- --data=src/qhttp/testdata/ --log-level=DEBUG`
