### PR TITLE
Force group and/or user deletion in user-specific build container

### DIFF
--- a/admin/tools/docker/build-user/Dockerfile
+++ b/admin/tools/docker/build-user/Dockerfile
@@ -19,8 +19,10 @@ ARG UID
 ARG GROUP
 ARG GID
 
-RUN getent group $GID || groupadd --gid $GID $GROUP
-RUN getent passwd $UID || useradd --uid $UID --gid $GROUP $USER
+RUN OGROUP=$(getent group $GID | cut -d: -f1) && if [ "$OGROUP" != "" ]; then groupdel $OGROUP; fi
+RUN groupadd --gid $GID $GROUP
+RUN OUSER=$(getent passwd $UID | cut -d: -f1) && if [ "$OUSER" != "" ]; then userdel $OUSER; fi
+RUN useradd --uid $UID --gid $GROUP $USER
 
 USER $USER
 WORKDIR /home/$USER


### PR DESCRIPTION
This is a little heavy-handed, but fixes the GHA build-container builds in the short term.