### PR TITLE
DM-33665: targs can get stuck in a loop if a var combines text with itself

### DIFF
--- a/src/admin/CMakeLists.txt
+++ b/src/admin/CMakeLists.txt
@@ -43,3 +43,8 @@ add_test(NAME test_qserv_log
   COMMAND python3 -m unittest tests.admin.test_qserv_log
   WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/python/
 )
+
+add_test(NAME test_render_targs
+  COMMAND python3 -m unittest tests.admin.test_render_targs
+  WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/python/
+)

--- a/src/admin/python/lsst/qserv/admin/cli/entrypoint.py
+++ b/src/admin/python/lsst/qserv/admin/cli/entrypoint.py
@@ -624,7 +624,7 @@ def worker_repl(ctx: click.Context, **kwargs: Any) -> None:
     required=True,
 )
 @db_admin_uri_option(
-    help="The admin URI to the proxy's database, used for schema initialization. " + socket_option_help,
+    help="The admin URI to the replication controller's database, used for schema initialization. " + socket_option_help,
     required=True,
 )
 @click.option(

--- a/src/admin/python/lsst/qserv/admin/cli/entrypoint.py
+++ b/src/admin/python/lsst/qserv/admin/cli/entrypoint.py
@@ -630,10 +630,11 @@ def worker_repl(ctx: click.Context, **kwargs: Any) -> None:
 @click.option(
     "--worker",
     "workers",
-    help=(
-        "The settings for each worker in the system. "
-        "The value must be in the form 'key1=val1,key2=val,...'"
-        f"\ntarg key name is {click.style('workers', bold=True)}"
+    help=("""The settings for each worker in the system.
+The value must be in the form 'key1=val1,key2=val2,...'
+These are used when initializing a fresh qserv to configure the replication controller. They become options passed to
+qserv-replica-config, like 'qserv-replica-config ADD_WORKER --key1=val1 --key2=val2, ...'.
+If using targs, name is plural; '{click.style('workers', bold=True)}'."""
     ),
     multiple=True,
 )

--- a/src/admin/python/lsst/qserv/admin/qservCli/qserv_cli.py
+++ b/src/admin/python/lsst/qserv/admin/qservCli/qserv_cli.py
@@ -609,13 +609,13 @@ def down(
 @click.argument("COMMAND", required=False)
 @qserv_image_option()
 @click.option(
-    "--entrypoint",
+    "--entrypoint/--no-entrypoint",
     is_flag=True,
     default=True,
     help="Show help output for the entrypoint command.",
 )
 @click.option(
-    "--spawned",
+    "--spawned/--no-spawned",
     is_flag=True,
     default=True,
     help="Show help output for the spawned app.",


### PR DESCRIPTION
This contains a few small fixes to entrypoint args, the fix for the bug is in the commit "fail if targs contains a self-reference"