### PR TITLE
DM-49396: small build fixes

### DIFF
--- a/admin/tools/docker/base/Dockerfile
+++ b/admin/tools/docker/base/Dockerfile
@@ -129,7 +129,7 @@ RUN cd /tmp \
     && git checkout tags/v5.6.2 \
     && git config --global user.email "qserv@slac.stanford.edu" \
     && git config --global user.name "Qserv" \
-    && git cherry-pick f48a11c92daad3e164ebf8b8f248c3b8bae06888 \
+    && git cherry-pick d85915a3927261e49859c3e13075bce1dfefcbe4 \
     && mkdir build \
     && cd build \
     && cmake -DENABLE_PYTHON=off .. \

--- a/src/replica/apps/HttpLibServerApp.cc
+++ b/src/replica/apps/HttpLibServerApp.cc
@@ -25,6 +25,7 @@
 // System headers
 #include <chrono>
 #include <iostream>
+#include <fstream>
 
 // Third party headers
 #include <httplib.h>


### PR DESCRIPTION
Address a couple build breakers where unpinned things shifted beneath `qserv`:

* XRootD SSI bug fix cherry pick commit
* An exposed missing `<fstream>` header dependency