### PR TITLE
DM-33748: Use multiple jobs in CI Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,15 @@ on:
     branches:
       - main
 jobs:
-  build:
-    name: Build image
+
+  update-base-images:
+    name: Update base images
     runs-on: ubuntu-20.04
+    outputs:
+      build-rebuilt: ${{ steps.rebuild.outputs.build-rebuilt }}
+      run-base-rebuilt: ${{ steps.rebuild.outputs.run-base-rebuilt }}
     steps:
+
       - name: Install python
         uses: actions/setup-python@v2
         with:
@@ -32,45 +37,107 @@ jobs:
           username: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
           password: ${{ secrets.FM_DOCKERHUB_TOKEN }}
 
-      - name: Prepare lite-build image
+      - name: Rebuild and push build image if needed
+        id: rebuild
         run: |
-          ./admin/local/cli/qserv --log-level DEBUG build-build-image \
-          --pull-image \
-          --push-image
+          if [[ $(./admin/local/cli/qserv dh-image-exists build-base) == "True" ]]; then
+            echo "Build image already on docker hub; skipping..."
+            echo "::set-output name=build-rebuilt::False"
+          else
+            ./admin/local/cli/qserv --log-level DEBUG build-build-image --push-image
+            echo "::set-output name=build-rebuilt::True"
+          fi
         env:
           QSERV_DH_USER: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
           QSERV_DH_TOKEN: ${{ secrets.FM_DOCKERHUB_TOKEN }}
 
-      - name: Prepare lite-run-base image
+      - name: Rebuild and push run base image if needed
         run: |
-          ./admin/local/cli/qserv --log-level DEBUG build-run-base-image \
-          --pull-image \
-          --push-image
+          if [[ $(./admin/local/cli/qserv dh-image-exists run-base) == "True" ]]; then
+            echo "Run base image already on docker hub; skipping..."
+            echo "::set-output name=run-base-rebuilt::False"
+          else
+            ./admin/local/cli/qserv --log-level DEBUG build-run-base-image --push-image
+            echo "::set-output name=run-base-rebuilt::True"
+          fi
         env:
           QSERV_DH_USER: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
           QSERV_DH_TOKEN: ${{ secrets.FM_DOCKERHUB_TOKEN }}
+
+  update-mariadb-image:
+    name: Update MariaDB image
+    runs-on: ubuntu-20.04
+    outputs:
+      rebuilt: ${{ steps.rebuild.outputs.rebuilt }}
+    steps:
+
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install click
+        run: |
+          python -m pip install --upgrade pip
+          pip install click pyyaml requests
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # 0 is "all history and branch tags"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
+          password: ${{ secrets.FM_DOCKERHUB_TOKEN }}
+
+      - name: Rebuild and push if needed
+        id: rebuild
+        run: |
+          if [[ $(./admin/local/cli/qserv dh-image-exists mariadb) == "True" ]]; then
+            echo "MariaDB image already on docker hub; skipping..."
+            echo "::set-output name=rebuilt::False"
+          else
+            ./admin/local/cli/qserv --log-level DEBUG build-mariadb-image --push-image
+            echo "::set-output name=rebuilt::True"
+          fi
+        env:
+          QSERV_DH_USER: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
+          QSERV_DH_TOKEN: ${{ secrets.FM_DOCKERHUB_TOKEN }}
+
+  update-run-image:
+    name: Update Qserv image
+    runs-on: ubuntu-20.04
+    needs: update-base-images
+    steps:
+
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install click
+        run: |
+          python -m pip install --upgrade pip
+          pip install click pyyaml requests
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # 0 is "all history and branch tags"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
+          password: ${{ secrets.FM_DOCKERHUB_TOKEN }}
 
       - name: Prepare user build image
         run: |
           ./admin/local/cli/qserv --log-level DEBUG build-user-build-image \
           --group docker_outer
 
-      - name: Prepare maraidb image
-        run: |
-          ./admin/local/cli/qserv --log-level DEBUG build-mariadb-image \
-          --pull-image \
-          --push-image
-        env:
-          QSERV_DH_USER: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
-          QSERV_DH_TOKEN: ${{ secrets.FM_DOCKERHUB_TOKEN }}
-
-      # Pull-image on this stage should only ever have an effect when rerunnning a job from
-      # the github actions web page. This is useful for re-running integration tests on
-      # a successful build to sniff out intermittent integration test issues.
-      # To rerun the whole build, push a new sha to the branch.
-      #
-      # Specify -j2 because the github actions virutal machine has 2 cores, so restrict the
-      # number of jobs to the same.
       - name: Build lite-qserv image
         run: |
           ./admin/local/cli/qserv --log-level DEBUG build \
@@ -80,6 +147,33 @@ jobs:
         env:
           QSERV_DH_USER: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
           QSERV_DH_TOKEN: ${{ secrets.FM_DOCKERHUB_TOKEN }}
+
+  compose-integration-tests:
+    name: Integration tests (compose)
+    runs-on: ubuntu-20.04
+    needs: [update-mariadb-image, update-run-image]
+    steps:
+
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install click
+        run: |
+          python -m pip install --upgrade pip
+          pip install click pyyaml requests
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # 0 is "all history and branch tags"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.FM_DOCKERHUB_TOKEN_USER }}
+          password: ${{ secrets.FM_DOCKERHUB_TOKEN }}
 
       - name: Launch qserv
         run: |
@@ -99,9 +193,14 @@ jobs:
           ./admin/local/cli/qserv --log-level DEBUG down \
           -v
 
-      - name: Notify Slack if CI failed on main
+  notify-on-fail:
+    name: Notify Slack if fail on main
+    runs-on: ubuntu-20.04
+    needs: [compose-integration-tests]
+    if: github.ref == 'refs/heads/main' && failure()
+    steps:
+      - name: Notify
         uses: voxmedia/github-action-slack-notify-build@v1
-        if: github.ref == 'refs/heads/main' && failure()
         with:
           channel_id: G2JPZ3GC8  # this is the channel id of the dm_db_team room
           status: FAILED


### PR DESCRIPTION
Using multiple jobs in the GHA CI workflow (instead of just multiple steps in a single job) sets the stage for being able to put documentation and Qserv container builds downstream of a single shared base container build job, for parallelized jobs, for parallelized integration tests (compose vs. k8s+operator), etc.  

This will be used as a basis for upcoming changes to containerize the documentation builds and to integrate qserv operator into the qserv repo.

See https://github.com/lsst/qserv/actions/runs/1862847776 for example of new workflow on this PR.