### PR TITLE
DM-38621: Restrict director index restrictions to `=` and `IN`

### DIFF
--- a/src/qana/QservRestrictorPlugin.cc
+++ b/src/qana/QservRestrictorPlugin.cc
@@ -337,7 +337,7 @@ std::shared_ptr<query::SecIdxInRestrictor> makeSecondaryIndexRestrictor(query::I
 }
 
 /**
- * @brief Make a Secondary Index comparison restrictor for the given between predicate, if one of the
+ * @brief Make a Secondary Index 'between' restrictor for the given between predicate, if one of the
  *      columns in the predicate is a director column.
  *
  * @param betweenPredicate
@@ -345,7 +345,7 @@ std::shared_ptr<query::SecIdxInRestrictor> makeSecondaryIndexRestrictor(query::I
  * @return std::shared_ptr<query::SIBetweenRestr> The restrictor that corresponds to the given predicate if
  * one of the columns is a director column, otherwise nullptr.
  */
-std::shared_ptr<query::SecIdxBetweenRestrictor> makeSecondaryIndexRestrictor(
+[[maybe_unused]] std::shared_ptr<query::SecIdxBetweenRestrictor> makeSecondaryIndexRestrictor(
         query::BetweenPredicate const& betweenPredicate, query::QueryContext const& context) {
     if (isSecIndexCol(context, betweenPredicate.value->getColumnRef())) {
         auto dirCol = getCorrespondingDirectorColumn(context, betweenPredicate.value->getColumnRef());
@@ -362,7 +362,7 @@ std::shared_ptr<query::SecIdxBetweenRestrictor> makeSecondaryIndexRestrictor(
 }
 
 /**
- * @brief Make a Secondary Index 'between' restrictor for the given comparison predicate, if one of the
+ * @brief Make a Secondary Index comparison restrictor for the given comparison predicate, if one of the
  *      columns in the comparison predicate is a director column.
  *
  * @param compPredicate
@@ -419,10 +419,9 @@ std::vector<std::shared_ptr<query::SecIdxRestrictor>> getSecIndexRestrictors(que
                 restrictor = makeSecondaryIndexRestrictor(*inPredicate, context);
             } else if (auto const compPredicate =
                                std::dynamic_pointer_cast<query::CompPredicate>(factorTerm)) {
-                restrictor = makeSecondaryIndexRestrictor(*compPredicate, context);
-            } else if (auto const betweenPredicate =
-                               std::dynamic_pointer_cast<query::BetweenPredicate>(factorTerm)) {
-                restrictor = makeSecondaryIndexRestrictor(*betweenPredicate, context);
+                if (compPredicate->op == query::CompPredicate::EQUALS_OP) {
+                    restrictor = makeSecondaryIndexRestrictor(*compPredicate, context);
+                }
             }
             if (restrictor) {
                 LOGS(_log, LOG_LVL_TRACE, "Add restrictor: " << *restrictor << " for " << factorTerm);

--- a/src/qproc/testQueryAnaBetween.cc
+++ b/src/qproc/testQueryAnaBetween.cc
@@ -76,19 +76,7 @@ BOOST_AUTO_TEST_CASE(SecondaryIndex) {
     std::shared_ptr<QueryContext> context = qs->dbgGetContext();
     BOOST_CHECK(context);
     BOOST_CHECK_EQUAL(context->dominantDb, std::string("LSST"));
-    BOOST_REQUIRE(context->secIdxRestrictors);
-    BOOST_CHECK_EQUAL(context->secIdxRestrictors->size(), 1U);
-    BOOST_REQUIRE(context->secIdxRestrictors->front());
-    auto betweenRestr =
-            std::dynamic_pointer_cast<SecIdxBetweenRestrictor>(context->secIdxRestrictors->front());
-    BOOST_REQUIRE(nullptr != betweenRestr);
-    BOOST_REQUIRE_EQUAL(
-            betweenRestr->getSecIdxLookupQuery(lsst::qserv::SEC_INDEX_DB, "LSST__Object",
-                                               lsst::qserv::CHUNK_COLUMN, lsst::qserv::SUB_CHUNK_COLUMN),
-            "SELECT `" + std::string(lsst::qserv::CHUNK_COLUMN) + "`, " + "`" +
-                    std::string(lsst::qserv::SUB_CHUNK_COLUMN) + "`" + " FROM `" +
-                    std::string(lsst::qserv::SEC_INDEX_DB) + "`" +
-                    ".`LSST__Object` WHERE `objectIdObjTest` BETWEEN 386942193651347 AND 386942193651349");
+    BOOST_REQUIRE(not context->secIdxRestrictors);  // since DM-38621
 }
 
 BOOST_AUTO_TEST_CASE(NoSecondaryIndex) {
@@ -115,19 +103,9 @@ BOOST_AUTO_TEST_CASE(DoubleSecondaryIndexRestrictor) {
     BOOST_CHECK(context);
     BOOST_CHECK_EQUAL(context->dominantDb, std::string("LSST"));
     BOOST_REQUIRE(context->secIdxRestrictors);
-    BOOST_CHECK_EQUAL(context->secIdxRestrictors->size(), 2U);
+    BOOST_CHECK_EQUAL(context->secIdxRestrictors->size(), 1U);  // since DM-38621
     BOOST_REQUIRE(context->secIdxRestrictors->at(0));
-    auto betweenRestr = std::dynamic_pointer_cast<SecIdxBetweenRestrictor>(context->secIdxRestrictors->at(0));
-    BOOST_REQUIRE(betweenRestr != nullptr);
-    BOOST_REQUIRE_EQUAL(
-            betweenRestr->getSecIdxLookupQuery(lsst::qserv::SEC_INDEX_DB, "LSST__Object",
-                                               lsst::qserv::CHUNK_COLUMN, lsst::qserv::SUB_CHUNK_COLUMN),
-            "SELECT `" + std::string(lsst::qserv::CHUNK_COLUMN) + "`, " + "`" +
-                    std::string(lsst::qserv::SUB_CHUNK_COLUMN) + "`" + " FROM " + "`" +
-                    std::string(lsst::qserv::SEC_INDEX_DB) + "`" +
-                    ".`LSST__Object` WHERE `objectIdObjTest` BETWEEN 38 AND 40");
-    BOOST_REQUIRE(context->secIdxRestrictors->at(1));
-    auto inRestrictor = std::dynamic_pointer_cast<SecIdxInRestrictor>(context->secIdxRestrictors->at(1));
+    auto inRestrictor = std::dynamic_pointer_cast<SecIdxInRestrictor>(context->secIdxRestrictors->at(0));
     BOOST_REQUIRE(inRestrictor != nullptr);
     BOOST_REQUIRE_EQUAL(
             inRestrictor->getSecIdxLookupQuery(lsst::qserv::SEC_INDEX_DB, "LSST__Object",
@@ -153,19 +131,9 @@ BOOST_AUTO_TEST_CASE(DoubleSecondaryIndexRestrictorCartesian) {
     BOOST_CHECK(context);
     BOOST_CHECK_EQUAL(context->dominantDb, std::string("LSST"));
     BOOST_REQUIRE(context->secIdxRestrictors);
-    BOOST_CHECK_EQUAL(context->secIdxRestrictors->size(), 2U);
+    BOOST_CHECK_EQUAL(context->secIdxRestrictors->size(), 1U);  // since DM-38621
     BOOST_REQUIRE(context->secIdxRestrictors->at(0));
-    auto betweenRestr = std::dynamic_pointer_cast<SecIdxBetweenRestrictor>(context->secIdxRestrictors->at(0));
-    BOOST_REQUIRE(betweenRestr != nullptr);
-    BOOST_REQUIRE_EQUAL(
-            betweenRestr->getSecIdxLookupQuery(lsst::qserv::SEC_INDEX_DB, "LSST__Object",
-                                               lsst::qserv::CHUNK_COLUMN, lsst::qserv::SUB_CHUNK_COLUMN),
-            "SELECT `" + std::string(lsst::qserv::CHUNK_COLUMN) + "`, " + "`" +
-                    std::string(lsst::qserv::SUB_CHUNK_COLUMN) + "`" + " FROM `" +
-                    std::string(lsst::qserv::SEC_INDEX_DB) + "`" +
-                    ".`LSST__Object` WHERE `objectIdObjTest` BETWEEN 38 AND 40");
-    BOOST_REQUIRE(context->secIdxRestrictors->at(1));
-    auto inRestrictor = std::dynamic_pointer_cast<SecIdxInRestrictor>(context->secIdxRestrictors->at(1));
+    auto inRestrictor = std::dynamic_pointer_cast<SecIdxInRestrictor>(context->secIdxRestrictors->at(0));
     BOOST_REQUIRE(inRestrictor != nullptr);
     BOOST_REQUIRE_EQUAL(
             inRestrictor->getSecIdxLookupQuery(lsst::qserv::SEC_INDEX_DB, "LSST__Object",


### PR DESCRIPTION
Director index queries currently take place on the query submission thread, and thus can block the single Lua thread in mysql-proxy if not completed expeditiously.

We have seen instances of this occurring "in the wild" on IDF, where queries are sometimes submitted resulting in `objectId >= 0` predicates in the `WHERE` clause, causing millions-of-rows queries to be dispatched to the `Object` director index during query submission, holding up the proxy for minutes at a time.

This ticket is for seat-belt work to confine director index restrictor generation to cases of `=` and `IN` predicates only, which can generally be assumed performant. Other predicate restrictions on director index columns will default through to full scans.