### PR TITLE
DM-46430: Garbage collection of the completed table contribution requests

### DIFF
--- a/src/replica/ingest/IngestHttpSvcMod.cc
+++ b/src/replica/ingest/IngestHttpSvcMod.cc
@@ -128,8 +128,8 @@ json IngestHttpSvcMod::_asyncCancelRequest() const {
     checkApiVersion(__func__, 13);
 
     auto const id = stoul(params().at("id"));
-    auto const contrib = _ingestRequestMgr->cancel(id);
-    return json::object({{"contrib", contrib.toJson()}});
+    _ingestRequestMgr->cancel(id);
+    return json::object({{"contrib", _ingestRequestMgr->find(id).toJson()}});
 }
 
 json IngestHttpSvcMod::_asyncTransRequests() const {
@@ -158,7 +158,8 @@ json IngestHttpSvcMod::_asyncTransCancelRequests() const {
     json contribsJson = json::array();
     for (auto& contrib : contribs) {
         try {
-            contribsJson.push_back(_ingestRequestMgr->cancel(contrib.id).toJson());
+            _ingestRequestMgr->cancel(contrib.id);
+            contribsJson.push_back(_ingestRequestMgr->find(contrib.id).toJson());
         } catch (IngestRequestNotFound const& ex) {
             // Ignore the false-positive error condition for the inactive requests that don't
             // have in-memory representation. These requests only exist in the persistent state


### PR DESCRIPTION
The output collection of the completed/cancalled/failed requests has been eliminated to avoid accumilating memory over the lifetime of the worker service. Minor changes to the request processing manager habe been made. The unit test was adjusted accordingly. The changed do not affet clients of the Replication/Ingest system's REST API.