### PR TITLE
Fixed a bug in qhttp response handler

### DIFF
--- a/src/qhttp/Response.cc
+++ b/src/qhttp/Response.cc
@@ -175,7 +175,7 @@ std::string Response::_headers() const {
     headerst << r->first << " " << r->second;
 
     auto ilength = headers.find("Content-Length");
-    std::size_t length = (ilength == headers.end()) ? 0 : std::stoi(ilength->second);
+    std::size_t length = (ilength == headers.end()) ? 0 : std::stoull(ilength->second);
     LOGLS_INFO(_log, logger(_server) << logger(_socket) << headerst.str() << " + " << length << " bytes");
 
     headerst << "\r\n";


### PR DESCRIPTION
The older version of the code was throwing an exception when creating HTTP headers for file sizes exceeding signed 32-bit representation (~2 GB).