### PR TITLE
DM-52756: repair accumulated `smig` bitrot

### DIFF
--- a/bin/qserv-smig
+++ b/bin/qserv-smig
@@ -23,6 +23,7 @@
 """Application which implements migration process for qserv databases."""
 
 import argparse
+import logging
 import os
 import sys
 
@@ -37,6 +38,7 @@ def main() -> int | None:
     parser.add_argument(
         "-v", "--verbose", default=0, action="count", help="Use one -v for INFO logging, two for DEBUG."
     )
+
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "-m",
@@ -51,6 +53,7 @@ def main() -> int | None:
         action="store_true",
         help="Check that migration is needed, script returns 0 if schema is up-to-date, 1 otherwise.",
     )
+
     parser.add_argument(
         "-n",
         "--final",
@@ -60,6 +63,7 @@ def main() -> int | None:
         metavar="VERSION",
         help="Stop migration at given version, by default update to latest version.",
     )
+
     parser.add_argument(
         "--scripts",
         default=_def_scripts,
@@ -67,27 +71,55 @@ def main() -> int | None:
         metavar="PATH",
         help="Location for migration scripts, def: %(default)s.",
     )
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument(
+
+    parser.add_argument(
         "-c",
         "--connection",
         metavar="CONNECTION",
         help="Connection string in format mysql://user:pass@host:port/database.",
     )
-    group.add_argument(
-        "-f",
-        "--config-file",
-        metavar="PATH",
-        help="Name of configuration file in INI format with connection parameters.",
-    )
+
     parser.add_argument(
-        "-s", "--config-section", metavar="NAME", help="Name of configuration section in configuration file."
+        "module",
+        help="Name of Qserv module for which to update schema, e.g. qmeta.",
     )
 
-    parser.add_argument("module", help="Name of Qserv module for which to update schema, e.g. qmeta.")
+    parser.add_argument(
+        "additional",
+        metavar="--arg[=value]",
+        nargs="*",
+        help="Additional arguments to pass to migration manager.",
+    )
 
     args = parser.parse_args()
-    return smig(**args)
+
+    levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    level = levels.get(args.verbose, logging.DEBUG)
+    fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt)
+
+    mig_mgr_args = {}
+    if args.additional:
+        for arg in args.additional:
+            if not arg.startswith("--"):
+                parser.error(f"Additional arguments must start with --: {arg}")
+            arg = arg[2:]
+            if "=" in arg:
+                key, val = arg.split("=", 1)
+            else:
+                key, val = arg, True
+            mig_mgr_args[key] = val
+
+    return smig(
+        do_migrate=args.do_migrate,
+        check=args.check,
+        final=args.final,
+        scripts=args.scripts,
+        connection=args.connection,
+        module=args.module,
+        mig_mgr_args=mig_mgr_args,
+        update=True,
+    )
 
 
 if __name__ == "__main__":

--- a/python/lsst/qserv/admin/cli/entrypoint.py
+++ b/python/lsst/qserv/admin/cli/entrypoint.py
@@ -33,6 +33,7 @@ from typing import Any
 import click
 from click.decorators import pass_context
 
