### PR TITLE
Remove pull request trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@
 name: "CI"
 on:
   push:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `pull_request` trigger always duplicates `on: push` and so can be removed.