### PR TITLE
DM-41477: Fixed a bug in the state transition logic of the worker tasks

### DIFF
--- a/src/wbase/Task.cc
+++ b/src/wbase/Task.cc
@@ -233,6 +233,7 @@ std::vector<Task::Ptr> Task::createTasks(std::shared_ptr<proto::TaskMsg> const& 
                                          std::shared_ptr<wdb::ChunkResourceMgr> const& chunkResourceMgr,
                                          mysql::MySqlConfig const& mySqlConfig,
                                          std::shared_ptr<wcontrol::SqlConnMgr> const& sqlConnMgr,
+                                         std::shared_ptr<wpublish::QueriesAndChunks> const& queriesAndChunks,
                                          uint16_t resultsHttpPort) {
     QueryId qId = taskMsg->queryid();
     QSERV_LOGCONTEXT_QUERY_JOB(qId, taskMsg->jobid());
@@ -267,8 +268,9 @@ std::vector<Task::Ptr> Task::createTasks(std::shared_ptr<proto::TaskMsg> const& 
     }
     for (auto task : vect) {
         /// Set the function called when it is time to process the task.
-        auto func = [task, chunkResourceMgr, mySqlConfig, sqlConnMgr](util::CmdData*) {
-            auto qr = wdb::QueryRunner::newQueryRunner(task, chunkResourceMgr, mySqlConfig, sqlConnMgr);
+        auto func = [task, chunkResourceMgr, mySqlConfig, sqlConnMgr, queriesAndChunks](util::CmdData*) {
+            auto qr = wdb::QueryRunner::newQueryRunner(task, chunkResourceMgr, mySqlConfig, sqlConnMgr,
+                                                       queriesAndChunks);
             bool success = false;
             try {
                 success = qr->runQuery();

--- a/src/wbase/Task.h
+++ b/src/wbase/Task.h
@@ -65,8 +65,9 @@ namespace lsst::qserv::wdb {
 class ChunkResourceMgr;
 }
 namespace lsst::qserv::wpublish {
+class QueriesAndChunks;
 class QueryStatistics;
-}
+}  // namespace lsst::qserv::wpublish
 
 namespace lsst::qserv::wbase {
 
@@ -167,6 +168,7 @@ public:
                                         std::shared_ptr<wdb::ChunkResourceMgr> const& chunkResourceMgr,
                                         mysql::MySqlConfig const& mySqlConfig,
                                         std::shared_ptr<wcontrol::SqlConnMgr> const& sqlConnMgr,
+                                        std::shared_ptr<wpublish::QueriesAndChunks> const& queriesAndChunks,
                                         uint16_t resultsHttpPort = 8080);
 
     void setQueryStatistics(std::shared_ptr<wpublish::QueryStatistics> const& qC);

--- a/src/wdb/QueryRunner.h
+++ b/src/wdb/QueryRunner.h
@@ -45,17 +45,17 @@
 #include "wbase/Task.h"
 #include "wdb/ChunkResource.h"
 
-namespace lsst::qserv {
-
-namespace xrdsvc {
+namespace lsst::qserv::xrdsvc {
 class StreamBuffer;
-}
+}  // namespace lsst::qserv::xrdsvc
 
-namespace wcontrol {
+namespace lsst::qserv::wcontrol {
 class SqlConnMgr;
-}  // namespace wcontrol
+}  // namespace lsst::qserv::wcontrol
 
-}  // namespace lsst::qserv
+namespace lsst::qserv::wpublish {
+class QueriesAndChunks;
+}  // namespace lsst::qserv::wpublish
 
 namespace lsst::qserv::wdb {
 
@@ -64,10 +64,10 @@ namespace lsst::qserv::wdb {
 class QueryRunner : public wbase::TaskQueryRunner, public std::enable_shared_from_this<QueryRunner> {
 public:
     using Ptr = std::shared_ptr<QueryRunner>;
-    static QueryRunner::Ptr newQueryRunner(wbase::Task::Ptr const& task,
-                                           ChunkResourceMgr::Ptr const& chunkResourceMgr,
-                                           mysql::MySqlConfig const& mySqlConfig,
-                                           std::shared_ptr<wcontrol::SqlConnMgr> const& sqlConnMgr);
+    static QueryRunner::Ptr newQueryRunner(
+            wbase::Task::Ptr const& task, ChunkResourceMgr::Ptr const& chunkResourceMgr,
+            mysql::MySqlConfig const& mySqlConfig, std::shared_ptr<wcontrol::SqlConnMgr> const& sqlConnMgr,
+            std::shared_ptr<wpublish::QueriesAndChunks> const& queriesAndChunks);
     // Having more than one copy of this would making tracking its progress difficult.
     QueryRunner(QueryRunner const&) = delete;
     QueryRunner& operator=(QueryRunner const&) = delete;
@@ -86,7 +86,8 @@ public:
 protected:
     QueryRunner(wbase::Task::Ptr const& task, ChunkResourceMgr::Ptr const& chunkResourceMgr,
                 mysql::MySqlConfig const& mySqlConfig,
-                std::shared_ptr<wcontrol::SqlConnMgr> const& sqlConnMgr);
+                std::shared_ptr<wcontrol::SqlConnMgr> const& sqlConnMgr,
+                std::shared_ptr<wpublish::QueriesAndChunks> const& queriesAndChunks);
 
 private:
     bool _initConnection();
@@ -115,6 +116,7 @@ private:
 
     /// Used to limit the number of open MySQL connections.
     std::shared_ptr<wcontrol::SqlConnMgr> const _sqlConnMgr;
+    std::shared_ptr<wpublish::QueriesAndChunks> const _queriesAndChunks;
     std::atomic<bool> _runQueryCalled{false};  ///< If runQuery gets called twice, the scheduler messed up.
 };
 

--- a/src/wsched/BlendScheduler.cc
+++ b/src/wsched/BlendScheduler.cc
@@ -254,8 +254,6 @@ void BlendScheduler::commandStart(util::Command::Ptr const& cmd) {
     } else {
         LOGS(_log, LOG_LVL_ERROR, "BlendScheduler::commandStart scheduler not found");
     }
-
-    _queries->startedTask(t);
     _infoChanged = true;
 }
 
@@ -277,7 +275,6 @@ void BlendScheduler::commandFinish(util::Command::Ptr const& cmd) {
     }
     _infoChanged = true;
     _logChunkStatus();
-    _queries->finishedTask(t);
     notify(true);  // notify all=true
 }
 

--- a/src/xrdsvc/SsiRequest.cc
+++ b/src/xrdsvc/SsiRequest.cc
@@ -205,7 +205,7 @@ void SsiRequest::execute(XrdSsiRequest& req) {
             }
             auto const tasks = wbase::Task::createTasks(taskMsg, channelShared, _foreman->chunkResourceMgr(),
                                                         _foreman->mySqlConfig(), _foreman->sqlConnMgr(),
-                                                        _foreman->httpPort());
+                                                        _foreman->queriesAndChunks(), _foreman->httpPort());
             for (auto const& task : tasks) {
                 _tasks.push_back(task);
             }


### PR DESCRIPTION
In the previous code, the task were declared as "finished" after being "booted" from a scheduler. In reality, the tasks could be still in the active state processing the corresponding queries and consuming resources (memory, CPU, MySQL connections). This change made the task monitoring correct and allowed to uncover tasks that were previously seen as "invisible".