### PR TITLE
DM-45311: Upgraded the Apache Arrow and Parquet libraries to version 17

### DIFF
--- a/admin/tools/docker/base/Dockerfile
+++ b/admin/tools/docker/base/Dockerfile
@@ -222,8 +222,8 @@ RUN dnf update -y \
        https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm \
     && dnf config-manager --set-enabled epel \
     && dnf config-manager --set-enabled crb \
-    && dnf install -y arrow16-libs \
-    && dnf install -y parquet16-libs \
+    && dnf install -y arrow1700-libs \
+    && dnf install -y parquet1700-libs \
     && dnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Note a change in the library version naming. It used to be "15", "16". As of the current version, it's "1700". 