### PR TITLE
Added symbolic definitions for known HTTP status codes in qhttp

### DIFF
--- a/src/qhttp/README.md
+++ b/src/qhttp/README.md
@@ -74,7 +74,7 @@ void getFoo(qhttp::Request::Ptr req, qhttp::Response::Ptr resp)
     string requestedFoo = req->params["foo"];
     auto const& foo = fooMap.find(requestedFoo);
     if (foo == fooMap.end()) {
-        resp->sendStatus(404); // simple status response
+        resp->sendStatus(qhttp::STATUS_NOT_FOUND); // simple status response
     } else {
         resp->send(foo->second.toJSON(), "application/json");
     }

--- a/src/qhttp/Response.h
+++ b/src/qhttp/Response.h
@@ -35,6 +35,9 @@
 #include "boost/asio.hpp"
 #include "boost/filesystem.hpp"
 
+// Local headers
+#include "qhttp/Status.h"
+
 namespace lsst::qserv::qhttp {
 
 class Server;
@@ -49,14 +52,14 @@ public:
     //      near the top of Response.cc for specific extensions supported.)
 
     void send(std::string const& content, std::string const& contentType = "text/html");
-    void sendStatus(unsigned int status);
+    void sendStatus(Status status);
     void sendFile(boost::filesystem::path const& path);
 
     //----- Response status code and additional headers may also be set with these members, and will be
     //      included/observed by the send methods above (sendStatus and sendFile will override status set
     //      here, though; sendFile will override any Content-Type header set here.)
 
-    unsigned int status = {200};
+    Status status = STATUS_OK;
     std::unordered_map<std::string, std::string> headers;
 
 private:

--- a/src/qhttp/StaticContent.cc
+++ b/src/qhttp/StaticContent.cc
@@ -30,6 +30,7 @@
 // Local headers
 #include "lsst/log/Log.h"
 #include "qhttp/LogHelpers.h"
+#include "qhttp/Status.h"
 
 namespace errc = boost::system::errc;
 namespace fs = boost::filesystem;
@@ -63,7 +64,7 @@ void StaticContent::add(Server& server, std::string const& pattern, std::string 
         requestPath /= request->params["0"];
         requestPath = fs::weakly_canonical(requestPath);
         if (!boost::starts_with(requestPath, rootPath)) {
-            response->sendStatus(403);
+            response->sendStatus(STATUS_FORBIDDEN);
             return;
         }
 
@@ -73,15 +74,15 @@ void StaticContent::add(Server& server, std::string const& pattern, std::string 
         if (fs::is_directory(requestPath)) {
             if (!boost::ends_with(request->path, "/")) {
                 response->headers["Location"] = request->path + "/";
-                response->sendStatus(301);
+                response->sendStatus(STATUS_MOVED_PERM);
                 return;
             }
             requestPath /= "index.html";
         }
 
-        // Handle the oft-expected 404 case here explicitly, rather than as an exception.
+        // Handle the oft-expected case here explicitly, rather than as an exception.
         if (!fs::exists(requestPath)) {
-            response->sendStatus(404);
+            response->sendStatus(STATUS_NOT_FOUND);
             return;
         }
 

--- a/src/qhttp/Status.h
+++ b/src/qhttp/Status.h
@@ -1,0 +1,94 @@
+/*
+ * LSST Data Management System
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_QSERV_QSTATUS_H
+#define LSST_QSERV_QSTATUS_H
+
+// This header declarations
+
+namespace lsst::qserv::qhttp {
+
+/**
+ * The enumeration type for symbolic definitions of the known HTTP status codes.
+ */
+enum Status : unsigned int {
+    STATUS_CONTINUE = 100,
+    STATUS_SWITCH_PROTOCOL = 101,
+    STATUS_PROCESSING = 102,
+    STATUS_OK = 200,
+    STATUS_CREATED = 201,
+    STATUS_ACCEPTED = 202,
+    STATUS_NON_AUTHORATIVE_INFO = 203,
+    STATUS_NO_CONTENT = 204,
+    STATUS_RESET_CONTENT = 205,
+    STATUS_PARTIAL_CONTENT = 206,
+    STATUS_MULTI_STATUS = 207,
+    STATUS_ALREADY_REPORTED = 208,
+    STATUS_IM_USED = 226,
+    STATUS_MULTIPLE_CHOICES = 300,
+    STATUS_MOVED_PERM = 301,
+    STATUS_FOUND = 302,
+    STATUS_SEE_OTHER = 303,
+    STATUS_NOT_MODIFIED = 304,
+    STATUS_USE_PROXY = 305,
+    STATUS_TEMP_REDIRECT = 307,
+    STATUS_PERM_REDIRECT = 308,
+    STATUS_BAD_REQ = 400,
+    STATUS_UNAUTHORIZED = 401,
+    STATUS_PAYMENT_REQUIRED = 402,
+    STATUS_FORBIDDEN = 403,
+    STATUS_NOT_FOUND = 404,
+    STATUS_METHOD_NOT_ALLOWED = 405,
+    STATUS_NON_ACCEPTABLE = 406,
+    STATUS_PROXY_AUTH_REQUIRED = 407,
+    STATUS_REQ_TIMEOUT = 408,
+    STATUS_CONFLICT = 409,
+    STATUS_GONE = 410,
+    STATUS_LENGTH_REQUIRED = 411,
+    STATUS_PRECOND_FAILED = 412,
+    STATUS_PAYLOAD_TOO_LARGE = 413,
+    STATUS_URI_TOO_LONG = 414,
+    STATUS_UNSUPPORTED_MEDIA_TYPE = 415,
+    STATUS_RANGE_NOT_SATISFIABLE = 416,
+    STATUS_FAILED_EXPECT = 417,
+    STATUS_MISREDIRECT_REQ = 421,
+    STATUS_UNPROCESSIBLE = 422,
+    STATUS_LOCKED = 423,
+    STATUS_FAILED_DEP = 424,
+    STATUS_UPGRADE_REQUIRED = 426,
+    STATUS_PRECOND_REQUIRED = 428,
+    STATUS_TOO_MANY_REQS = 429,
+    STATUS_REQ_HDR_FIELDS_TOO_LARGE = 431,
+    STATUS_INTERNAL_SERVER_ERR = 500,
+    STATUS_NOT_IMPL = 501,
+    STATUS_BAD_GATEWAY = 502,
+    STATUS_SERVICE_UNAVAIL = 503,
+    STATUS_GSATEWAY_TIMEOUT = 504,
+    STATUS_UNDSUPPORT_VERSION = 505,
+    STATUS_VARIANT_NEGOTIATES = 506,
+    STATUS_NO_STORAGE = 507,
+    STATUS_LOOP = 508,
+    STATUS_NOT_EXTENDED = 510,
+    STATUS_NET_AUTH_REQUIRED = 511
+};
+
+}  // namespace lsst::qserv::qhttp
+
+#endif /* LSST_QSERV_QSTATUS_H */


### PR DESCRIPTION
Also migrated clients of the module to use these definitions instead of numeric literals ("magic" constants).