### PR TITLE
DM-49795: Fixed a bug in the the worker configuration classes

### DIFF
--- a/src/util/ConfigValMap.h
+++ b/src/util/ConfigValMap.h
@@ -162,11 +162,11 @@ public:
 
 protected:
     ConfigValT(std::string const& section, std::string const& name, bool required, T defVal, bool hidden)
-            : ConfigVal(section, name, required, hidden), _val(defVal) {}
+            : ConfigVal(section, name, required, hidden), _defVal(defVal), _val(_defVal) {}
 
 private:
-    T _val;     ///< Value for the item this class is storing.
-    T _defVal;  ///< Default value for the item this class is storing.
+    T const _defVal;  ///< Default value for the item this class is storing.
+    T _val;           ///< Value for the item this class is storing.
 };
 
 /// Bool is special case for json as the value should be "true" or "false" but

--- a/src/wconfig/WorkerConfig.h
+++ b/src/wconfig/WorkerConfig.h
@@ -88,9 +88,9 @@ public:
 private:
     ConfigValResultDeliveryProtocol(std::string const& section, std::string const& name, bool required,
                                     std::string const& defVal, bool hidden)
-            : ConfigVal(section, name, required, hidden), _val(parse(defVal)) {}
-    TEnum _val;
-    TEnum _defVal;
+            : ConfigVal(section, name, required, hidden), _defVal(parse(defVal)), _val(_defVal) {}
+    TEnum const _defVal;  ///< Default value for the item this class is storing.
+    TEnum _val;           ///< Value for the item this class is storing.
 };
 
 /// Provide all configuration parameters for a Qserv worker instance.


### PR DESCRIPTION
Some data members were not initialized. This was causing occasionbal crashes of the application and possible memory corruption.