### PR TITLE
mypy fixes for recent changes to mysql.connector package

### DIFF
--- a/src/admin/python/lsst/qserv/admin/cli/_integration_test.py
+++ b/src/admin/python/lsst/qserv/admin/cli/_integration_test.py
@@ -101,7 +101,7 @@ def wait_for_czar(czar_db_uri: str) -> None:
         ) as connection:
             with closing(connection.cursor()) as cursor:
                 cursor.execute("show databases;")
-                return [row[0] for row in cursor.fetchall()]
+                return [str(row[0]) for row in cursor.fetchall()]
 
     databases = get_databases()
     checkdb = "qservMeta"

--- a/src/admin/python/lsst/qserv/admin/mysql_connection.py
+++ b/src/admin/python/lsst/qserv/admin/mysql_connection.py
@@ -25,6 +25,7 @@
 
 import logging
 import mysql.connector
+from typing import cast
 from urllib.parse import urlparse
 
 _log = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ def mysql_connection(
     uri: str,
     get_warnings: bool = True,
     local_infile: bool = False,
-) -> mysql.connector.connection:
+) -> mysql.connector.abstracts.MySQLConnectionAbstract:
     """Create a mysql.connection that is connected to a database.
 
     Parameters
@@ -58,12 +59,16 @@ def mysql_connection(
         user = parsed.username
         pw = parsed.password
     _log.debug("mysql_connection hostname:%s, port:%s, user:%s", hostname, port, user)
-    cnx = mysql.connector.connect(
-        user=user,
-        password=pw,
-        host=hostname,
-        port=port,
-        allow_local_infile=local_infile,
+    # Cast justified because no pool args passed here to connect(), so cnx cannot be PooledMySQLConnection
+    cnx = cast(
+        mysql.connector.abstracts.MySQLConnectionAbstract,
+        mysql.connector.connect(
+            user=user,
+            password=pw,
+            host=hostname,
+            port=port,
+            allow_local_infile=local_infile,
+        ),
     )
     cnx.get_warnings = get_warnings
     return cnx

--- a/src/admin/python/lsst/qserv/admin/watcher.py
+++ b/src/admin/python/lsst/qserv/admin/watcher.py
@@ -26,7 +26,7 @@ from contextlib import closing
 import logging
 import requests
 from time import sleep
-from typing import List, Sequence, Set, Type, Union
+from typing import List, Sequence, Set, Type, Union, Any
 
 _log = logging.getLogger(__name__)
 
@@ -168,7 +168,7 @@ class Watcher:
             _log.error(f"Failed to send notification {msg}, exception: {e}")
         _log.debug(f"Sent notification: {msg}")
 
-    def query(self, uri: str, stmt: str) -> List[Sequence[str]]:
+    def query(self, uri: str, stmt: str) -> Sequence[Any]:
         """Execute a mysql query at the provided URI
 
         Parameters

--- a/src/replica/python/replicaConfig.py
+++ b/src/replica/python/replicaConfig.py
@@ -23,6 +23,7 @@ import backoff
 from contextlib import closing
 import mysql.connector
 import logging
+from typing import cast
 from urllib.parse import urlparse
 
 from lsst.qserv.admin.backoff import qserv_backoff, on_backoff
@@ -44,11 +45,15 @@ def applyConfiguration(connection: str, sql: str) -> None:
     """Apply configuration sql to the replication controller database."""
     c = urlparse(connection)
     with closing(
-        mysql.connector.connect(
-            user=c.username,
-            password=c.password,
-            host=c.hostname,
-            port=c.port,
+        # Cast justified because no pool args passed here to connect(), so cannot be PooledMySQLConnection
+        cast(
+            mysql.connector.abstracts.MySQLConnectionAbstract,
+            mysql.connector.connect(
+                user=c.username,
+                password=c.password,
+                host=c.hostname,
+                port=c.port,
+            ),
         )
     ) as cnx:
         cnx.database = replicaDb


### PR DESCRIPTION
Latest Qserv release build attempt pulled in a new version of `mysql-connector-python`, with type hint changes.

The main issue is that `mysql.connector.connect()` is now hinted as `Union[PooledMySQLConnection, MySQLConnection, CMySQLConnection]`.  You only get a pooled connection back if you pass pool kwargs to `connect`.  The pooled connection is meagre compared to the other two, and doesn't support all the calls we make in our code.  We don't pass pool kwargs anywhere to `connect`, and aren't expecting any pooled connections.

The other two varieties (and their associated cursor classes) are much more congruent, and share ABCs `MySQLConnectionAbstract` and `MySQLCursorAbstract` which have (almost) everything we need/use.  The `MySQL...` versions are pure Python, while the `CMySQL...` versions leverage a C extension for greater performance.  Which flavor you get back from `connect` by default depends on platform and whether or not the C extension is available/installed, but defaults are now trending toward the C-accelerated versions.

Mostly here I've opted for `typing.cast` to the ABCs, because we can know from the immediately surrounding code that we aren't passing pool kwargs, and it makes us insensitive to whether we get a pure Python or a C-accelerated connection.  Some alternatives I could think of:

* Use runtime `assert isinstance` instead of `cast`, for future-proofing against code changes?
* Say we don't care about performance for this application and explicitly construct tightly typed pure Python `MySQLConnector` by calling the `MySQLConnector` ctor instead of the generic `connector.connect` (or the other way around, and make the C extension a prerequisite for Qserv; perhaps that's even better.)

Opinions?  Thanks.  This is holding up the next Qserv release, so we should try to pick something soon...