### PR TITLE
DM-43139: Refactor FileChannelShared to reduce mutex lock 

### DIFF
--- a/src/wbase/FileChannelShared.h
+++ b/src/wbase/FileChannelShared.h
@@ -180,7 +180,7 @@ private:
      * @note The method may not extract all rows if the amount of data found
      *   in the result set exceeded the maximum size allowed by the Google Protobuf
      *   implementation. Also, the iterative approach to the data extraction allows
-     *   the driving code to be interrupted should the correponding query be cancelled
+     *   the driving code to be interrupted should the corresponding query be cancelled
      *   during the lengthy data processing phase.
      * @param responseData - proto buffer to hold the response being constructed.
      * @param protobufArena - proto buffer memory management control.

--- a/src/wbase/FileChannelShared.h
+++ b/src/wbase/FileChannelShared.h
@@ -182,7 +182,8 @@ private:
      *   implementation. Also, the iterative approach to the data extraction allows
      *   the driving code to be interrupted should the correponding query be cancelled
      *   during the lengthy data processing phase.
-     * @param tMtxLock - a lock on the mutex tMtx
+     * @param responseData - proto buffer to hold the response being constructed.
+     * @param protobufArena - proto buffer memory management control.
      * @param task - a task that produced the result set
      * @param mResult - MySQL result to be used as a source
      * @param bytes - the number of bytes in the result message recorded into the file
@@ -192,7 +193,6 @@ private:
      * @throws std::runtime_error for problems encountered when attemting to create the file
      *   or write into the file.
      */
