### PR TITLE
Increased key limits in the configurations of the MariaDB services

### DIFF
--- a/src/admin/templates/integration-test/etc/my.cnf
+++ b/src/admin/templates/integration-test/etc/my.cnf
@@ -17,10 +17,16 @@ host_cache_size=0
 
 # Configure max number of connections
 # Recommended value: 256 for every 50 simultaneous queries
-max_connections = 4096
+max_connections = 16384
+connect_timeout = 28800
 
 socket = /qserv/data/mysql/mysql.sock
 port = 3306
+
+# Extend read and write connection timeouts that can be triggered
+# by large result sets.
+net_read_timeout=90000
+net_write_timeout=90000
 
 query-cache-size = 0
 

--- a/src/admin/templates/mariadb/etc/my.cnf
+++ b/src/admin/templates/mariadb/etc/my.cnf
@@ -21,7 +21,8 @@ innodb_file_per_table=1
 
 # Configure max number of connections
 # Recommended value: 256 for every 50 simultaneous queries
-max_connections=1028
+max_connections = 16384
+connect_timeout = 28800
 
 # Configure usage of stats tables if available/generated,
 # enable independant storage engine statistics
@@ -34,9 +35,8 @@ optimizer_use_condition_selectivity=3
 
 # Extend read and write connection timeouts that can be triggerd
 # by large result sets on the workers.
-net_read_timeout=900
-net_write_timeout=900
-
+net_read_timeout=90000
+net_write_timeout=90000
 
 #
 # Advanced logging

--- a/src/admin/templates/repl-db/etc/my.cnf
+++ b/src/admin/templates/repl-db/etc/my.cnf
@@ -15,10 +15,16 @@ host_cache_size=0
 
 # Configure max number of connections
 # Recommended value: 256 for every 50 simultaneous queries
-max_connections = 4096
+max_connections = 16384
+connect_timeout = 28800
 
 socket = /qserv/data/mysql/mysql.sock
 port = 3306
+
+# Extend read and write connection timeouts that can be triggered
+# by large result sets.
+net_read_timeout=90000
+net_write_timeout=90000
 
 query-cache-size = 0
 


### PR DESCRIPTION
The previous limits were too low for production instances