### PR TITLE
DM-42562: Improved version of the response buffer management in qhttp

### DIFF
--- a/src/qhttp/Response.h
+++ b/src/qhttp/Response.h
@@ -72,18 +72,26 @@ private:
             std::function<void(boost::system::error_code const& ec, std::size_t bytesTransferred)>;
 
     Response(std::shared_ptr<Server> const server, std::shared_ptr<boost::asio::ip::tcp::socket> const socket,
-             DoneCallback const& doneCallback);
+             DoneCallback const& doneCallback, std::size_t const maxResponseBufSize);
 
     std::string _headers() const;
-    void _write();
+    void _startTransmit();
+    void _finishTransmit(boost::system::error_code const& ec, std::size_t sent);
+    void _sendFileRecord(std::string::size_type pos, std::size_t size);
 
     std::shared_ptr<Server> const _server;
 
     std::shared_ptr<boost::asio::ip::tcp::socket> const _socket;
-    boost::asio::streambuf _responsebuf;
+    std::string _responseBuf;
     std::atomic_flag _transmissionStarted;
 
+    std::string _fileName;
+    std::ifstream _inFile;
+    std::size_t _bytesRemaining = 0;  // initialized with the file size
+    std::size_t _bytesSent = 0;       // including the header
+
     DoneCallback _doneCallback;
+    std::size_t const _maxResponseBufSize;
 };
 
 }  // namespace lsst::qserv::qhttp

--- a/src/qhttp/Server.h
+++ b/src/qhttp/Server.h
@@ -75,7 +75,8 @@ public:
     //      maximum length of the queue of pending connections.
 
     static Ptr create(boost::asio::io_service& io_service, unsigned short port,
-                      int backlog = boost::asio::socket_base::max_listen_connections);
+                      int backlog = boost::asio::socket_base::max_listen_connections,
+                      std::size_t const _maxResponseBufSize = 0);
     unsigned short getPort();
 
     ~Server();
@@ -99,6 +100,13 @@ public:
 
     void setRequestTimeout(std::chrono::milliseconds const& timeout);
 
+    //----- setMaxResponseBufSize() allows the user to override the default (or explicitly specified in
+    //      the class's constructor) size of the response buffer. There are no restricton on when the method
+    //      is called. The change will affect next requests processed after making the call.
+    //      Passing 0 as a value of the parameter will reset the buffer size to the implementation default.
+
+    void setMaxResponseBufSize(std::size_t const maxResponseBufSize);
+
     //----- start() opens the server listening socket and installs the head of the asynchronous event
     //      handler chain onto the asio::io_service provided when the Server instance was constructed.
     //      Server execution may be halted either calling stop(), or by calling asio::io_service::stop()
@@ -117,7 +125,8 @@ private:
     Server(Server const&) = delete;
     Server& operator=(Server const&) = delete;
 
-    Server(boost::asio::io_service& io_service, unsigned short port, int backlog);
+    Server(boost::asio::io_service& io_service, unsigned short port, int backlog,
+           std::size_t const _maxResponseBufSize);
 
     void _accept();
 
@@ -134,6 +143,7 @@ private:
     boost::asio::io_service& _io_service;
 
     int const _backlog;
+    std::size_t _maxResponseBufSize;
     boost::asio::ip::tcp::endpoint _acceptorEndpoint;
     boost::asio::ip::tcp::acceptor _acceptor;
 


### PR DESCRIPTION
When sending the payload of the static files, the file content is split into records, where the maximum size of each record is limited by 2MB.