### PR TITLE
DM-49862: Switched to using a specific release of the cpp-httplib

### DIFF
--- a/admin/tools/docker/base/Dockerfile
+++ b/admin/tools/docker/base/Dockerfile
@@ -150,8 +150,10 @@ RUN cd /tmp \
 
 RUN cd /tmp \
     && git clone https://github.com/yhirose/cpp-httplib.git \
-    && mkdir cpp-httplib/build \
-    && cd cpp-httplib/build \
+    && cd cpp-httplib \
+    && git checkout v0.19.0 \
+    && mkdir build \
+    && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release -DHTTPLIB_REQUIRE_OPENSSL=on -DHTTPLIB_COMPILE=on -DBUILD_SHARED_LIBS=on .. \
     && cmake --build . --target install \
     && cd /tmp \


### PR DESCRIPTION
Release v0.19.0 was made before a bug related to zstd was introduced in v0.20.0.