-    // &&& fix doc tMtxLock  responseData  protobufArena
     bool _writeToFile(proto::ResponseData* responseData,
                       std::unique_ptr<google::protobuf::Arena> const& protobufArena,
                       std::shared_ptr<Task> const& task, MYSQL_RES* mResult, int& bytes, int& rows,
@@ -201,13 +201,13 @@ private:
     /**
      * Extract as many rows as allowed by the Google Protobuf implementation from
      * from the input result set into the output result object.
-     * @param tMtxLock - a lock on the mutex tMtx
+     * @param responseData - proto buffer to hold the response being constructed.
+     * @param protobufArena - proto buffer memory management control.
      * @param mResult - MySQL result to be used as a source
      * @param rows - the number of rows extracted from the result set
      * @param tSize - the approximate amount of data extracted from the result set
      * @return 'true' if there are more rows left in the result set.
      */
-    //&&& fix doc
     static bool _fillRows(proto::ResponseData* responseData, MYSQL_RES* mResult, int& rows, size_t& tSize);
 
     /**

--- a/src/wbase/FileChannelShared.h
+++ b/src/wbase/FileChannelShared.h
@@ -274,6 +274,10 @@ private:
 
     uint32_t _rowcount = 0;      ///< The total numnber of rows in all result sets of a query.
     uint64_t _transmitsize = 0;  ///< The total amount of data (bytes) in all result sets of a query.
+
+    /// This should be set to true if there were any issues that invalidate the file, such as errors
+    /// or cancellation.
+    std::atomic<bool> _issueRequiresFileRemoval{false};
 };
 
 }  // namespace lsst::qserv::wbase

--- a/src/wdb/QueryRunner.cc
+++ b/src/wdb/QueryRunner.cc
@@ -147,7 +147,6 @@ size_t QueryRunner::_getDesiredLimit() {
 util::TimerHistogram memWaitHisto("memWait Hist", {1, 5, 10, 20, 40});
 
 bool QueryRunner::runQuery() {
-    LOGS(_log, LOG_LVL_WARN, "&&& runQuery start");
     util::InstanceCount ic(to_string(_task->getQueryId()) + "_rq_LDB");  // LockupDB
     util::HoldTrack::Mark runQueryMarkA(ERR_LOC, "runQuery " + to_string(_task->getQueryId()));
     QSERV_LOGCONTEXT_QUERY_JOB(_task->getQueryId(), _task->getJobId());
@@ -255,7 +254,6 @@ private:
 };
 
 bool QueryRunner::_dispatchChannel() {
-    LOGS(_log, LOG_LVL_WARN, "&&& dispatch start");
     bool erred = false;
     bool needToFreeRes = false;  // set to true once there are results to be freed.
     // Collect the result in _transmitData. When a reasonable amount of data has been collected,
@@ -300,9 +298,7 @@ bool QueryRunner::_dispatchChannel() {
                 if (sendChan == nullptr) {
                     throw util::Bug(ERR_LOC, "QueryRunner::_dispatchChannel() sendChan==null");
                 }
-                LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmitResult a");
                 erred = sendChan->buildAndTransmitResult(res, _task, _multiError, _cancelled);
-                LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmitResult a1");
             }
         }
     } catch (sql::SqlErrorObject const& e) {
@@ -325,12 +321,10 @@ bool QueryRunner::_dispatchChannel() {
         erred = true;
         // Send results. This needs to happen after the error check.
         // If any errors were found, send an error back.
-        LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmiError b");
         if (!_task->getSendChannel()->buildAndTransmitError(_multiError, _task, _cancelled)) {
             LOGS(_log, LOG_LVL_WARN,
                  " Could not report error to czar as sendChannel not accepting msgs." << _task->getIdStr());
         }
-        LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmiError b1");
     }
     return !erred;
 }

--- a/src/wdb/QueryRunner.cc
+++ b/src/wdb/QueryRunner.cc
@@ -147,6 +147,7 @@ size_t QueryRunner::_getDesiredLimit() {
 util::TimerHistogram memWaitHisto("memWait Hist", {1, 5, 10, 20, 40});
 
 bool QueryRunner::runQuery() {
+    LOGS(_log, LOG_LVL_WARN, "&&& runQuery start");
     util::InstanceCount ic(to_string(_task->getQueryId()) + "_rq_LDB");  // LockupDB
     util::HoldTrack::Mark runQueryMarkA(ERR_LOC, "runQuery " + to_string(_task->getQueryId()));
     QSERV_LOGCONTEXT_QUERY_JOB(_task->getQueryId(), _task->getJobId());
@@ -254,6 +255,7 @@ private:
 };
 
 bool QueryRunner::_dispatchChannel() {
+    LOGS(_log, LOG_LVL_WARN, "&&& dispatch start");
     bool erred = false;
     bool needToFreeRes = false;  // set to true once there are results to be freed.
     // Collect the result in _transmitData. When a reasonable amount of data has been collected,
@@ -298,7 +300,9 @@ bool QueryRunner::_dispatchChannel() {
                 if (sendChan == nullptr) {
                     throw util::Bug(ERR_LOC, "QueryRunner::_dispatchChannel() sendChan==null");
                 }
+                LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmitResult a");
                 erred = sendChan->buildAndTransmitResult(res, _task, _multiError, _cancelled);
+                LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmitResult a1");
             }
         }
     } catch (sql::SqlErrorObject const& e) {
@@ -321,10 +325,12 @@ bool QueryRunner::_dispatchChannel() {
         erred = true;
         // Send results. This needs to happen after the error check.
         // If any errors were found, send an error back.
+        LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmiError b");
         if (!_task->getSendChannel()->buildAndTransmitError(_multiError, _task, _cancelled)) {
             LOGS(_log, LOG_LVL_WARN,
                  " Could not report error to czar as sendChannel not accepting msgs." << _task->getIdStr());
         }
+        LOGS(_log, LOG_LVL_WARN, "&&& dispatch calling buildAndTransmiError b1");
     }
     return !erred;
 }


### PR DESCRIPTION
The only thing I'm concerned about here is that moving the mutex may result in more contention within mariadb as it can be required to hand out more results concurrently. Testing shows about a 20% improvement in dealing with tests/q7688979.1.4k.chunks.sql, but this may not be a great test case. At least moving some of the member variables to local makes it easier to relocate the mutex.