### PR TITLE
DM-38810: Upgrade XRootD to tip of branch ssi-5.5.3

### DIFF
--- a/admin/tools/docker/base/Dockerfile
+++ b/admin/tools/docker/base/Dockerfile
@@ -108,9 +108,9 @@ RUN cd /tmp \
     && rm -rf mysqlproxy
 
 RUN cd /tmp \
-    && git clone https://github.com/lsst/xrootd \
+    && git clone https://github.com/xrootd/xrootd.git \
     && cd xrootd \
-    && git checkout affinity-flex-hash \
+    && git checkout ssi-5.3.x \
     && mkdir build \
     && cd build \
     && cmake -DENABLE_PYTHON=off .. \

--- a/src/czar/CMakeLists.txt
+++ b/src/czar/CMakeLists.txt
@@ -8,7 +8,6 @@ target_sources(czar PRIVATE
 
 target_include_directories(czar PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(czar PUBLIC

--- a/src/qdisp/CMakeLists.txt
+++ b/src/qdisp/CMakeLists.txt
@@ -17,7 +17,6 @@ target_sources(qdisp PRIVATE
 
 target_include_directories(qdisp PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(qdisp PUBLIC
@@ -29,7 +28,6 @@ add_executable(testQDisp testQDisp.cc)
 
 target_include_directories(testQDisp PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(testQDisp

--- a/src/replica/CMakeLists.txt
+++ b/src/replica/CMakeLists.txt
@@ -459,7 +459,6 @@ target_sources(replica PRIVATE
 
 target_include_directories(replica PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(replica PUBLIC
@@ -483,7 +482,7 @@ FUNCTION(REPLICA_UTILS)
     FOREACH(UTIL IN ITEMS ${ARGV})
         add_executable(${UTIL})
         target_sources(${UTIL} PRIVATE tools/${UTIL}.cc)
-        target_include_directories(${UTIL} PRIVATE ${XROOTD_INCLUDE_DIRS} ${XROOTD_INCLUDE_DIRS}/private)
+        target_include_directories(${UTIL} PRIVATE ${XROOTD_INCLUDE_DIRS})
         target_link_libraries(${UTIL} PRIVATE replica)
         install(TARGETS ${UTIL})
     ENDFOREACH()

--- a/src/wbase/CMakeLists.txt
+++ b/src/wbase/CMakeLists.txt
@@ -13,7 +13,6 @@ target_sources(wbase PRIVATE
 
 target_include_directories(wbase PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(wbase PUBLIC

--- a/src/wcontrol/CMakeLists.txt
+++ b/src/wcontrol/CMakeLists.txt
@@ -10,7 +10,6 @@ target_sources(wcontrol PRIVATE
 
 target_include_directories(wcontrol PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(wcontrol PUBLIC

--- a/src/wdb/CMakeLists.txt
+++ b/src/wdb/CMakeLists.txt
@@ -10,7 +10,6 @@ target_sources(wdb PRIVATE
 
 target_include_directories(wdb PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(wdb PUBLIC
@@ -23,7 +22,6 @@ FUNCTION(wdb_tests)
         add_executable(${TEST} ${TEST}.cc)
         target_include_directories(${TEST} PRIVATE
             ${XROOTD_INCLUDE_DIRS}
-            ${XROOTD_INCLUDE_DIRS}/private
         )
         target_link_libraries(${TEST} PUBLIC
             crypto

--- a/src/wpublish/CMakeLists.txt
+++ b/src/wpublish/CMakeLists.txt
@@ -23,7 +23,6 @@ target_sources(wpublish PRIVATE
 
 target_include_directories(wpublish PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(wpublish PUBLIC

--- a/src/wsched/CMakeLists.txt
+++ b/src/wsched/CMakeLists.txt
@@ -17,7 +17,6 @@ add_executable(testSchedulers testSchedulers.cc)
 
 target_include_directories(testSchedulers PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(testSchedulers PUBLIC

--- a/src/xrdlog/CMakeLists.txt
+++ b/src/xrdlog/CMakeLists.txt
@@ -6,7 +6,6 @@ target_sources(xrdlog PRIVATE
 
 target_include_directories(xrdlog PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(xrdlog PUBLIC

--- a/src/xrdsvc/CMakeLists.txt
+++ b/src/xrdsvc/CMakeLists.txt
@@ -11,7 +11,6 @@ target_sources(qserv_xrdsvc PRIVATE
 
 target_include_directories(qserv_xrdsvc PRIVATE
     ${XROOTD_INCLUDE_DIRS}
-    ${XROOTD_INCLUDE_DIRS}/private
 )
 
 target_link_libraries(qserv_xrdsvc PUBLIC


### PR DESCRIPTION
This cherry-picks the commit Igor has been running in his feature branch for a while now (Igor: it should just get lifted out of your branch next time you rebase.)

Also remove `/private` XRootD include dir from cmake files -- no longer necessary with this upgrade.