### PR TITLE
DM-51963: Upgraded Apache Arrow and Parquet libs to version 21

### DIFF
--- a/admin/tools/docker/base/Dockerfile
+++ b/admin/tools/docker/base/Dockerfile
@@ -262,8 +262,8 @@ RUN dnf update -y \
        https://apache.jfrog.io/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
     && dnf config-manager --set-enabled epel \
     && dnf config-manager --set-enabled crb \
-    && dnf install -y arrow2000-libs \
-    && dnf install -y parquet2000-libs \
+    && dnf install -y arrow2100-libs \
+    && dnf install -y parquet2100-libs \
     && dnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Otherwise applications crash with:

  error while loading shared libraries: libarrow.so.2100: cannot open shared object file:
  No such file or directory