### PR TITLE
DM-41685: Update run base to arrow and parquet libs to version 14

### DIFF
--- a/admin/tools/docker/base/Dockerfile
+++ b/admin/tools/docker/base/Dockerfile
@@ -213,8 +213,8 @@ RUN dnf update -y \
        https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm \
     && dnf config-manager --set-enabled epel \
     && dnf config-manager --set-enabled crb \
-    && dnf install -y arrow13-libs \
-    && dnf install -y parquet13-libs \
+    && dnf install -y arrow14-libs \
+    && dnf install -y parquet14-libs \
     && dnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
This seems needed since the "default" versions picked up in the build container have now advanced to version 14.