### PR TITLE
DM-43625: Extend the MySQL API of the Qserv Replication Framework

### DIFF
--- a/src/replica/mysql/DatabaseMySQLGenerator.cc
+++ b/src/replica/mysql/DatabaseMySQLGenerator.cc
@@ -104,17 +104,59 @@ string QueryGenerator::createTable(SqlId const& sqlId, bool ifNotExists, list<Sq
 
 string QueryGenerator::insertPacked(string const& tableName, string const& packedColumns,
                                     vector<string> const& packedValues) const {
-    if (packedValues.empty()) {
-        string const msg = "QueryGenerator::" + string(__func__) +
-                           " the collection of the packed values can not be empty.";
-        throw invalid_argument(msg);
-    }
+    _assertNotEmpty(__func__, packedValues);
     string sql = "INSERT INTO " + id(tableName).str + " (" + packedColumns + ") VALUES ";
     for (size_t i = 0, size = packedValues.size(); i < size; ++i) {
         if (i != 0) sql += ",";
         sql += "(" + packedValues[i] + ")";
     }
     return sql;
+}
+
+vector<string> QueryGenerator::insertPacked(string const& tableName, string const& packedColumns,
+                                            vector<string> const& packedValues,
+                                            size_t const maxQueryLength) const {
+    _assertNotEmpty(__func__, packedValues);
+    vector<string> queries;
+    string sql;
+    size_t numRowsPacked = 0;
+    for (vector<string>::const_iterator itr = packedValues.cbegin(); itr != packedValues.cend();) {
+        string const& row = *itr;
+        if (sql.empty()) {
+            sql = "INSERT INTO " + id(tableName).str + " (" + packedColumns + ") VALUES ";
+        }
+        // 2 more characters are needed for injecting the first row: "(" + row + ")"
+        // And 1 more - for subsequent rows: ",(" + row + ")"
+        size_t const extraSpacePerRow = (numRowsPacked == 0 ? 2 : 3);
+        size_t const projectedQueryLength = sql.size() + extraSpacePerRow + row.size();
+        if (projectedQueryLength <= maxQueryLength) {
+            // -- Extend the current query and move on to the next row (if any)
+            if (numRowsPacked != 0) sql += ",";
+            sql += "(" + row + ")";
+            numRowsPacked++;
+            ++itr;
+        } else {
+            // -- Flush the current query and start building the next one
+            if (numRowsPacked == 0) {
+                string const msg = "QueryGenerator::" + string(__func__) + " the generated query length " +
+                                   to_string(projectedQueryLength) + " exceeds the limit " +
+                                   to_string(maxQueryLength);
+                throw invalid_argument(msg);
+            }
+            queries.push_back(move(sql));
+            sql = string();
+            numRowsPacked = 0;
+        }
+    }
+    // -- Flush the current query
+    if (!sql.empty()) queries.push_back(move(sql));
+    return queries;
+}
+
+void QueryGenerator::_assertNotEmpty(string const& func, vector<string> const& coll) {
+    if (coll.empty()) {
+        throw invalid_argument("QueryGenerator::" + func + " the input collection is empty.");
+    }
 }
 
 string QueryGenerator::showVars(SqlVarScope scope, string const& pattern) const {


### PR DESCRIPTION
The new extension allows to generate collections of multi-row INSERT queries where the maximum length of each query is constrained by the specified limit.