### PR TITLE
Added support for copying the query text

### DIFF
--- a/src/www/qserv/css/StatusUserQueries.css
+++ b/src/www/qserv/css/StatusUserQueries.css
@@ -26,8 +26,8 @@ table#fwk-status-queries caption.updating {
     background-color: #ffeeba;
 }
 
-table#fwk-status-queries      tbody > tr:hover,
-table#fwk-status-queries-past tbody > tr:hover {
+table#fwk-status-queries      tbody > tr > td.query_toggler:hover,
+table#fwk-status-queries-past tbody > tr > td.query_toggler:hover {
     cursor:pointer;
 }
 table#fwk-status-queries      tbody pre.query.hidden,


### PR DESCRIPTION
Refactored tables on the query monitoring page to allow copying queries
to the clipboard (a fallback solution is offered for cases
when the clipboard is not writeable). Separated query formatting controls
from browsing the table rows in order to allow additional operations
over queries (the first one was mentoned earlier).