### PR TITLE
DM-42770: Added "relaxed" memory management mode at Qserv worker

### DIFF
--- a/src/admin/templates/xrootd/etc/xrdssi.cf.jinja
+++ b/src/admin/templates/xrootd/etc/xrdssi.cf.jinja
@@ -15,7 +15,7 @@ password =
 [memman]
 
 # MemMan class to use for managing memory for tables
-# can be "MemManReal" or "MemManNone"
+# can be "MemManReal", "MemManNone" or "MemManNoneRelaxed"
 # class = MemManReal
 
 # Memory available for locking tables, in MB

--- a/src/xrdsvc/SsiService.cc
+++ b/src/xrdsvc/SsiService.cc
@@ -168,6 +168,9 @@ SsiService::SsiService(XrdSsiLogger* log) {
                 memman::MemMan::create(memManSize, workerConfig->getMemManLocation()));
     } else if (cfgMemMan == "MemManNone") {
         memMan = make_shared<memman::MemManNone>(1, false);
+    } else if (cfgMemMan == "MemManNoneRelaxed") {
+        bool const alwaysLock = true;
+        memMan = make_shared<memman::MemManNone>(1, alwaysLock);
     } else {
         LOGS(_log, LOG_LVL_ERROR, "Unrecognized memory manager " << cfgMemMan);
         throw wconfig::WorkerConfigError("Unrecognized memory manager.");


### PR DESCRIPTION
The memory management node is a variation of MemManNone except it won't report a failure to (memory) lock tables where such locking is required. With this mode, the scheduler would not enforce additional restrictions on the number of queries that are processed in parallel. In case of using the non-relaxed manager MemManNone the processing concurrency is forced to be 1 per queue regardles of what's specified in the worker's configuration or the number of the hardware threads on a machine.