### PR TITLE
DM-33510: when tagging images use the release tag if it is newer than dockerfile changes

### DIFF
--- a/src/admin/python/lsst/qserv/admin/qservCli/opt.py
+++ b/src/admin/python/lsst/qserv/admin/qservCli/opt.py
@@ -32,7 +32,7 @@ import os
 from typing import Callable, List, Optional, Union
 
 
-from .images import get_tag
+from .images import get_description
 
 
 _log = logging.getLogger(__name__)
@@ -188,7 +188,7 @@ def tagged_image_name(image_name: str, dockerfiles: Optional[List[str]]) -> Opti
     qserv_root = qserv_root_ev.val()
     if qserv_root is None:
         return None
-    return f"{image_name}:{image_tag_ev.val(get_tag(dockerfiles, qserv_root))}"
+    return f"{image_name}:{image_tag_ev.val(get_description(dockerfiles, qserv_root))}"
 
 
 qserv_root_ev = FlagEnvVal(


### PR DESCRIPTION
When creating lite qserv image tags, the description of the sha
that has the most recent changes to the relevant dockerfile(s)
is used to tag the image.
This can be confusing if the most recent changes are from a
previous release.
To make it more clear, if the most recent git tag (qserv release)
is newer then the most recent dockefile changes then use a
description of the SHA of the release tag instead.