+from ..template import save_template_cfg
 from ..watcher import watch
 from . import script, utils
 from .options import (
@@ -57,6 +58,7 @@ from .options import (
     option_repl_admin_auth_key,
     option_repl_auth_key,
     option_repl_connection,
+    option_repl_connection_nonadmin,
     option_repl_http_port,
     option_repl_instance_id,
     option_repl_registry_host,
@@ -64,6 +66,7 @@ from .options import (
     option_results_dirname,
     option_run,
     option_run_tests,
+    option_targs,
     option_tests_yaml,
     option_unload,
     option_vnid_config,
@@ -1042,13 +1045,22 @@ def watcher(
 @option_czar_connection()
 @option_worker_connection()
 @option_repl_connection()
-@option_options_file()
-def smig_update(czar_connection: str, worker_connections: list[str], repl_connection: str) -> None:
+@option_repl_connection_nonadmin()
+@option_targs()
+def smig_update(
+    czar_connection: str,
+    worker_connections: list[str],
+    repl_connection: str,
+    repl_connection_nonadmin: str,
+    targs: dict[str, Any],
+) -> None:
     """Run schema update on nodes."""
+    save_template_cfg(targs)
     script.smig_update(
         czar_connection=czar_connection,
         worker_connections=worker_connections,
         repl_connection=repl_connection,
+        repl_connection_nonadmin=repl_connection_nonadmin,
     )
 
 

--- a/python/lsst/qserv/admin/cli/options.py
+++ b/python/lsst/qserv/admin/cli/options.py
@@ -116,6 +116,13 @@ option_repl_connection = partial(
 )
 
 
+option_repl_connection_nonadmin = partial(
+    click.option,
+    "--repl-connection-nonadmin",
+    help="The non-admin connection string for the replication database in format mysql://user:pass@host:port/database",
+)
+
+
 option_repl_instance_id = partial(
     click.option,
     "--repl-instance-id",

--- a/python/lsst/qserv/admin/cli/script.py
+++ b/python/lsst/qserv/admin/cli/script.py
@@ -32,9 +32,8 @@ from functools import partial
 from pathlib import Path
 
 import backoff
-from sqlalchemy.engine.url import URL, make_url
-
 import mysql.connector
+from sqlalchemy.engine.url import URL, make_url
 
 from ...schema import MigMgrArgs, SchemaUpdateRequiredError, smig, smig_block
 from ..itest import ITestResults
@@ -868,7 +867,12 @@ def enter_replication_registry(
     sys.exit(_run(args=None, cmd=cmd, env=env, run=run))
 
 
-def smig_update(czar_connection: str, worker_connections: list[str], repl_connection: str) -> None:
+def smig_update(
+    czar_connection: str,
+    worker_connections: list[str],
+    repl_connection: str,
+    repl_connection_nonadmin: str,
+) -> None:
     """Update smig on nodes that need it.
 
     All connection strings are in format mysql://user:pass@host:port/database
@@ -888,7 +892,9 @@ def smig_update(czar_connection: str, worker_connections: list[str], repl_connec
         for c in worker_connections:
             smig_worker(connection=c, update=True)
     if repl_connection:
-        smig_replication_controller(db_admin_uri=repl_connection, db_uri=None, update=True)
+        smig_replication_controller(
+            db_admin_uri=repl_connection, db_uri=repl_connection_nonadmin, update=True
+        )
 
 
 def _run(

--- a/python/lsst/qserv/admin/cli/utils.py
+++ b/python/lsst/qserv/admin/cli/utils.py
@@ -166,7 +166,7 @@ def targs(
 
     Returns
     -------
-    targs : Dict[str, Union[int, Any]]
+    targs : Dict[str, Any]
         The dict of values to to render templates.
     """
     options = copy.copy(ctx.params)

--- a/python/lsst/qserv/admin/template.py
+++ b/python/lsst/qserv/admin/template.py
@@ -42,7 +42,7 @@ def save_template_cfg(values: Targs) -> None:
 
     Parameters
     ----------
-    values : `dict` [`str`, `str`]
+    values : `dict` [`str`, `Any`]
         Key-value pairs to add.
     """
     if not values:
@@ -57,7 +57,7 @@ def save_template_cfg(values: Targs) -> None:
         f.write(yaml.dump(cfg))
 
 
-def get_template_cfg() -> dict[Any, Any]:
+def get_template_cfg() -> dict[str, Any]:
     """Get the dict of key-value pairs from the config parameter file."""
     try:
         with open(cfg_file_path) as f:

--- a/python/lsst/qserv/admin/tests/test_smig.py
+++ b/python/lsst/qserv/admin/tests/test_smig.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 
 from lsst.qserv.admin.cli import script
 from lsst.qserv.qmeta.schema_migration import QMetaMigrationManager
-from lsst.qserv.schema import SchemaMigMgr, SchemaUpdateRequiredError, Uninitialized
+from lsst.qserv.schema import SchemaMigMgr, SchemaUpdateRequiredError, Uninitialized, Version
 
 migration_files = [
     "migrate-0-to-1.sql",
@@ -40,9 +40,9 @@ migration_files = [
 ]
 
 # This number must match the highest 'to' number in migration_files.
-latest_qmeta_schema_version = 5
+latest_qmeta_schema_version = Version(5)
 # This number must match the second highest 'to' number in migration_files.
-previous_qmeta_schema_version = 4
+previous_qmeta_schema_version = Version(4)
 # This is the file that migrates from Uninitialized to latest
 qmeta_migrate_uninit_to_newest = migration_files[4]
 # This is the file that migrates from previous to latest

--- a/src/tests/MySqlUdf.py
+++ b/src/tests/MySqlUdf.py
@@ -230,9 +230,9 @@ class MySqlUdfTestCase(unittest.TestCase):
             self._pt_in_sph_poly(None, 0.0, 0.0, 0, 0, 90, 0, 0, d)
 
         # test for incorrect number of poly coordinates
-        self.assertRaises(Exception, self._pt_in_sph_poly, None, 0.0, 0.0, 0, 0, 90, 0, 60, 45, 30)
-        self.assertRaises(Exception, self._pt_in_sph_poly, None, 0.0, 0.0, 0, 0, 90, 0, 60)
-        self.assertRaises(Exception, self._pt_in_sph_poly, None, 0.0, 0.0, 0, 0, 90, 0)
+        self.assertRaises(Exception, self._pt_in_sph_poly, None, 0.0, 0.0, 0, 0, 90, 0, 60, 45, 30)  # noqa: B017
+        self.assertRaises(Exception, self._pt_in_sph_poly, None, 0.0, 0.0, 0, 0, 90, 0, 60)  # noqa: B017
+        self.assertRaises(Exception, self._pt_in_sph_poly, None, 0.0, 0.0, 0, 0, 90, 0)  # noqa: B017
 
         # Test for non-exceptional cases
         x = (0, 0)
@@ -282,7 +282,7 @@ def main():
     parser.add_option(
         "-p", "--password", dest="password", default="", help="Password for db login. ('-' prompts)"
     )
-    (_options, args) = parser.parse_args()
+    (_options, _) = parser.parse_args()
     if _options.password == "-":
         _options.password = getpass.getpass()
     random.seed(123456789)


### PR DESCRIPTION
The `smig` schema upgrade tooling in the Qserv containers has bitrotted slightly.  First noticed when working up the new Helm chart for modern Qserv and initializing a cluster on a set of completely blank databases.

* Repair standalone `bin/qserv-smig` script, which had been busted for a while.  This was mostly fiddling with `argparse` in the top-level script, removing deprecated args, wiring back up logging, and adding a pass-through for additional mig-mgr-specific args.

* Added some arg plumbing to `entrypoint smig-update ...`, needed when this is used instead of entrypoint `auto-smig` in the case that databases are completely blank.  This adds a new `--repl-connection-nonadmin` arg for the replication case, and `--targs` support for passing needed template variables in other cases.

* Fix some minor typing issues around `Version` in the `smig` core code, which also fixes a bug in the reporting of which migrations are applied on any given run.

* Some minor `ruff` lints detected by newest version (on separate commit.)