### PR TITLE
Tickets/dm 54206

### DIFF
--- a/src/ccontrol/UserQuerySelect.cc
+++ b/src/ccontrol/UserQuerySelect.cc
@@ -253,7 +253,7 @@ void UserQuerySelect::submit() {
 
     string dbName("");
     bool dbNameSet = false;
-
+    bool checkDbs = true;
     for (auto i = _qSession->cQueryBegin(), e = _qSession->cQueryEnd(); i != e && !exec->getCancelled();
          ++i) {
         auto& chunkSpec = *i;
@@ -267,7 +267,10 @@ void UserQuerySelect::submit() {
         {
             lock_guard<mutex> lock(chunksMtx);
             bool fillInChunkIdTag = false;  // do not fill in the chunkId
-            cs = _qSession->buildChunkQuerySpec(queryTemplates, chunkSpec, fillInChunkIdTag);
+            cs = _qSession->buildChunkQuerySpec(queryTemplates, chunkSpec, fillInChunkIdTag, checkDbs);
+            // Only need to check the dominantDbs for the first chunk, as all chunks
+            // should have the same databases (same databases, different tables).
+            checkDbs = false;
             chunks.push_back(cs->chunkId);
         }
 

--- a/src/czar/ActiveWorker.cc
+++ b/src/czar/ActiveWorker.cc
@@ -72,11 +72,10 @@ void ActiveWorker::setWorkerContactInfo(protojson::WorkerContactInfo::Ptr const&
 }
 
 void ActiveWorker::_changeStateTo(State newState, double secsSinceUpdate, string const& note) {
-    auto lLvl = (newState == DEAD) ? LOG_LVL_ERROR : LOG_LVL_INFO;
+    auto lLvl = (newState == DEAD) ? LOG_LVL_ERROR : LOG_LVL_WARN;
     LOGS(_log, lLvl,
          note << " oldState=" << getStateStr(_state) << " newState=" << getStateStr(newState)
               << " secsSince=" << secsSinceUpdate);
-    _state = newState;
 }
 
 void ActiveWorker::updateStateAndSendMessages(double timeoutAliveSecs, double timeoutDeadSecs,
@@ -96,6 +95,9 @@ void ActiveWorker::updateStateAndSendMessages(double timeoutAliveSecs, double ti
              cName(__func__) << " wInfo=" << wInfo_->dump()
                              << " secsSince=" << wInfo_->timeSinceRegUpdateSeconds()
                              << " secsSinceUpdate=" << secsSinceUpdate);
+        LOGS(_log, LOG_LVL_WARN,
+             "&&& " << cName(__func__) << " wInfo=" << wInfo_->dump() << " secsSince="
+                    << wInfo_->timeSinceRegUpdateSeconds() << " secsSinceUpdate=" << secsSinceUpdate);
 
         // Update the last time the registry contacted this worker.
         // TODO:DM-53240 - This needs to be added to the dashboard.

--- a/src/czar/Czar.cc
+++ b/src/czar/Czar.cc
@@ -162,7 +162,7 @@ Czar::Czar(string const& configFilePath, string const& czarName)
           _clientToQuery(),
           _monitorSleepTime(_czarConfig->getMonitorSleepTimeMilliSec()),
           _activeWorkerMap(new ActiveWorkerMap(_czarConfig)),
-          _fqdn(util::get_current_host_fqdn()) {
+          _fqdn(util::get_current_host_fqdn_wait()) {
     // set id counter to milliseconds since the epoch, mod 1 year.
     struct timeval tv;
     gettimeofday(&tv, nullptr);
@@ -728,6 +728,20 @@ protojson::ExecutiveRespMsg::Ptr Czar::handleUberJobReadyMsg(
     return importRes;
 }
 
+protojson::ExecutiveRespMsg::Ptr Czar::handleUberJobReadyMsgNoThrow(
+        std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg, string const& note) {
+    protojson::ExecutiveRespMsg::Ptr execRespMsg;
+    try {
+        execRespMsg = handleUberJobReadyMsg(jrMsg, note);
+    } catch (invalid_argument const& ex) {
+        LOGS(_log, LOG_LVL_WARN, note << " exception: " << ex.what());
+        // The message was parsed, but this UberJob is no longer needed by the czar.
+        execRespMsg = protojson::ExecutiveRespMsg::create(false, true, jrMsg->queryId, jrMsg->uberJobId,
+                                                          jrMsg->czarId, "uberJobEnded", ex.what());
+    }
+    return execRespMsg;
+}
+
 protojson::ExecutiveRespMsg::Ptr Czar::handleUberJobErrorMsg(
         std::shared_ptr<protojson::UberJobErrorMsg> const& jrMsg, string const& note) {
     auto queryId = jrMsg->queryId;
@@ -753,13 +767,32 @@ protojson::ExecutiveRespMsg::Ptr Czar::handleUberJobErrorMsg(
         LOGS(_log, LOG_LVL_WARN, note << " No UberJob for " << idMsg);
         execRespMsg->success = true;
         execRespMsg->dataObsolete = true;
-        execRespMsg->errorType = "queryEnded";
+        execRespMsg->errorType = "uberJobEnded";
         execRespMsg->note = "null UberJob";
         return execRespMsg;
     }
 
     uj->workerError(jrMsg->multiError, *execRespMsg);
     return execRespMsg;
+}
+
+void Czar::incrCommErrCount(std::string const& type, std::string const& worker, std::string const& note) {
+    LOGS(_log, LOG_LVL_WARN, "Czar::incrCommErrCount " << type << " worker=" << worker << " " << note);
+    stringstream os;
+    lock_guard lg(_commErrCountMtx);
+    auto key = std::make_pair(type, worker);
+    auto iter = _commErrCountMap.find(key);
+    if (iter == _commErrCountMap.end()) {
+        _commErrCountMap[key] = 1;
+    } else {
+        iter->second += 1;
+    }
+    os << "Czar::incrCommErrCount {";
+    for (auto const& [key, val] : _commErrCountMap) {
+        LOGS(_log, LOG_LVL_WARN, "(" << key.first << " worker=" << key.second << " count=" << val << ")");
+    }
+    os << "}";
+    LOGS(_log, LOG_LVL_WARN, os.str());
 }
 
 }  // namespace lsst::qserv::czar

--- a/src/czar/Czar.cc
+++ b/src/czar/Czar.cc
@@ -698,8 +698,8 @@ void Czar::killIncompleteUbjerJobsOn(std::string const& restartedWorkerId) {
     }
 }
 
-nlohmann::json Czar::handleUberJobReadyMsg(std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg,
-                                           string const& note, bool const retry) {
+protojson::ExecutiveRespMsg::Ptr Czar::handleUberJobReadyMsg(
+        std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg, string const& note) {
     auto queryId = jrMsg->queryId;
     auto czarId = jrMsg->czarId;
     auto uberJobId = jrMsg->uberJobId;
@@ -708,6 +708,7 @@ nlohmann::json Czar::handleUberJobReadyMsg(std::shared_ptr<protojson::UberJobRea
     if (exec == nullptr) {
         LOGS(_log, LOG_LVL_WARN,
              note << " null exec QID:" << queryId << " ujId=" << uberJobId << " cz=" << czarId);
+        // This means the user query is done and the results on the worker won't be needed
         throw invalid_argument(string("HttpCzarWorkerModule::_handleJobReady No executive for qid=") +
                                to_string(queryId) + " czar=" + to_string(czarId));
     }
@@ -723,30 +724,42 @@ nlohmann::json Czar::handleUberJobReadyMsg(std::shared_ptr<protojson::UberJobRea
     uj->setResultFileSize(jrMsg->fileUrlInfo.fileSize);
     exec->checkResultFileSize(jrMsg->fileUrlInfo.fileSize);
 
-    auto importRes = uj->importResultFile(jrMsg->fileUrlInfo, retry);
+    auto importRes = uj->importResultFile(jrMsg->fileUrlInfo);
     return importRes;
 }
 
-nlohmann::json Czar::handleUberJobErrorMsg(std::shared_ptr<protojson::UberJobErrorMsg> const& jrMsg,
-                                           string const& note) {
+protojson::ExecutiveRespMsg::Ptr Czar::handleUberJobErrorMsg(
+        std::shared_ptr<protojson::UberJobErrorMsg> const& jrMsg, string const& note) {
     auto queryId = jrMsg->queryId;
     auto czarId = jrMsg->czarId;
     auto uberJobId = jrMsg->uberJobId;
+    string const idMsg =
+            "qId=" + to_string(queryId) + " ujId=" + to_string(uberJobId) + " czId=" + to_string(czarId);
+    auto execRespMsg = protojson::ExecutiveRespMsg::create(false, false, queryId, uberJobId, czarId);
 
     // Find UberJob
     qdisp::Executive::Ptr exec = czar::Czar::getCzar()->getExecutiveFromMap(queryId);
     if (exec == nullptr) {
-        throw invalid_argument(note + " No executive for qid=" + to_string(queryId) +
-                               " czar=" + to_string(czarId));
+        // exec==nullptr just means this czar no longer has any use for any data associated with this QID.
+        LOGS(_log, LOG_LVL_WARN, note << " No executive for " << idMsg);
+        execRespMsg->success = true;
+        execRespMsg->dataObsolete = true;
+        execRespMsg->errorType = "queryEnded";
+        execRespMsg->note = "null Executive";
+        return execRespMsg;
     }
     qdisp::UberJob::Ptr uj = exec->findUberJob(uberJobId);
     if (uj == nullptr) {
-        throw invalid_argument(note + " No UberJob for qid=" + to_string(queryId) +
-                               " ujId=" + to_string(uberJobId) + " czar=" + to_string(czarId));
+        LOGS(_log, LOG_LVL_WARN, note << " No UberJob for " << idMsg);
+        execRespMsg->success = true;
+        execRespMsg->dataObsolete = true;
+        execRespMsg->errorType = "queryEnded";
+        execRespMsg->note = "null UberJob";
+        return execRespMsg;
     }
 
-    auto importRes = uj->workerError(jrMsg->multiError);
-    return importRes;
+    uj->workerError(jrMsg->multiError, *execRespMsg);
+    return execRespMsg;
 }
 
 }  // namespace lsst::qserv::czar

--- a/src/czar/Czar.h
+++ b/src/czar/Czar.h
@@ -41,6 +41,7 @@
 #include "global/intTypes.h"
 #include "global/stringTypes.h"
 #include "mysql/MySqlConfig.h"
+#include "protojson/ResponseMsg.h"
 #include "util/ConfigStore.h"
 #include "util/Timer.h"
 
@@ -170,15 +171,13 @@ public:
 
     /// Starts the process of collecting a result file from the worker.
     /// @throws std::invalid_argument
-    /// @param retry - true indicates this is a retry of a failed communication and
-    ///          should not kill the associated UberJob due to an unexpected state.
-    nlohmann::json handleUberJobReadyMsg(std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg,
-                                         std::string const& note, bool const retry = false);
+    protojson::ExecutiveRespMsg::Ptr handleUberJobReadyMsg(
+            std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg, std::string const& note);
 
     /// Handle an UberJob processing error from the worker.
     /// @throws std::invalid_argument
-    nlohmann::json handleUberJobErrorMsg(std::shared_ptr<protojson::UberJobErrorMsg> const& jrMsg,
-                                         std::string const& note);
+    protojson::ExecutiveRespMsg::Ptr handleUberJobErrorMsg(
+            std::shared_ptr<protojson::UberJobErrorMsg> const& jrMsg, std::string const& note);
 
     /// Startup time of czar, sent to workers so they can detect that the czar was
     /// was restarted when this value changes.

--- a/src/czar/Czar.h
+++ b/src/czar/Czar.h
@@ -174,10 +174,18 @@ public:
     protojson::ExecutiveRespMsg::Ptr handleUberJobReadyMsg(
             std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg, std::string const& note);
 
-    /// Handle an UberJob processing error from the worker.
-    /// @throws std::invalid_argument
+    /// Same as handleUberJobReadyMsg but returns an altered message instead of throwing.
+    protojson::ExecutiveRespMsg::Ptr handleUberJobReadyMsgNoThrow(
+            std::shared_ptr<protojson::UberJobReadyMsg> const& jrMsg, std::string const& note);
+
+    /// Handle an UberJob processing error from the worker, does not throw exceptions.
+    /// It alters the returned response message instead of throwing an exception.
     protojson::ExecutiveRespMsg::Ptr handleUberJobErrorMsg(
             std::shared_ptr<protojson::UberJobErrorMsg> const& jrMsg, std::string const& note);
+
+    /// Increment a communication error count. Just logging them now as it probably is not an
+    /// issue, but may be they have been happening and it would be useful to know.
+    void incrCommErrCount(std::string const& type, std::string const& worker, std::string const& note);
 
     /// Startup time of czar, sent to workers so they can detect that the czar was
     /// was restarted when this value changes.
@@ -275,6 +283,11 @@ private:
 
     /// FQDN for this czar.
     std::string const _fqdn;
+
+    /// Map of communication error counts by type and worker, protected by _commErrCountMtx.
+    /// Key - <error type, worker id> - value - count of errors of that type for that worker.
+    std::map<std::pair<std::string, std::string>, int> _commErrCountMap;
+    mutable std::mutex _commErrCountMtx;  ///< protects _commErrCountMap
 };
 
 }  // namespace lsst::qserv::czar

--- a/src/czar/HttpCzarWorkerModule.cc
+++ b/src/czar/HttpCzarWorkerModule.cc
@@ -109,12 +109,12 @@ json HttpCzarWorkerModule::_handleJobError(string const& func) {
         auto const& jsReq = body().objJson;
         auto jrMsg = protojson::UberJobErrorMsg::createFromJson(jsReq);
         auto importRes = czar::Czar::getCzar()->handleUberJobErrorMsg(jrMsg, fName);
-        return importRes;
+        return importRes->toJson();
     } catch (std::invalid_argument const& iaEx) {
         LOGS(_log, LOG_LVL_ERROR,
              "HttpCzarWorkerModule::_handleJobError received "
                      << iaEx.what() << " js=" << protojson::pwHide(body().objJson));
-        protojson::ResponseMsg respMsg(false, "parse", iaEx.what());
+        protojson::ExecutiveRespMsg respMsg(false, false, 0, 0, 0, "parse", iaEx.what());
         return respMsg.toJson();
     }
 }
@@ -129,12 +129,12 @@ json HttpCzarWorkerModule::_handleJobReady(string const& func) {
         auto const& jsReq = body().objJson;
         auto jrMsg = protojson::UberJobReadyMsg::createFromJson(jsReq);
         auto importRes = czar::Czar::getCzar()->handleUberJobReadyMsg(jrMsg, fName);
-        return importRes;
+        return importRes->toJson();
     } catch (std::invalid_argument const& iaEx) {
         LOGS(_log, LOG_LVL_ERROR,
              "HttpCzarWorkerModule::_handleJobReady received "
                      << iaEx.what() << " js=" << protojson::pwHide(body().objJson));
-        protojson::ResponseMsg respMsg(false, "parse", iaEx.what());
+        protojson::ExecutiveRespMsg respMsg(false, false, 0, 0, 0, "parse", iaEx.what());
         return respMsg.toJson();
     }
 }
@@ -150,7 +150,7 @@ json HttpCzarWorkerModule::_handleWorkerCzarComIssue(string const& func) {
         auto wccIssue = protojson::WorkerCzarComIssue::createFromJson(jsReq, authC);
 
         auto wId = wccIssue->getWorkerInfo()->wId;
-        if (wccIssue->getThoughtCzarWasDead()) {
+        if (wccIssue->getThoughtCzarWasDeadTime() > 0) {
             LOGS(_log, LOG_LVL_WARN,
                  "HttpCzarWorkerModule::_handleWorkerCzarComIssue worker="
                          << wId << " thought czar was dead and killed related uberjobs.");
@@ -164,30 +164,34 @@ json HttpCzarWorkerModule::_handleWorkerCzarComIssue(string const& func) {
                 execPtr->killIncompleteUberJobsOnWorker(wId);
             }
         }
-        // The response here includes the QueryId and UberJobId of all
-        // uberjobs in the original message. If the czar cannot handle
-        // one now, it won't be able to handle it later, so there's no
-        // point in the worker sending it again.
-        // Under normal circumstances, the czar should be able to
-        // find and handle all failed transmits. Anything it can't find should
-        // show up in completed query IDs, or failed uberJobs, and failing that
-        // it should be garbage collected.
-        auto jsRet = wccIssue->responseToJson();
+
+        // Responses are sent for all `failedTransmits` in the message. If
+        // something couldn't be parsed, the response indicates that and
+        // the UberJob will be abandoned by the worker. If the query
+        // could finish without the results of that uberjob, it indicates
+        // that the result file is obsolete. If the this was successful,
+        // the worker just waits for the czar to collect the file as usual.
+        // In all cases, the worker will remove the item from its
+        // `failedTransmits` list so it won't be tried again.
+        vector<protojson::ExecutiveRespMsg::Ptr> execRespMsgs;
         auto failedTransmits = wccIssue->takeFailedTransmitsMap();
         for (auto& [key, elem] : *failedTransmits) {
             protojson::UberJobStatusMsg::Ptr& statusMsg = elem;
             auto rdyMsg = dynamic_pointer_cast<protojson::UberJobReadyMsg>(statusMsg);
             if (rdyMsg != nullptr) {
-                bool const retry = true;
                 // Put the file on a queue to be collected later.
-                czar::Czar::getCzar()->handleUberJobReadyMsg(rdyMsg, fName, retry);
+                auto erMsg = czar::Czar::getCzar()->handleUberJobReadyMsg(rdyMsg, fName);
+                execRespMsgs.push_back(erMsg);
             } else {
                 auto errMsg = dynamic_pointer_cast<protojson::UberJobErrorMsg>(statusMsg);
                 // Kill the UberJob or user query depending on the error.
-                czar::Czar::getCzar()->handleUberJobErrorMsg(errMsg, fName);
+                auto erMsg = czar::Czar::getCzar()->handleUberJobErrorMsg(errMsg, fName);
+                execRespMsgs.push_back(erMsg);
             }
         }
-        LOGS(_log, LOG_LVL_TRACE, "HttpCzarWorkerModule::_handleWorkerCzarComIssue jsRet=" << jsRet.dump());
+        auto jsRet = wccIssue->responseToJson(wccIssue->getThoughtCzarWasDeadTime(), execRespMsgs);
+        LOGS(_log, LOG_LVL_TRACE,
+             "HttpCzarWorkerModule::_handleWorkerCzarComIssue jsRet=" << protojson::pwHide(jsRet));
         return jsRet;
     } catch (std::invalid_argument const& iaEx) {
         LOGS(_log, LOG_LVL_ERROR,

--- a/src/czar/HttpCzarWorkerModule.cc
+++ b/src/czar/HttpCzarWorkerModule.cc
@@ -143,13 +143,14 @@ json HttpCzarWorkerModule::_handleWorkerCzarComIssue(string const& func) {
     string const fName("HttpCzarWorkerModule::_handleWorkerCzarComIssue");
     LOGS(_log, LOG_LVL_DEBUG, fName << " start");
     // Parse and verify the json message and then deal with the problems.
+    string wId = "unknown";
     try {
         protojson::AuthContext const authC(cconfig::CzarConfig::instance()->replicationInstanceId(),
                                            cconfig::CzarConfig::instance()->replicationAuthKey());
         auto const& jsReq = body().objJson;
         auto wccIssue = protojson::WorkerCzarComIssue::createFromJson(jsReq, authC);
 
-        auto wId = wccIssue->getWorkerInfo()->wId;
+        wId = wccIssue->getWorkerInfo()->wId;
         if (wccIssue->getThoughtCzarWasDeadTime() > 0) {
             LOGS(_log, LOG_LVL_WARN,
                  "HttpCzarWorkerModule::_handleWorkerCzarComIssue worker="
@@ -180,13 +181,13 @@ json HttpCzarWorkerModule::_handleWorkerCzarComIssue(string const& func) {
             auto rdyMsg = dynamic_pointer_cast<protojson::UberJobReadyMsg>(statusMsg);
             if (rdyMsg != nullptr) {
                 // Put the file on a queue to be collected later.
-                auto erMsg = czar::Czar::getCzar()->handleUberJobReadyMsg(rdyMsg, fName);
-                execRespMsgs.push_back(erMsg);
+                auto exRespMsg = czar::Czar::getCzar()->handleUberJobReadyMsgNoThrow(rdyMsg, fName);
+                execRespMsgs.push_back(exRespMsg);
             } else {
                 auto errMsg = dynamic_pointer_cast<protojson::UberJobErrorMsg>(statusMsg);
-                // Kill the UberJob or user query depending on the error.
-                auto erMsg = czar::Czar::getCzar()->handleUberJobErrorMsg(errMsg, fName);
-                execRespMsgs.push_back(erMsg);
+                // Kill the UberJob or user query depending on the error. (Doesn't throw)
+                auto exRespMsg = czar::Czar::getCzar()->handleUberJobErrorMsg(errMsg, fName);
+                execRespMsgs.push_back(exRespMsg);
             }
         }
         auto jsRet = wccIssue->responseToJson(wccIssue->getThoughtCzarWasDeadTime(), execRespMsgs);
@@ -197,6 +198,9 @@ json HttpCzarWorkerModule::_handleWorkerCzarComIssue(string const& func) {
         LOGS(_log, LOG_LVL_ERROR,
              "HttpCzarWorkerModule::_handleWorkerCzarComIssue received "
                      << iaEx.what() << " js=" << protojson::pwHide(body().objJson));
+        // This is very bad as there's no way to know what is going wrong. Just one of these is surviveable,
+        // but if it keeps happening, the system is unstable.
+        Czar::getCzar()->incrCommErrCount("WorkerCzarComIssue", wId, iaEx.what());
         protojson::ResponseMsg respMsg(false, "parse", iaEx.what());
         return respMsg.toJson();
     }

--- a/src/mysql/CsvMemDisk.cc
+++ b/src/mysql/CsvMemDisk.cc
@@ -213,7 +213,7 @@ public:
 
     unsigned fetch(char* buffer, unsigned bufLen) override {
         if (bufLen == 0) {
-            throw LocalInfileError("CsvStreamBuffer::fetch Can't fetch non-positive bytes");
+            throw LocalInfileError("CsvMemDiskBuffer::fetch Can't fetch non-positive bytes");
         }
         auto csvMd = _csvMemDisk.lock();
         if (csvMd == nullptr) return 0;
@@ -234,7 +234,7 @@ public:
         return bytesToCopy;
     }
 
-    string dump() const override { return "CsvStreamBuffer"; }
+    string dump() const override { return "CsvMemDiskBuffer"; }
 
 private:
     weak_ptr<CsvMemDisk> _csvMemDisk;

--- a/src/protojson/PwHideJson.cc
+++ b/src/protojson/PwHideJson.cc
@@ -34,7 +34,7 @@ LOG_LOGGER _log = LOG_GET("lsst.qserv.protojson.PwHideJson");
 
 namespace lsst::qserv::protojson {
 
-//&&& Really need to make this recursive.
+// TODO Really need to make this recursive.
 nlohmann::json PwHideJson::hide(nlohmann::json const& in) const {
     try {
         nlohmann::json js(in);

--- a/src/protojson/PwHideJson.cc
+++ b/src/protojson/PwHideJson.cc
@@ -34,6 +34,7 @@ LOG_LOGGER _log = LOG_GET("lsst.qserv.protojson.PwHideJson");
 
 namespace lsst::qserv::protojson {
 
+//&&& Really need to make this recursive.
 nlohmann::json PwHideJson::hide(nlohmann::json const& in) const {
     try {
         nlohmann::json js(in);

--- a/src/protojson/ResponseMsg.cc
+++ b/src/protojson/ResponseMsg.cc
@@ -64,17 +64,112 @@ bool ResponseMsg::equal(ResponseMsg const& other) const {
 
 string ResponseMsg::dump() const {
     ostringstream os;
-    dump(os);
+    dumpOs(os);
     return os.str();
 }
 
-ostream& ResponseMsg::dump(ostream& os) const {
+ostream& ResponseMsg::dumpOs(ostream& os) const {
     os << "protojson::ResponseMsg success=" << success << " errorType=" << errorType << " note=" << note;
     return os;
 }
 
 ostream& operator<<(ostream& os, ResponseMsg const& cmd) {
-    cmd.dump(os);
+    cmd.dumpOs(os);
+    return os;
+}
+
+ExecutiveRespMsg::ExecutiveRespMsg(bool success_, bool dataObsolete_, QueryId qId_, UberJobId ujId_,
+                                   CzarId czId_, std::string const& errorType_, std::string const& note_)
+        : ResponseMsg(success_, errorType_, note_),
+          dataObsolete(dataObsolete_),
+          qId(qId_),
+          ujId(ujId_),
+          czId(czId_) {}
+
+ExecutiveRespMsg::Ptr ExecutiveRespMsg::createFromJson(nlohmann::json const& respJson) {
+    auto basePtr = ResponseMsg::createFromJson(respJson);
+    auto success_ = basePtr->success;
+    auto errorType_ = basePtr->errorType;
+    auto note_ = basePtr->note;
+
+    auto dataObsolete_ = http::RequestBodyJSON::required<bool>(respJson, "dataObsolete");
+    auto qId_ = http::RequestBodyJSON::required<QueryId>(respJson, "qId");
+    auto ujId_ = http::RequestBodyJSON::required<UberJobId>(respJson, "ujId");
+    auto czId_ = http::RequestBodyJSON::required<CzarId>(respJson, "czId");
+
+    return ExecutiveRespMsg::create(success_, dataObsolete_, qId_, ujId_, czId_, errorType_, note_);
+}
+
+json ExecutiveRespMsg::toJson() const {
+    json js = ResponseMsg::toJson();
+    js["dataObsolete"] = dataObsolete;
+    js["qId"] = qId;
+    js["ujId"] = ujId;
+    js["czId"] = czId;
+    return js;
+}
+
+std::ostream& ExecutiveRespMsg::dumpOs(std::ostream& os) const {
+    ResponseMsg::dumpOs(os);
+    os << "(ExecutiveRespMsg ";
+    os << " qId=" << qId;
+    os << " ujId=" << ujId;
+    os << " czId=" << czId;
+    os << " dataObsolete=" << dataObsolete;
+    os << ")";
+    return os;
+}
+
+WorkerCzarComRespMsg::Ptr WorkerCzarComRespMsg::createFromJson(nlohmann::json const& respJson) {
+    auto basePtr = ResponseMsg::createFromJson(respJson);
+    auto success_ = basePtr->success;
+    auto errorType_ = basePtr->errorType;
+    auto note_ = basePtr->note;
+
+    auto thoughtCzarWasDeadTime_ =
+            http::RequestBodyJSON::required<uint64_t>(respJson, "thoughtCzarWasDeadTime");
+    auto execRespMsgs_ = json::array();
+    if (respJson.contains("execRespMsgs")) {
+        execRespMsgs_ = respJson["execRespMsgs"];
+    }
+    vector<ExecutiveRespMsg::Ptr> execRMsgs;
+    for (auto const& jsExecRespMsg : execRespMsgs_) {
+        try {
+            auto execRespMsg = ExecutiveRespMsg::createFromJson(jsExecRespMsg);
+            execRMsgs.emplace_back(execRespMsg);
+        } catch (std::invalid_argument const& ex) {
+            LOGS(_log, LOG_LVL_WARN,
+                 "WorkerCzarComRespMsg::createFromJson failed to read execRespMsg:"
+                         << jsExecRespMsg << " exception: " << ex.what());
+        }
+    }
+    auto wccRespMsg = WorkerCzarComRespMsg::create(success_, thoughtCzarWasDeadTime_, errorType_, note_);
+    wccRespMsg->execRespMsgs = execRMsgs;
+    return wccRespMsg;
+}
+
+json WorkerCzarComRespMsg::toJson() const {
+    json js = ResponseMsg::toJson();
+    js["thoughtCzarWasDeadTime"] = thoughtCzarWasDeadTime;
+
+    json jsExecRespMsgs = json::array();
+    for (auto const& erMsg : execRespMsgs) {
+        jsExecRespMsgs.emplace_back(erMsg->toJson());
+    }
+    js["execRespMsgs"] = jsExecRespMsgs;
+    return js;
+}
+
+std::ostream& WorkerCzarComRespMsg::dumpOs(std::ostream& os) const {
+    ResponseMsg::dumpOs(os);
+    os << "(WorkerCzarComRespMsg czarDeadTime=" << thoughtCzarWasDeadTime;
+    os << " execRespMsgs(";
+    for (auto const& msg : execRespMsgs) {
+        os << "(";
+        msg->dumpOs(os);
+        os << ")";
+    }
+    os << "))";
     return os;
 }
 

--- a/src/protojson/ResponseMsg.cc
+++ b/src/protojson/ResponseMsg.cc
@@ -26,6 +26,7 @@
 
 // Qserv headers
 #include "http/RequestBodyJSON.h"
+#include "protojson/PwHideJson.h"
 
 // LSST headers
 #include "lsst/log/Log.h"
@@ -120,17 +121,17 @@ std::ostream& ExecutiveRespMsg::dumpOs(std::ostream& os) const {
     return os;
 }
 
-WorkerCzarComRespMsg::Ptr WorkerCzarComRespMsg::createFromJson(nlohmann::json const& respJson) {
-    auto basePtr = ResponseMsg::createFromJson(respJson);
+WorkerCzarComRespMsg::Ptr WorkerCzarComRespMsg::createFromJson(nlohmann::json const& inJson) {
+    auto basePtr = ResponseMsg::createFromJson(inJson);
     auto success_ = basePtr->success;
     auto errorType_ = basePtr->errorType;
     auto note_ = basePtr->note;
 
     auto thoughtCzarWasDeadTime_ =
-            http::RequestBodyJSON::required<uint64_t>(respJson, "thoughtCzarWasDeadTime");
+            http::RequestBodyJSON::required<uint64_t>(inJson, "thoughtCzarWasDeadTime");
     auto execRespMsgs_ = json::array();
-    if (respJson.contains("execRespMsgs")) {
-        execRespMsgs_ = respJson["execRespMsgs"];
+    if (inJson.contains("execRespMsgs")) {
+        execRespMsgs_ = inJson["execRespMsgs"];
     }
     vector<ExecutiveRespMsg::Ptr> execRMsgs;
     for (auto const& jsExecRespMsg : execRespMsgs_) {
@@ -138,9 +139,12 @@ WorkerCzarComRespMsg::Ptr WorkerCzarComRespMsg::createFromJson(nlohmann::json co
             auto execRespMsg = ExecutiveRespMsg::createFromJson(jsExecRespMsg);
             execRMsgs.emplace_back(execRespMsg);
         } catch (std::invalid_argument const& ex) {
+            // Can anything be done beyond logging the error?
+            // The worker is probably going to send this until the qId/ujId is killed.
+            // This error message should never show up, but good to know if it happens.
             LOGS(_log, LOG_LVL_WARN,
                  "WorkerCzarComRespMsg::createFromJson failed to read execRespMsg:"
-                         << jsExecRespMsg << " exception: " << ex.what());
+                         << protojson::pwHide(jsExecRespMsg) << " exception: " << ex.what());
         }
     }
     auto wccRespMsg = WorkerCzarComRespMsg::create(success_, thoughtCzarWasDeadTime_, errorType_, note_);

--- a/src/protojson/ResponseMsg.h
+++ b/src/protojson/ResponseMsg.h
@@ -140,8 +140,8 @@ public:
         return Ptr(new WorkerCzarComRespMsg(success_, thoughtCzarWasDeadTime_, errorType_, note_));
     }
 
-    /// This function creates WorkerCzarComRespMsg from respJson, if reasonable.
-    static Ptr createFromJson(nlohmann::json const& respJson);
+    /// This function creates WorkerCzarComRespMsg from inJson, if reasonable.
+    static Ptr createFromJson(nlohmann::json const& inJson);
 
     std::string cName(const char* fName) const { return std::string("WorkerCzarComRespMsg::") + fName; }
 

--- a/src/protojson/ResponseMsg.h
+++ b/src/protojson/ResponseMsg.h
@@ -85,7 +85,7 @@ public:
     std::string cName(const char* fName) const { return std::string("ResponseMsg::") + fName; }
 
     /// Returns a string for logging.
-    /// Note: Naming dumpOs just dump should work, but is causes gcc to fail when child classes in
+    /// Note: Naming dumpOs just dump should work, but it causes gcc to fail when child classes in
     ///       unit tests try to call dump() and the base class version is not found.
     virtual std::ostream& dumpOs(std::ostream& os) const;
     std::string dump() const;

--- a/src/protojson/ResponseMsg.h
+++ b/src/protojson/ResponseMsg.h
@@ -82,16 +82,79 @@ public:
     virtual nlohmann::json toJson() const;
 
     /// class name for log, fName is expected to be __func__.
-    std::string cName(const char* fName) const { return std::string("ResponseMsg"); }
+    std::string cName(const char* fName) const { return std::string("ResponseMsg::") + fName; }
 
     /// Returns a string for logging.
-    virtual std::ostream& dump(std::ostream& os) const;
+    /// Note: Naming dumpOs just dump should work, but is causes gcc to fail when child classes in
+    ///       unit tests try to call dump() and the base class version is not found.
+    virtual std::ostream& dumpOs(std::ostream& os) const;
     std::string dump() const;
     friend std::ostream& operator<<(std::ostream& os, ResponseMsg const& cmd);
 
     bool success;
     std::string errorType;
     std::string note;
+};
+
+class ExecutiveRespMsg : public ResponseMsg {
+public:
+    using Ptr = std::shared_ptr<ExecutiveRespMsg>;
+
+    ExecutiveRespMsg(bool success_, bool dataObsolete_, QueryId qId_, UberJobId ujId_, CzarId czId_,
+                     std::string const& errorType_ = "none", std::string const& note_ = std::string());
+
+    virtual ~ExecutiveRespMsg() = default;
+
+    static Ptr create(bool success_, bool dataObsolete_, QueryId qId_, UberJobId ujId_, CzarId czId_,
+                      std::string const& errorType_ = "none", std::string const& note_ = std::string()) {
+        return Ptr(new ExecutiveRespMsg(success_, dataObsolete_, qId_, ujId_, czId_, errorType_, note_));
+    }
+
+    /// This function creates ExecutiveRespMsg from respJson, if reasonable.
+    static Ptr createFromJson(nlohmann::json const& respJson);
+
+    std::string cName(const char* fName) const { return std::string("ExecutiveRespMsg::") + fName; }
+
+    nlohmann::json toJson() const override;
+
+    std::ostream& dumpOs(std::ostream& os) const override;
+
+    bool dataObsolete;  ///< Indicates that the result data the worker has is obsolete and may be deleted.
+    QueryId qId;        ///< The query id for the data, if applicable.
+    UberJobId ujId;     ///< The uberjob id for the data, if applicable.
+    CzarId czId;        ///< The czar id for the data, if applicable.
+};
+
+class WorkerCzarComRespMsg : public ResponseMsg {
+public:
+    using Ptr = std::shared_ptr<WorkerCzarComRespMsg>;
+
+    WorkerCzarComRespMsg(bool success_, uint64_t thoughtCzarWasDeadTime_,
+                         std::string const& errorType_ = "none", std::string const& note_ = std::string())
+            : ResponseMsg(success_, errorType_, note_), thoughtCzarWasDeadTime(thoughtCzarWasDeadTime_) {}
+
+    virtual ~WorkerCzarComRespMsg() = default;
+
+    static Ptr create(bool success_, uint64_t thoughtCzarWasDeadTime_, std::string const& errorType_ = "none",
+                      std::string const& note_ = std::string()) {
+        return Ptr(new WorkerCzarComRespMsg(success_, thoughtCzarWasDeadTime_, errorType_, note_));
+    }
+
+    /// This function creates WorkerCzarComRespMsg from respJson, if reasonable.
+    static Ptr createFromJson(nlohmann::json const& respJson);
+
+    std::string cName(const char* fName) const { return std::string("WorkerCzarComRespMsg::") + fName; }
+
+    nlohmann::json toJson() const override;
+
+    std::ostream& dumpOs(std::ostream& os) const override;
+
+    /// Indicates the `thoughtCzarWasDeadTime` sent by the worker (normally 0)
+    uint64_t thoughtCzarWasDeadTime;
+
+    /// List of ExecutiveRespMsg objects for the UberJobs that were
+    /// in the originating WorkerCzarComIssue message.
+    std::vector<ExecutiveRespMsg::Ptr> execRespMsgs;
 };
 
 }  // namespace lsst::qserv::protojson

--- a/src/protojson/WorkerCzarComIssue.cc
+++ b/src/protojson/WorkerCzarComIssue.cc
@@ -28,6 +28,7 @@
 #include "http/Client.h"
 #include "http/MetaModule.h"
 #include "http/RequestBodyJSON.h"
+#include "protojson/PwHideJson.h"
 #include "protojson/ResponseMsg.h"
 #include "protojson/UberJobErrorMsg.h"
 #include "protojson/UberJobReadyMsg.h"
@@ -62,7 +63,7 @@ json WorkerCzarComIssue::toJson() {
     jsCzarR["czar"] = _czInfo->czName;
     jsCzarR["workerinfo"] = _wInfo->toJson();
 
-    jsCzarR["thoughtczarwasdead"] = _thoughtCzarWasDead;
+    jsCzarR["thoughtczarwasdead"] = _thoughtCzarWasDeadTime;
 
     // List of failed transmits
     jsCzarR["failedtransmits"] = json::array();
@@ -100,8 +101,8 @@ WorkerCzarComIssue::Ptr WorkerCzarComIssue::createFromJson(nlohmann::json const&
         }
         auto wccIssue = create(authContext_);
         wccIssue->setContactInfo(wInfo_, czInfo_);
-        wccIssue->_thoughtCzarWasDead =
-                http::RequestBodyJSON::required<bool>(jsCzarReq, "thoughtczarwasdead");
+        wccIssue->_thoughtCzarWasDeadTime =
+                http::RequestBodyJSON::required<uint64_t>(jsCzarReq, "thoughtczarwasdead");
         json fTransmits = json::array();
         fTransmits = jsCzarReq.at("failedtransmits");
         if (!fTransmits.is_array()) {
@@ -136,7 +137,7 @@ WorkerCzarComIssue::Ptr WorkerCzarComIssue::createFromJson(nlohmann::json const&
 
 bool WorkerCzarComIssue::operator==(WorkerCzarComIssue const& other) const {
     if ((*_wInfo != *other._wInfo) || (*_czInfo != *other._czInfo) || (_authContext != other._authContext) ||
-        (_thoughtCzarWasDead != other._thoughtCzarWasDead)) {
+        (_thoughtCzarWasDeadTime != other._thoughtCzarWasDeadTime)) {
         return false;
     }
 
@@ -172,9 +173,10 @@ void WorkerCzarComIssue::_addFailedTransmit(QueryId qId, UberJobId ujId,
     (*_failedTransmits)[key] = ujMsg;
 }
 
-json WorkerCzarComIssue::responseToJson() const {
+json WorkerCzarComIssue::responseToJson(uint64_t msgThoughtCzarWasDeadTime,
+                                        vector<protojson::ExecutiveRespMsg::Ptr> const& execRespMsgs) const {
     lock_guard _lgWciMtx(_wciMtx);
-    return _responseToJson();
+    return _responseToJson(msgThoughtCzarWasDeadTime, execRespMsgs);
 }
 
 std::shared_ptr<FailedTransmitsMap> WorkerCzarComIssue::takeFailedTransmitsMap() {
@@ -184,48 +186,74 @@ std::shared_ptr<FailedTransmitsMap> WorkerCzarComIssue::takeFailedTransmitsMap()
     return res;
 }
 
-size_t WorkerCzarComIssue::clearMapEntries(nlohmann::json const& response) {
-    if (!response.contains("recvtransmits")) {
-        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " response did not have 'recvtransmits' " << response);
-        return 0;
-    }
-    auto const& recvTransmits = response["recvtransmits"];
-    if (!recvTransmits.is_array()) {
-        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " response 'recvtransmits' is not array " << response);
-        return 0;
-    }
+tuple<size_t, vector<UberJobIdentifierType>, vector<UberJobIdentifierType>>
+WorkerCzarComIssue::clearMapEntries(nlohmann::json const& response) {
+    vector<UberJobIdentifierType> ujDataObsoleteList;
+    vector<UberJobIdentifierType> ujParseErrorList;
     size_t count = 0;
+    if (!response.contains("execRespMsgs")) {
+        LOGS(_log, LOG_LVL_WARN,
+             cName(__func__) << " response did not have 'execRespMsgs' " << pwHide(response));
+        return {count, ujDataObsoleteList, ujParseErrorList};
+    }
+    auto const& jsExecRespMsgs = response["execRespMsgs"];
+    if (!jsExecRespMsgs.is_array()) {
+        LOGS(_log, LOG_LVL_WARN,
+             cName(__func__) << " response 'execRespMsgs' is not array " << pwHide(response));
+        return {count, ujDataObsoleteList, ujParseErrorList};
+    }
+
     lock_guard _lgWciMtx(_wciMtx);
-    for (auto const& elem : recvTransmits) {
+    for (auto const& elem : jsExecRespMsgs) {
         if (!(elem.contains("qId") && elem.contains("ujId"))) {
             LOGS(_log, LOG_LVL_WARN, cName(__func__) << "elem missing qId or ujId elem=" << elem);
             continue;
         }
         QueryId qId = elem["qId"];
         UberJobId ujId = elem["ujId"];
-        LOGS(_log, LOG_LVL_DEBUG,
-             cName(__func__) << " removing qId=" << qId << "_ujId=" << ujId << " from map");
-        _failedTransmits->erase(make_pair(qId, ujId));
-        count++;
+
+        try {
+            auto execRespMsg = ExecutiveRespMsg::createFromJson(elem);
+            if (execRespMsg == nullptr) {
+                LOGS(_log, LOG_LVL_WARN,
+                     cName(__func__) << " failed to parse execRespMsg elem=" << pwHide(elem));
+                continue;
+            }
+            // Find the appropriate Task and update it if needed.
+            if (execRespMsg->success) {
+                // Nothing needs to be done if the UberJob is not obsolete. If it
+                // is obsolete, it could be useful to delete the result file.
+                if (execRespMsg->dataObsolete) {
+                    ujDataObsoleteList.emplace_back(_czInfo, qId, ujId);
+                }
+            } else {
+                // The czar couldn't parse this for some reason, leaving no way to get the result
+                // file back to the czar. Delete the result file and return an error.
+                ujParseErrorList.emplace_back(_czInfo, qId, ujId);
+            }
+            LOGS(_log, LOG_LVL_DEBUG,
+                 cName(__func__) << " removing qId=" << qId << "_ujId=" << ujId << " from map");
+            _failedTransmits->erase(make_pair(qId, ujId));  //&&& probably needs to lock _wciMtx.
+            count++;
+        } catch (std::invalid_argument const& ex) {
+            LOGS(_log, LOG_LVL_ERROR,
+                 cName(__func__) << " failed to parse execRespMsg elem=" << elem
+                                 << " exception: " << ex.what());
+            // This should never happen as all messages should parse.
+            // There's probably nothing else that can be done at this point. Hopefully, other
+            // cleanup mechanisms will be enough to prevent this from causing problems.
+            continue;
+        }
     }
-    return count;
+    return {count, ujDataObsoleteList, ujParseErrorList};
 }
 
-json WorkerCzarComIssue::_responseToJson() const {
-    protojson::ResponseMsg respMsg(true);
-
-    // Add a list of uberjobs that are being handled by this czar due to
-    // the worker's WorkerCzarComIssue message.
-    nlohmann::json jsResp = respMsg.toJson();
-    jsResp["recvtransmits"] = json::array();
-    auto& jsFts = jsResp["recvtransmits"];
-    for (auto const& [key, elem] : *_failedTransmits) {
-        QueryId qId = key.first;
-        UberJobId ujId = key.second;
-        json jsF = json{{"qId", qId}, {"ujId", ujId}};
-        jsFts.push_back(jsF);
-    }
-    return jsResp;
+json WorkerCzarComIssue::_responseToJson(
+        uint64_t msgThoughtCzarWasDeadTime,
+        vector<protojson::ExecutiveRespMsg::Ptr> const& execRespMsgs_) const {
+    protojson::WorkerCzarComRespMsg wccRespMsg(true, msgThoughtCzarWasDeadTime);
+    wccRespMsg.execRespMsgs = execRespMsgs_;
+    return wccRespMsg.toJson();
 }
 
 string WorkerCzarComIssue::dump() const {
@@ -237,7 +265,7 @@ string WorkerCzarComIssue::_dump() const {
     stringstream os;
     os << "WorkerCzarComIssue wInfo=" << ((_wInfo == nullptr) ? "?" : _wInfo->dump());
     os << " czInfo=" << _czInfo->dump();
-    os << " thoughtCzarWasDead=" << _thoughtCzarWasDead;
+    os << " thoughtCzarWasDeadTime=" << _thoughtCzarWasDeadTime;
     os << " failedTransmits[";
     for (auto const& [key, ft] : *_failedTransmits) {
         os << "{qId=" << key.first << " ujId=" << key.second << "{";

--- a/src/protojson/WorkerCzarComIssue.cc
+++ b/src/protojson/WorkerCzarComIssue.cc
@@ -48,6 +48,20 @@ LOG_LOGGER _log = LOG_GET("lsst.qserv.protojson.WorkerCzarComIssue");
 
 namespace lsst::qserv::protojson {
 
+std::string WorkerCzarComIssue::wrkCzIdLog() const {
+    stringstream os;
+    auto wInf = _wInfo;
+    auto cInf = _czInfo;
+    os << " wId=" << (wInf == nullptr ? "null" : wInf->wId) << " czId=";
+    // `?` doesn't like mixing return types.
+    if (cInf == nullptr)
+        os << "null";
+    else
+        os << cInf->czId;
+    os << " ";
+    return os.str();
+}
+
 json WorkerCzarComIssue::toJson() {
     json jsCzarR;
     lock_guard _lgWciMtx(_wciMtx);
@@ -171,6 +185,7 @@ void WorkerCzarComIssue::_addFailedTransmit(QueryId qId, UberJobId ujId,
                                             std::shared_ptr<protojson::UberJobStatusMsg> const& ujMsg) {
     auto key = make_pair(qId, ujId);
     (*_failedTransmits)[key] = ujMsg;
+    LOGS(_log, LOG_LVL_WARN, cName(__func__) << " failedTransmits sz=" << _failedTransmits->size());
 }
 
 json WorkerCzarComIssue::responseToJson(uint64_t msgThoughtCzarWasDeadTime,
@@ -186,10 +201,10 @@ std::shared_ptr<FailedTransmitsMap> WorkerCzarComIssue::takeFailedTransmitsMap()
     return res;
 }
 
-tuple<size_t, vector<UberJobIdentifierType>, vector<UberJobIdentifierType>>
-WorkerCzarComIssue::clearMapEntries(nlohmann::json const& response) {
-    vector<UberJobIdentifierType> ujDataObsoleteList;
-    vector<UberJobIdentifierType> ujParseErrorList;
+tuple<size_t, vector<UberJobIdentType>, vector<UberJobIdentType>> WorkerCzarComIssue::clearMapEntries(
+        nlohmann::json const& response) {
+    vector<UberJobIdentType> ujDataObsoleteList;
+    vector<UberJobIdentType> ujParseErrorList;
     size_t count = 0;
     if (!response.contains("execRespMsgs")) {
         LOGS(_log, LOG_LVL_WARN,
@@ -228,12 +243,12 @@ WorkerCzarComIssue::clearMapEntries(nlohmann::json const& response) {
                 }
             } else {
                 // The czar couldn't parse this for some reason, leaving no way to get the result
-                // file back to the czar. Delete the result file and return an error.
+                // file back to the czar. Delete the result file.
                 ujParseErrorList.emplace_back(_czInfo, qId, ujId);
             }
             LOGS(_log, LOG_LVL_DEBUG,
                  cName(__func__) << " removing qId=" << qId << "_ujId=" << ujId << " from map");
-            _failedTransmits->erase(make_pair(qId, ujId));  //&&& probably needs to lock _wciMtx.
+            _failedTransmits->erase(make_pair(qId, ujId));
             count++;
         } catch (std::invalid_argument const& ex) {
             LOGS(_log, LOG_LVL_ERROR,
@@ -246,6 +261,36 @@ WorkerCzarComIssue::clearMapEntries(nlohmann::json const& response) {
         }
     }
     return {count, ujDataObsoleteList, ujParseErrorList};
+}
+
+void WorkerCzarComIssue::clearFailedTransmitsForQids(std::map<QueryId, TIMEPOINT> const& qIdMap) {
+    size_t startSize = 0;
+    size_t endSize = 0;
+    {
+        std::lock_guard lg(_wciMtx);
+        // Normally empty.
+        startSize = _failedTransmits->size();
+        if (startSize == 0) {
+            return;
+        }
+        // Make a qId set for faster lookup.
+        std::set<QueryId> qIdSet;
+        for (auto const& [qId, tm] : qIdMap) {
+            qIdSet.insert(qId);
+        }
+        for (auto iter = _failedTransmits->begin(); iter != _failedTransmits->end();) {
+            QueryId qIdFailed = iter->first.first;
+            if (qIdSet.find(qIdFailed) != qIdSet.end()) {
+                iter = _failedTransmits->erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+        endSize = _failedTransmits->size();
+    }
+    if (startSize > 0) {
+        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " startSize=" << startSize << " endSize=" << endSize);
+    }
 }
 
 json WorkerCzarComIssue::_responseToJson(

--- a/src/protojson/WorkerCzarComIssue.h
+++ b/src/protojson/WorkerCzarComIssue.h
@@ -34,6 +34,7 @@
 // qserv headers
 #include "protojson/ResponseMsg.h"
 #include "protojson/WorkerQueryStatusData.h"
+#include "wpublish/QueriesAndChunks.h"
 
 // This header declarations
 namespace lsst::qserv::protojson {
@@ -42,8 +43,6 @@ class UberJobStatusMsg;
 
 typedef std::shared_ptr<UberJobStatusMsg> FailedTransmitType;
 typedef std::map<std::pair<QueryId, UberJobId>, FailedTransmitType> FailedTransmitsMap;
-
-typedef std::tuple<CzarContactInfo::Ptr, QueryId, UberJobId> UberJobIdentifierType;
 
 /// This class is used to send/receive a message from the worker to a specific
 /// czar. It is used when there has been a communication issue with the worker
@@ -76,7 +75,9 @@ public:
 
     bool operator==(WorkerCzarComIssue const& other) const;
 
-    std::string cName(const char* funcN) const { return std::string("WorkerCzarComIssue") + funcN; }
+    std::string cName(const char* funcN) const {
+        return std::string("WorkerCzarComIssue") + funcN + wrkCzIdLog();
+    }
 
     static Ptr create(AuthContext const& authContext_) { return Ptr(new WorkerCzarComIssue(authContext_)); }
 
@@ -85,18 +86,6 @@ public:
     void setThoughtCzarWasDeadTime(uint64_t msDeadNowAliveTime) {
         std::lock_guard lg(_wciMtx);
         _thoughtCzarWasDeadTime = msDeadNowAliveTime;
-    }
-
-    /// Remove all entries from the failedTransmits map with QueryId `qId`.
-    void clearTransmitsForQid(QueryId qId) {  //&&& this needs to be called somewhere. &&&
-        std::lock_guard lg(_wciMtx);
-        for (auto it = _failedTransmits->begin(); it != _failedTransmits->end();) {
-            if (it->first.first == qId) {
-                it = _failedTransmits->erase(it);
-            } else {
-                ++it;
-            }
-        }
     }
 
     /// Go through the list of QueryId + UberJobId values in the response and clear those entries from the
@@ -108,8 +97,15 @@ public:
     /// will conserve resources. The vector of UberJob identifiers that the czar could not parse is a problem.
     /// An error message should be sent back to the czar for each of those in an attempt to maintain system
     /// stability, but they really should never have happened in the first place.
-    std::tuple<size_t, std::vector<UberJobIdentifierType>, std::vector<UberJobIdentifierType>>
-    clearMapEntries(nlohmann::json const& response);
+    std::tuple<size_t, std::vector<UberJobIdentType>, std::vector<UberJobIdentType>> clearMapEntries(
+            nlohmann::json const& response);
+
+    /// Remove all entries from the failedTransmits map with QueryId `qId`.
+    /// The czar is done with these queries.
+    /// @param qIdMap - map of dead queries and times. The times aren't needed
+    ///              here, but using the existing map is more efficient.
+    /// Note:  _failedTransmits is normally empty.
+    void clearFailedTransmitsForQids(std::map<QueryId, TIMEPOINT> const& qIdMap);
 
     uint64_t getThoughtCzarWasDeadTime() const { return _thoughtCzarWasDeadTime; }
 
@@ -150,6 +146,9 @@ public:
 
     /// Take the failedTransmitsMap and make an empty one to take its place.
     std::shared_ptr<FailedTransmitsMap> takeFailedTransmitsMap();
+
+    /// Return a short string with worker and czar IDs for logging.
+    std::string wrkCzIdLog() const;
 
     std::string dump() const;
 

--- a/src/protojson/WorkerCzarComIssue.h
+++ b/src/protojson/WorkerCzarComIssue.h
@@ -32,6 +32,7 @@
 #include "nlohmann/json.hpp"
 
 // qserv headers
+#include "protojson/ResponseMsg.h"
 #include "protojson/WorkerQueryStatusData.h"
 
 // This header declarations
@@ -41,6 +42,8 @@ class UberJobStatusMsg;
 
 typedef std::shared_ptr<UberJobStatusMsg> FailedTransmitType;
 typedef std::map<std::pair<QueryId, UberJobId>, FailedTransmitType> FailedTransmitsMap;
+
+typedef std::tuple<CzarContactInfo::Ptr, QueryId, UberJobId> UberJobIdentifierType;
 
 /// This class is used to send/receive a message from the worker to a specific
 /// czar. It is used when there has been a communication issue with the worker
@@ -79,19 +82,41 @@ public:
 
     static Ptr createFromJson(nlohmann::json const& workerJson, AuthContext const& authContext_);
 
-    void setThoughtCzarWasDead(bool wasDead) {
+    void setThoughtCzarWasDeadTime(uint64_t msDeadNowAliveTime) {
         std::lock_guard lg(_wciMtx);
-        _thoughtCzarWasDead = wasDead;
+        _thoughtCzarWasDeadTime = msDeadNowAliveTime;
     }
 
-    size_t clearMapEntries(nlohmann::json const& response);
+    /// Remove all entries from the failedTransmits map with QueryId `qId`.
+    void clearTransmitsForQid(QueryId qId) {  //&&& this needs to be called somewhere. &&&
+        std::lock_guard lg(_wciMtx);
+        for (auto it = _failedTransmits->begin(); it != _failedTransmits->end();) {
+            if (it->first.first == qId) {
+                it = _failedTransmits->erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
 
-    bool getThoughtCzarWasDead() const { return _thoughtCzarWasDead; }
+    /// Go through the list of QueryId + UberJobId values in the response and clear those entries from the
+    /// failedTransmits map.
+    /// @return - the number of entries cleared,
+    ///         - a vector of obsolete UberJob identifiers
+    ///         - a vector of UberJob identifier that the czar could not parse
+    /// Nothing really needs to be done with the vector of obsolete UberJob identifiers, but deleting them
+    /// will conserve resources. The vector of UberJob identifiers that the czar could not parse is a problem.
+    /// An error message should be sent back to the czar for each of those in an attempt to maintain system
+    /// stability, but they really should never have happened in the first place.
+    std::tuple<size_t, std::vector<UberJobIdentifierType>, std::vector<UberJobIdentifierType>>
+    clearMapEntries(nlohmann::json const& response);
+
+    uint64_t getThoughtCzarWasDeadTime() const { return _thoughtCzarWasDeadTime; }
 
     /// Return true if there is a reason this WorkerCzarComIssue should be sent to this czar.
     bool needToSend() const {
         std::lock_guard lg(_wciMtx);
-        return (_thoughtCzarWasDead || _failedTransmits->size() > 0);
+        return (_thoughtCzarWasDeadTime > 0 || _failedTransmits->size() > 0);
     }
 
     /// Set the contact information for the appropriate czar and worker.
@@ -120,7 +145,8 @@ public:
 
     /// Return a json object indicating the status of the message for the
     /// original requester.
-    nlohmann::json responseToJson() const;
+    nlohmann::json responseToJson(uint64_t msgThoughtCzarWasDeadTime,
+                                  std::vector<protojson::ExecutiveRespMsg::Ptr> const& execRespMsgs) const;
 
     /// Take the failedTransmitsMap and make an empty one to take its place.
     std::shared_ptr<FailedTransmitsMap> takeFailedTransmitsMap();
@@ -136,7 +162,8 @@ private:
 
     /// Return a json object indicating the status of the message for the
     /// original requester.
-    nlohmann::json _responseToJson() const;
+    nlohmann::json _responseToJson(uint64_t thoughtCzarWasDeadTime,
+                                   std::vector<protojson::ExecutiveRespMsg::Ptr> const& execRespMsgs_) const;
 
     std::string _dump() const;
 
@@ -144,9 +171,13 @@ private:
     CzarContactInfo::Ptr _czInfo;
     AuthContext _authContext;
 
-    /// Set to by the worker true if the czar was considered dead, and reset to false
-    /// after the czar has acknowledged successful reception of this message.
-    bool _thoughtCzarWasDead = false;
+    /// If the worker thought the czar was dead, this is the time in milliseconds that the worker
+    /// thought the czar came back to life. This is passed to the czar so the czar knows
+    /// the worker has killed all related UberJobs. The czar sends this value back to
+    /// the worker in the response to avoid race conditions. If the returned value matches
+    /// or is greater than what is stored, it is certain that there have not been any
+    /// dead/alive cycles since the czar received the message.
+    uint64_t _thoughtCzarWasDeadTime = 0;
 
     /// Map of failed transmits using QueryId + UberJobId for the key
     std::shared_ptr<FailedTransmitsMap> _failedTransmits{new FailedTransmitsMap};

--- a/src/protojson/WorkerQueryStatusData.h
+++ b/src/protojson/WorkerQueryStatusData.h
@@ -170,11 +170,6 @@ public:
 
     void setRegUpdateTime(TIMEPOINT updateTime);
 
-    TIMEPOINT getRegUpdateTime(TIMEPOINT updateTime) {
-        std::lock_guard lg(_rMtx);
-        return _regUpdateTime;
-    }
-
     double timeSinceRegUpdateSeconds() const {
         std::lock_guard lg(_rMtx);
         double secs = std::chrono::duration<double>(CLOCK::now() - _regUpdateTime).count();

--- a/src/protojson/WorkerQueryStatusData.h
+++ b/src/protojson/WorkerQueryStatusData.h
@@ -101,6 +101,17 @@ private:
               czStartupTime(czStartupTime_) {}
 };
 
+class UberJobIdentType {
+public:
+    UberJobIdentType() = default;
+    UberJobIdentType(CzarContactInfo::Ptr const& czInfo_, QueryId qId_, UberJobId ujId_)
+            : czInfo(czInfo_), qId(qId_), ujId(ujId_) {}
+
+    CzarContactInfo::Ptr czInfo;
+    QueryId qId;
+    UberJobId ujId;
+};
+
 /// This class just contains the worker id and network communication information.
 class WorkerContactInfo {
 public:

--- a/src/protojson/testStatusData.cc
+++ b/src/protojson/testStatusData.cc
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
     auto workerA = WorkerContactInfo::create("sd_workerA", "host_w1", "mgmhost_a", 3421, start);
     auto jsWorkerA = workerA->toJson();
 
-    // WorkerCzarComIssue, thaought czar was dead test.
+    // WorkerCzarComIssue, thought czar was dead test.
     auto wccIssueA = lsst::qserv::protojson::WorkerCzarComIssue::create(authContext_);
     wccIssueA->setContactInfo(workerA, czarA);
     BOOST_REQUIRE(wccIssueA->needToSend() == false);
@@ -300,6 +300,91 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
 
     auto ftMap = wccIssueA1->takeFailedTransmitsMap();
     BOOST_REQUIRE(ftMap->size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(WorkerCzarComIssueClearFailedTransmitsForQids) {
+    AuthContext authContext_("repliInstId", "repliIAuthKey");
+
+    uint64_t czStartTime = lsst::qserv::millisecSinceEpoch(lsst::qserv::CLOCK::now() - 5s);
+    string const czName("czar_name");
+    lsst::qserv::CzarId const czId = 32;
+    int czPort = 2022;
+    string const czHost("cz_host");
+
+    auto czarA = lsst::qserv::protojson::CzarContactInfo::create(czName, czId, czPort, czHost, czStartTime);
+
+    auto start = lsst::qserv::CLOCK::now();
+    auto workerA = WorkerContactInfo::create("sd_workerA", "host_w1", "mgmhost_a", 3421, start);
+
+    // Create the WorkerCzarComIssue and set contact info
+    auto wcc = lsst::qserv::protojson::WorkerCzarComIssue::create(authContext_);
+    wcc->setContactInfo(workerA, czarA);
+
+    // Build three failed transmit messages:
+    // - qIdA has two UberJobs (uj 1 and uj 2)
+    // - qIdB has one UberJob (uj 3)
+    lsst::qserv::QueryId const qIdA = 1001;
+    lsst::qserv::QueryId const qIdB = 2002;
+    lsst::qserv::UberJobId const ujA1 = 1;
+    lsst::qserv::UberJobId const ujA2 = 2;
+    lsst::qserv::UberJobId const ujB1 = 3;
+
+    string const workerId1 = "wrkr1";
+    int const resultPort = 436;
+    int const rowlimit = 0;
+    int const maxTableBytes = 1'000'000;
+    bool const scaninteractive = true;
+    auto scanInfo = lsst::qserv::protojson::ScanInfo::create();
+
+    // create UberJobData for qIdA ujA1
+    lsst::qserv::protojson::FileUrlInfo fileInf1("http://test/fn1", 10, 100);
+    auto ujDataA1 = lsst::qserv::wbase::UberJobData::create(
+            ujA1, czName, czId, czHost, czPort, qIdA, rowlimit, maxTableBytes, scanInfo, scaninteractive,
+            workerId1, nullptr, authContext_.replicationAuthKey, resultPort);
+    auto ujRespA1 = ujDataA1->responseFileReadyBuild(fileInf1, authContext_);
+    wcc->addFailedTransmit(qIdA, ujA1, ujRespA1);
+
+    // create UberJobData for qIdA ujA2
+    lsst::qserv::protojson::FileUrlInfo fileInf2("http://test/fn2", 20, 200);
+    auto ujDataA2 = lsst::qserv::wbase::UberJobData::create(
+            ujA2, czName, czId, czHost, czPort, qIdA, rowlimit, maxTableBytes, scanInfo, scaninteractive,
+            workerId1, nullptr, authContext_.replicationAuthKey, resultPort);
+    auto ujRespA2 = ujDataA2->responseFileReadyBuild(fileInf2, authContext_);
+    wcc->addFailedTransmit(qIdA, ujA2, ujRespA2);
+
+    // create UberJobData for qIdB ujB1
+    lsst::qserv::protojson::FileUrlInfo fileInf3("http://test/fn3", 30, 300);
+    auto ujDataB1 = lsst::qserv::wbase::UberJobData::create(
+            ujB1, czName, czId, czHost, czPort, qIdB, rowlimit, maxTableBytes, scanInfo, scaninteractive,
+            workerId1, nullptr, authContext_.replicationAuthKey, resultPort);
+    auto ujRespB1 = ujDataB1->responseFileReadyBuild(fileInf3, authContext_);
+    wcc->addFailedTransmit(qIdB, ujB1, ujRespB1);
+
+    // Confirm three failed transmits exist via JSON representation
+    auto jsBefore = wcc->toJson();
+    BOOST_REQUIRE(jsBefore.contains("failedtransmits"));
+    auto const& arrBefore = jsBefore["failedtransmits"];
+    BOOST_REQUIRE(arrBefore.is_array());
+    BOOST_REQUIRE(arrBefore.size() == 3);
+
+    // Prepare a map with qIdA to be cleared
+    std::map<lsst::qserv::QueryId, lsst::qserv::TIMEPOINT> qIdMap;
+    qIdMap[qIdA] = lsst::qserv::CLOCK::now();
+
+    // Call clearFailedTransmitsForQids
+    wcc->clearFailedTransmitsForQids(qIdMap);
+
+    // Verify only the qIdB entry remains
+    auto jsAfter = wcc->toJson();
+    BOOST_REQUIRE(jsAfter.contains("failedtransmits"));
+    auto const& arrAfter = jsAfter["failedtransmits"];
+    BOOST_REQUIRE(arrAfter.is_array());
+    BOOST_REQUIRE(arrAfter.size() == 1);
+    // remaining element should have qId == qIdB
+    auto rem = arrAfter[0];
+    BOOST_REQUIRE(rem.contains("qId"));
+    lsst::qserv::QueryId remQ = rem["qId"];
+    BOOST_REQUIRE(remQ == qIdB);
 }
 
 BOOST_AUTO_TEST_CASE(ResponseMsg) {

--- a/src/protojson/testStatusData.cc
+++ b/src/protojson/testStatusData.cc
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(WorkerQueryStatusData) {
 }
 
 BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
-    lsst::qserv::protojson::AuthContext authContext_("repliInstId", "repliIAuthKey");
+    AuthContext authContext_("repliInstId", "repliIAuthKey");
 
     uint64_t cxrStartTime = lsst::qserv::millisecSinceEpoch(lsst::qserv::CLOCK::now() - 5s);
 
@@ -171,18 +171,23 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
     auto workerA = WorkerContactInfo::create("sd_workerA", "host_w1", "mgmhost_a", 3421, start);
     auto jsWorkerA = workerA->toJson();
 
-    // WorkerCzarComIssue
+    // WorkerCzarComIssue, thaought czar was dead test.
     auto wccIssueA = lsst::qserv::protojson::WorkerCzarComIssue::create(authContext_);
     wccIssueA->setContactInfo(workerA, czarA);
     BOOST_REQUIRE(wccIssueA->needToSend() == false);
-    wccIssueA->setThoughtCzarWasDead(true);
+    wccIssueA->setThoughtCzarWasDeadTime(3452987);
     BOOST_REQUIRE(wccIssueA->needToSend() == true);
 
     auto jsIssueA = wccIssueA->toJson();
 
+    // The source WorkerCzarComIssue for failed transmit tests.
     auto wccIssueA1 = lsst::qserv::protojson::WorkerCzarComIssue::createFromJson(jsIssueA, authContext_);
     auto jsIssueA1 = wccIssueA1->toJson();
     BOOST_REQUIRE(jsIssueA == jsIssueA1);
+
+    // A vector of the expected responses from the czar from UberJobData responses
+    // added to wccIssueA1 as failed transmits.
+    std::vector<ExecutiveRespMsg::Ptr> czarResponseMsgs;
 
     // Test a list of failed messages.
     string const czarHost = "czarHost";
@@ -206,6 +211,8 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
             scaninteractive1, workerId1, nullptr, authContext_.replicationAuthKey, resultPort);
     auto ujResponse1 = ujData1->responseFileReadyBuild(fileInf1, authContext_);
     wccIssueA1->addFailedTransmit(qId1, ujId1, ujResponse1);
+    auto execRespMsg1 = ExecutiveRespMsg::create(true, false, qId1, ujId1, czarId);
+    czarResponseMsgs.push_back(execRespMsg1);
 
     auto jsWcA1 = wccIssueA1->toJson();
     // parse jsWcA1 and check if the answer is correct
@@ -220,6 +227,8 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
             scaninteractive1, workerId1, nullptr, authContext_.replicationAuthKey, resultPort);
     auto ujResponse1a = ujData1->responseFileReadyBuild(fileInf1a, authContext_);
     wccIssueA1->addFailedTransmit(qId1a, ujId1a, ujResponse1a);
+    auto execRespMsg1a = ExecutiveRespMsg::create(true, true, qId1a, ujId1a, czarId);
+    czarResponseMsgs.push_back(execRespMsg1a);
 
     auto jsWcA1a = wccIssueA1->toJson();
     // parse jsWcA1a and check if the answer is correct
@@ -237,6 +246,8 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
             scaninteractive2, workerId1, nullptr, authContext_.replicationAuthKey, resultPort);
     auto ujResponse2 = ujData2->responseFileReadyBuild(fileInf2, authContext_);
     wccIssueA1->addFailedTransmit(qId2, ujId2, ujResponse2);
+    auto execRespMsg2 = ExecutiveRespMsg::create(true, false, qId2, ujId2, czarId);
+    czarResponseMsgs.push_back(execRespMsg2);
 
     auto jsWcA2 = wccIssueA1->toJson();
     // parse jsWcA2 and check if the answer is correct
@@ -256,6 +267,8 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
     auto ujResponse3 =
             ujData3->responseErrorBuild(multiErr, chunkId3, cancelled3, LOG_LVL_DEBUG, authContext_);
     wccIssueA1->addFailedTransmit(qId3, ujId3, ujResponse3);
+    auto execRespMsg3 = ExecutiveRespMsg::create(true, true, qId3, ujId3, czarId);
+    czarResponseMsgs.push_back(execRespMsg3);
 
     auto jsWcA3 = wccIssueA1->toJson();
     // parse jsWcA3 and check if the answer is correct
@@ -265,17 +278,30 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
     BOOST_REQUIRE(*wccIssueA1 != *wccIssueA2Out1);
     BOOST_REQUIRE(*wccIssueA1 == *wccIssueA3Out1);
 
-    // Create the response to jsWcA3.
-    auto jsRespA3Out1 = wccIssueA3Out1->responseToJson();
-    LOGS(_log, LOG_LVL_INFO, "jsRespA3Out1=" << jsRespA3Out1);
+    // Add the ExecutiveRespMsg messages that correlate to the failed transmits to
+    // the czar response message so they can be used to clear the map entries.
+    auto czarRespMsgJson =
+            wccIssueA3Out1->responseToJson(wccIssueA3Out1->getThoughtCzarWasDeadTime(), czarResponseMsgs);
+    LOGS(_log, LOG_LVL_INFO, "czarRespMsgJson=" << czarRespMsgJson);
 
     // Parse the response and remove the appropriate entries from wccIsueA1.
-    auto respMsg = lsst::qserv::protojson::ResponseMsg::createFromJson(jsRespA3Out1);
-    BOOST_REQUIRE(respMsg->success == true);
-    BOOST_REQUIRE(wccIssueA1->clearMapEntries(jsRespA3Out1) == 4);
+    auto czRespMsg = lsst::qserv::protojson::WorkerCzarComRespMsg::createFromJson(czarRespMsgJson);
+    LOGS(_log, LOG_LVL_INFO, "czRespMsg=" << czRespMsg->dump());
+    BOOST_REQUIRE(czRespMsg->success == true);
+
+    // Use the response to clear the original transmit failure messages from the originating worker.
+    auto [countA3Out1, obsoleteList, parseErrorList] = wccIssueA1->clearMapEntries(czarRespMsgJson);
+    LOGS(_log, LOG_LVL_INFO,
+         "countA3Out1=" << countA3Out1 << " obsoleteSz=" << obsoleteList.size()
+                        << " parseErrorSz=" << parseErrorList.size());
+    BOOST_REQUIRE(countA3Out1 == 4);
+    BOOST_REQUIRE(obsoleteList.size() == 2);
+    BOOST_REQUIRE(parseErrorList.size() == 0);
 
     auto ftMap = wccIssueA1->takeFailedTransmitsMap();
     BOOST_REQUIRE(ftMap->size() == 0);
+
+    //&&& TODO repeat this test adding a parseError response.
 }
 
 BOOST_AUTO_TEST_CASE(ResponseMsg) {
@@ -293,6 +319,8 @@ BOOST_AUTO_TEST_CASE(ResponseMsg) {
     BOOST_REQUIRE(!respMsgA->equal(*respMsgBOut));
     BOOST_REQUIRE(!respMsgB->equal(*respMsgC));
     BOOST_REQUIRE(!respMsgD->equal(*respMsgC));
+
+    // &&& test for ExecutiveRespMsg and WorkerCzarComRespMsg should be added here.
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/protojson/testStatusData.cc
+++ b/src/protojson/testStatusData.cc
@@ -300,8 +300,6 @@ BOOST_AUTO_TEST_CASE(WorkerCzarComIssue) {
 
     auto ftMap = wccIssueA1->takeFailedTransmitsMap();
     BOOST_REQUIRE(ftMap->size() == 0);
-
-    //&&& TODO repeat this test adding a parseError response.
 }
 
 BOOST_AUTO_TEST_CASE(ResponseMsg) {
@@ -319,8 +317,21 @@ BOOST_AUTO_TEST_CASE(ResponseMsg) {
     BOOST_REQUIRE(!respMsgA->equal(*respMsgBOut));
     BOOST_REQUIRE(!respMsgB->equal(*respMsgC));
     BOOST_REQUIRE(!respMsgD->equal(*respMsgC));
+}
 
-    // &&& test for ExecutiveRespMsg and WorkerCzarComRespMsg should be added here.
+BOOST_AUTO_TEST_CASE(ExecutiveRespMsg) {
+    auto respMsgA = lsst::qserv::protojson::ExecutiveRespMsg::create(true, false, 123, 456, 9, "allGood",
+                                                                     "just a test");
+    auto jsA = respMsgA->toJson();
+    auto respMsgAOut = lsst::qserv::protojson::ExecutiveRespMsg::createFromJson(jsA);
+    BOOST_REQUIRE(respMsgA->equal(*respMsgAOut));
+}
+
+BOOST_AUTO_TEST_CASE(WorkerCzarComRespMsg) {
+    auto respMsgA = lsst::qserv::protojson::WorkerCzarComRespMsg::create(true, 73);
+    auto jsA = respMsgA->toJson();
+    auto respMsgAOut = lsst::qserv::protojson::WorkerCzarComRespMsg::createFromJson(jsA);
+    BOOST_REQUIRE(respMsgA->equal(*respMsgAOut));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/qdisp/Executive.cc
+++ b/src/qdisp/Executive.cc
@@ -848,7 +848,9 @@ shared_ptr<lock_guard<mutex>> Executive::getLimitSquashLock() {
 
 void Executive::collectFile(std::shared_ptr<UberJob> ujPtr, protojson::FileUrlInfo const& fileUrlInfo,
                             std::string const& idStr) {
-    // Limit collecting LIMIT queries to one at a time, but only those.
+    // Limit collecting LIMIT queries to one at a time, but only for LIMIT.
+    // This is to avoid having to wait for multiple large files to merge when only a
+    // few are needed to satisfy the LIMIT. This can make a huge difference.
     shared_ptr<lock_guard<mutex>> limitSquashL;
     if (_limitSquashApplies) {
         limitSquashL.reset(new lock_guard<mutex>(_mtxLimitSquash));

--- a/src/qdisp/UberJob.cc
+++ b/src/qdisp/UberJob.cc
@@ -253,18 +253,20 @@ void UberJob::callMarkCompleteFunc(bool success) {
     _jobs.clear();
 }
 
-json UberJob::importResultFile(protojson::FileUrlInfo const& fileUrlInfo_, bool const retry) {
+protojson::ExecutiveRespMsg::Ptr UberJob::importResultFile(protojson::FileUrlInfo const& fileUrlInfo_) {
     LOGS(_log, LOG_LVL_DEBUG, cName(__func__) << fileUrlInfo_.dump());
 
     auto exec = _executive.lock();
     if (exec == nullptr) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) + " no executive");
-        return importResultError(true, "cancelled", "Query cancelled - no executive");
+        return protojson::ExecutiveRespMsg::create(true, true, _queryId, _uberJobId, _czarId, "cancelled",
+                                                   "Query cancelled no executive");
     }
 
     if (exec->getCancelled()) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) << " import job was cancelled.");
-        return importResultError(true, "cancelled", "Query cancelled");
+        return protojson::ExecutiveRespMsg::create(true, true, _queryId, _uberJobId, _czarId, "cancelled",
+                                                   "Query cancelled");
     }
 
     if (exec->isRowLimitComplete()) {
@@ -273,22 +275,26 @@ json UberJob::importResultFile(protojson::FileUrlInfo const& fileUrlInfo_, bool 
             LOGS(_log, LOG_LVL_INFO,
                  "UberJob ignoring, enough rows already " << "dataIgnored=" << dataIgnored);
         }
-        return importResultError(false, "rowLimited", "Enough rows already");
+        return protojson::ExecutiveRespMsg::create(true, false, _queryId, _uberJobId, _czarId, "rowLimited",
+                                                   "Enough rows already");
     }
 
     LOGS(_log, LOG_LVL_TRACE, cName(__func__) << " fileSize=" << fileUrlInfo_.fileSize);
     bool const statusSet =
             setStatusIfOk(qmeta::JobStatus::RESPONSE_READY, getIdStr() + " " + fileUrlInfo_.fileUrl);
+    // During flaky communications, it's possible to get messages out of order, which can make for a real
+    // mess. Going to err on the side of caution and give up if things are not as expected.
     if (!statusSet) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) << " setStatusFail could not set status to RESPONSE_READY");
-        if (!retry) {
-            // This is a retry, subject to many awful race conditions due to not knowing if
-            // previous attempts worked. If a previous attempt worked, it should
-            // be allowed to continue.
-            protojson::ResponseMsg respMsg(false, "ignored", "ignored");
-            return respMsg.toJson();
-        }
-        return importResultError(false, "setStatusFail", "could not set status to RESPONSE_READY");
+        // If this UberJob has not started merging, this will kill it. If it has started merging,
+        // a previous message worked and everything should be okay.
+        bool killed = killUberJob();
+        LOGS(_log, LOG_LVL_WARN,
+             cName(__func__) << " killUberJob "
+                             << (killed ? "stopped before merge" : "already merging or merged"));
+        // Since things are strange, don't flag the worker result file as obsolete at this point.
+        return protojson::ExecutiveRespMsg::create(true, false, _queryId, _uberJobId, _czarId,
+                                                   "setStatusFail", "could not set status to RESPONSE_READY");
     }
 
     weak_ptr<UberJob> ujThis = static_pointer_cast<UberJob>(shared_from_this());
@@ -316,19 +322,21 @@ json UberJob::importResultFile(protojson::FileUrlInfo const& fileUrlInfo_, bool 
     exec->queueFileCollect(cmd);
 
     // The file collection has been queued for later, let the worker know that it's okay so far.
-    protojson::ResponseMsg respMsg(true, "", "queued for collection");
-    return respMsg.toJson();
+    return protojson::ExecutiveRespMsg::create(true, false, _queryId, _uberJobId, _czarId, "",
+                                               "queued for collection");
 }
 
-json UberJob::workerError(util::MultiError const& multiErr_) {
+void UberJob::workerError(util::MultiError const& multiErr_, protojson::ExecutiveRespMsg& execRespMsg) {
     LOGS(_log, LOG_LVL_WARN, cName(__func__) << " multiErr=" << multiErr_);
 
-    bool const deleteData = true;
-    bool const keepData = !deleteData;
     auto exec = _executive.lock();
     if (exec == nullptr || exec->getCancelled()) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) << " no executive or cancelled " << multiErr_);
-        return _workerErrorFinish(deleteData, "cancelled");
+        execRespMsg.success = true;
+        execRespMsg.dataObsolete = true;
+        execRespMsg.errorType = "queryEnded";
+        execRespMsg.note = "nullExecutive";
+        return;
     }
 
     if (exec->isRowLimitComplete()) {
@@ -338,7 +346,11 @@ json UberJob::workerError(util::MultiError const& multiErr_) {
                  cName(__func__) << " ignoring, enough rows already "
                                  << "dataIgnored=" << dataIgnored);
         }
-        return _workerErrorFinish(keepData, "none", "rowLimitComplete");
+        execRespMsg.success = true;
+        execRespMsg.dataObsolete = true;
+        execRespMsg.errorType = "none";
+        execRespMsg.note = "rowLimitComplete";
+        return;
     }
 
     exec->addMultiError(multiErr_);
@@ -386,11 +398,16 @@ json UberJob::workerError(util::MultiError const& multiErr_) {
         exec->squash(string("UberJob::workerError ") + mErrMsg);
     }
 
-    return _workerErrorFinish(deleteData, mErrMsg, "");
+    execRespMsg.success = true;
+    execRespMsg.dataObsolete = true;
+    execRespMsg.errorType = mErrMsg;
 }
 
-json UberJob::importResultError(bool shouldCancel, string const& errorType, string const& note) {
-    protojson::ResponseMsg respMsg(false, errorType, note);
+protojson::ExecutiveRespMsg::Ptr UberJob::importResultError(bool shouldCancel, string const& errorType,
+                                                            string const& note) {
+    // If there's been an error, the worker should consider the result file obsolete.
+    auto respMsg =
+            protojson::ExecutiveRespMsg::create(true, true, _queryId, _uberJobId, _czarId, errorType, note);
     // In all cases, the worker should delete the file as this czar will not ask for it.
 
     auto exec = _executive.lock();
@@ -417,7 +434,7 @@ json UberJob::importResultError(bool shouldCancel, string const& errorType, stri
              cName(__func__) << " already cancelled shouldCancel=" << shouldCancel
                              << " errorType=" << errorType << " " << note);
     }
-    return respMsg.toJson();
+    return respMsg;
 }
 
 bool UberJob::importResultFinish() {
@@ -436,22 +453,23 @@ bool UberJob::importResultFinish() {
     return statusSet;
 }
 
-nlohmann::json UberJob::_workerErrorFinish(bool deleteData, std::string const& errorType,
-                                           std::string const& note) {
+void UberJob::_workerErrorFinish(protojson::ExecutiveRespMsg& execRespMsg, std::string const& errorType,
+                                 std::string const& note) {
     // If this is called, the error has been received and the worker should delete
     // the result file.
     // Return error message received "success:1" json message to be sent to the worker.
     auto exec = _executive.lock();
     if (exec == nullptr) {
         LOGS(_log, LOG_LVL_DEBUG, cName(__func__) << " executive is null");
-        protojson::ResponseMsg respMsg(false, "cancelled", "executive is null");
-        return respMsg.toJson();
+        execRespMsg.success = true;
+        execRespMsg.dataObsolete = true;
+        execRespMsg.errorType = "cancelled_QID";
+        execRespMsg.note = " executive is null";
+        return;
     }
 
-    protojson::ResponseMsg respMsg(true);
-    json jsRet = respMsg.toJson();
-    jsRet["deletedata"] = deleteData;
-    return jsRet;
+    execRespMsg.success = true;
+    return;
 }
 
 bool UberJob::killUberJob() {
@@ -492,6 +510,7 @@ bool UberJob::killUberJob() {
     // this czar.)
     bool cancelledMerge = getRespHandler()->cancelFileMerge();
     if (cancelledMerge) {
+        // The merge could be cancelled
         _unassignJobs();
     }
     // Let Czar::_monitor reassign jobs - other UberJobs are probably being killed

--- a/src/qdisp/UberJob.h
+++ b/src/qdisp/UberJob.h
@@ -79,6 +79,8 @@ public:
     /// @return true if the UberJob results were stopped from merging. False means
     ///         the results for this UberJob were already being merged or were merged before
     ///         killUberJob was called.
+    /// Note that returning false means merging either already finished or merging has already
+    /// started and there's no way to stop it without corrupting the results.
     bool killUberJob();
 
     std::shared_ptr<ResponseHandler> getRespHandler() { return _respHandler; }
@@ -108,15 +110,12 @@ public:
     protojson::WorkerContactInfo::Ptr getWorkerContactInfo() { return _wContactInfo; }
 
     /// Queue the lambda function to collect and merge the results from the worker.
-    /// @param retry - true indicates this is a retry of failed communication
-    ///            and should not be used to kill this UberJob due to an unexpected
-    ///            state.
     /// @return a json message indicating success unless the query has been
     ///         cancelled, limit row complete, or similar.
-    nlohmann::json importResultFile(protojson::FileUrlInfo const& fileUrlInfo_, bool const retry = false);
+    protojson::ExecutiveRespMsg::Ptr importResultFile(protojson::FileUrlInfo const& fileUrlInfo_);
 
     /// Handle an error from the worker.
-    nlohmann::json workerError(util::MultiError const& multiErr_);
+    void workerError(util::MultiError const& multiErr_, protojson::ExecutiveRespMsg& execRespMsg);
 
     void setResultFileSize(uint64_t fileSize) { _resultFileSize = fileSize; }
     uint64_t getResultFileSize() { return _resultFileSize; }
@@ -125,8 +124,8 @@ public:
     bool importResultFinish();
 
     /// Import and error from trying to collect results.
-    nlohmann::json importResultError(bool shouldCancel, std::string const& errorType,
-                                     std::string const& note);
+    protojson::ExecutiveRespMsg::Ptr importResultError(bool shouldCancel, std::string const& errorType,
+                                                       std::string const& note);
 
     std::ostream& dump(std::ostream& os) const override;
 
@@ -149,8 +148,9 @@ private:
     void _unassignJobs();
 
     /// Let the Executive know about errors while handling results.
-    nlohmann::json _workerErrorFinish(bool successful, std::string const& errorType = std::string(),
-                                      std::string const& note = std::string());
+    void _workerErrorFinish(protojson::ExecutiveRespMsg& execRespMsg,
+                            std::string const& errorType = std::string(),
+                            std::string const& note = std::string());
 
     std::vector<std::shared_ptr<JobQuery>> _jobs;  ///< List of Jobs in this UberJob.
     mutable std::mutex _jobsMtx;                   ///< Protects _jobs, _jobStatus

--- a/src/qproc/QuerySession.cc
+++ b/src/qproc/QuerySession.cc
@@ -442,9 +442,21 @@ std::ostream& operator<<(std::ostream& out, QuerySession const& querySession) {
 protojson::ScanInfo::Ptr QuerySession::getScanInfo() const { return _context->scanInfo; }
 
 ChunkQuerySpec::Ptr QuerySession::buildChunkQuerySpec(query::QueryTemplate::Vect const& queryTemplates,
-                                                      ChunkSpec const& chunkSpec,
-                                                      bool fillInChunkIdTag) const {
-    if (!validateDominantDbs()) {
+                                                      ChunkSpec const& chunkSpec, bool fillInChunkIdTag,
+                                                      bool checkDominantDb) const {
+    /// TODO: checkDominantDb may not be the best way to go about this, but checking it
+    ///   for every chunk is not useful and wastes a lot of time as the information doesn't
+    ///   change and all chunks use the same databases (while using different tables).
+    ///   There are things that could be done, maybe all are applicable, or maybe not worth the effort:
+    ///   - validateDominantDbs() is called in many places and maybe it just doesn't need to be called
+    ///     that often.
+    ///   - Create a cache of CSS that is immutable so many threads can read without locking.
+    ///     - When a query is started, it asks for a shared pointer to the CSS cache, if the
+    ///       CSS cache is obsolete, a new cache is made and returned, otherwise the existing
+    ///       cache is returned. This way, the CSS cache is only updated when the CSS changes,
+    ///       and all threads can read from it without locking. Changing CSS values mid analysis
+    //        may be detrimental, and this would prevent that as well.
+    if (checkDominantDb && !validateDominantDbs()) {
         throw std::logic_error("QuerySession::" + std::string(__func__) + ": Invalid dominant databases");
     }
 

--- a/src/qproc/QuerySession.h
+++ b/src/qproc/QuerySession.h
@@ -169,8 +169,10 @@ public:
     /// @param fillinChunIdTag - When true replace the CHUNK_TAG string with the chunk id number.
     ///         Template strings sent to the worker should not fill in the tag, but unit tests
     ///         need it filled in.
+    /// @param checkDominantDb - When true, validate the dominant databases.
     ChunkQuerySpec::Ptr buildChunkQuerySpec(query::QueryTemplate::Vect const& queryTemplates,
-                                            ChunkSpec const& chunkSpec, bool fillInChunkIdTag = true) const;
+                                            ChunkSpec const& chunkSpec, bool fillInChunkIdTag,
+                                            bool checkDominantDb = true) const;
 
     /// Finalize a query after chunk coverage has been updated
     void finalize();

--- a/src/qproc/testQueryAnaGeneral.cc
+++ b/src/qproc/testQueryAnaGeneral.cc
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(RestrictorNeighborCount) {
     auto e = qs->cQueryEnd();
     BOOST_REQUIRE(i != e);
     auto queryTemplates = qs->makeQueryTemplates();
-    auto first = qs->buildChunkQuerySpec(queryTemplates, *i);
+    auto first = qs->buildChunkQuerySpec(queryTemplates, *i, true);
     int numQueries = first->queries.size();
     BOOST_CHECK_EQUAL(numQueries, 2);
     BOOST_REQUIRE(numQueries > 0);
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(Triple) {
     BOOST_CHECK(context);
     std::string parallel = queryAnaHelper.buildFirstParallelQuery();
     BOOST_CHECK_EQUAL(parallel, expected);
-    auto first = qs->buildChunkQuerySpec(qs->makeQueryTemplates(), *qs->cQueryBegin());
+    auto first = qs->buildChunkQuerySpec(qs->makeQueryTemplates(), *qs->cQueryBegin(), true);
     BOOST_REQUIRE_EQUAL(first->subChunkIds.size(), 3u);
     BOOST_CHECK_EQUAL(first->subChunkIds[0], 100000);
     BOOST_CHECK_EQUAL(first->subChunkIds[1], 100010);
@@ -772,7 +772,7 @@ BOOST_AUTO_TEST_CASE(CountQuery2) {
     auto e = qs->cQueryEnd();
     BOOST_REQUIRE(i != e);
     auto queryTemplates = qs->makeQueryTemplates();
-    auto first = qs->buildChunkQuerySpec(queryTemplates, *i);
+    auto first = qs->buildChunkQuerySpec(queryTemplates, *i, true);
     BOOST_CHECK_EQUAL(first->queries.size(), 1U);
     BOOST_CHECK_EQUAL(first->queries[0], expected_100);
 }
@@ -1150,7 +1150,7 @@ BOOST_AUTO_TEST_CASE(NoSpec) {
     auto e = qs->cQueryEnd();
     BOOST_REQUIRE(i != e);
     auto queryTemplates = qs->makeQueryTemplates();
-    auto first = qs->buildChunkQuerySpec(queryTemplates, *i);
+    auto first = qs->buildChunkQuerySpec(queryTemplates, *i, true);
     BOOST_CHECK_EQUAL(first->queries.size(), 1U);
     BOOST_CHECK_EQUAL(first->queries[0], expected);
     BOOST_CHECK_EQUAL(first->subChunkTables.size(), 0U);
@@ -1385,7 +1385,7 @@ BOOST_AUTO_TEST_CASE(Case01_1081) {
     auto e = qs->cQueryEnd();
     BOOST_REQUIRE(i != e);
     auto queryTemplates = qs->makeQueryTemplates();
-    auto first = qs->buildChunkQuerySpec(queryTemplates, *i);
+    auto first = qs->buildChunkQuerySpec(queryTemplates, *i, true);
     int numQueries = first->queries.size();
     BOOST_CHECK_EQUAL(numQueries, 2);
     BOOST_REQUIRE(numQueries > 0);

--- a/src/qproc/testQueryAnaIn.cc
+++ b/src/qproc/testQueryAnaIn.cc
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(CountIn) {
     for (auto i = queryAnaHelper.querySession->cQueryBegin(), e = queryAnaHelper.querySession->cQueryEnd();
          i != e; ++i) {
         auto queryTemplates = queryAnaHelper.querySession->makeQueryTemplates();
-        auto cs = queryAnaHelper.querySession->buildChunkQuerySpec(queryTemplates, *i);
+        auto cs = queryAnaHelper.querySession->buildChunkQuerySpec(queryTemplates, *i, true);
         LOGS_DEBUG("Chunk spec: " << *cs);
     }
     std::shared_ptr<QueryContext> context = qs->dbgGetContext();

--- a/src/tests/QueryAnaHelper.cc
+++ b/src/tests/QueryAnaHelper.cc
@@ -100,7 +100,7 @@ std::string QueryAnaHelper::buildFirstParallelQuery(bool withSubChunks) {
 
     auto& chunkSpec = *i;
     auto queryTemplates = querySession->makeQueryTemplates();
-    auto first = querySession->buildChunkQuerySpec(queryTemplates, chunkSpec);
+    auto first = querySession->buildChunkQuerySpec(queryTemplates, chunkSpec, true);
     std::string const& firstParallelQuery = first->queries[0];
     LOGS(_log, LOG_LVL_TRACE, "First parallel query: " << firstParallelQuery);
     return firstParallelQuery;

--- a/src/wbase/FileChannelShared.cc
+++ b/src/wbase/FileChannelShared.cc
@@ -168,6 +168,29 @@ void FileChannelShared::cleanUpResults(uint32_t czarId, QueryId queryId) {
          context << "removed " << numFilesRemoved << " result files from " << dirPath << ".");
 }
 
+void FileChannelShared::cleanUpResults(uint32_t czarId, QueryId queryId, UberJobId ujId) {
+    string const context = "FileChannelShared::" + string(__func__) + " ";
+    fs::path const dirPath = wconfig::WorkerConfig::instance()->resultsDirname();
+    LOGS(_log, LOG_LVL_INFO,
+         context << "removing result files from " << dirPath << " for czarId=" << czarId
+                 << ", queryId=" << queryId << ", and ujId=" << ujId << ".");
+    lock_guard<mutex> const lock(_resultsDirCleanupMtx);
+    size_t const numFilesRemoved = ::cleanUpResultsImpl(
+            context, dirPath, [&context, czarId, queryId, ujId](string const& fileName) -> bool {
+                try {
+                    auto const fileAttributes = util::ResultFileName(fileName);
+                    return (fileAttributes.czarId() == czarId) && (fileAttributes.queryId() == queryId) &&
+                           (fileAttributes.ujId() == ujId);
+                } catch (exception const& ex) {
+                    LOGS(_log, LOG_LVL_WARN,
+                         context << "failed to parse the file name " << fileName << ", ex: " << ex.what());
+                }
+                return false;
+            });
+    LOGS(_log, LOG_LVL_INFO,
+         context << "removed " << numFilesRemoved << " result files from " << dirPath << ".");
+}
+
 json FileChannelShared::statusToJson() {
     string const context = "FileChannelShared::" + string(__func__) + " ";
     auto const config = wconfig::WorkerConfig::instance();

--- a/src/wbase/FileChannelShared.h
+++ b/src/wbase/FileChannelShared.h
@@ -87,9 +87,17 @@ public:
     /**
      * Clean up result files of the specified query.
      * @param czarId The unique identifier of Czar that initiated the query.
-     * @param queryId The most recent user query registered before restart.
+     * @param queryId The id of the query results to be removed.
      */
     static void cleanUpResults(uint32_t czarId, QueryId queryId);
+
+    /**
+     * Clean up result files of the specified UberJob.
+     * @param czarId The unique identifier of Czar that initiated the query.
+     * @param queryId The id of the UberJob results to be removed.
+     * @param ujId The id of the UberJob results to be removed.
+     */
+    static void cleanUpResults(uint32_t czarId, QueryId queryId, UberJobId ujId);
 
     /// @return Status and statistics on the results folder (capacity, usage, etc.)
     static nlohmann::json statusToJson();

--- a/src/wbase/FileChannelShared.h
+++ b/src/wbase/FileChannelShared.h
@@ -177,7 +177,7 @@ private:
      * @param task - a task that produced the result set
      * @param mResult - MySQL result to be used as a source
      * @param bytes - the number of bytes in the result message recorded into the file
-     * @param rows - the number of rows extracted from th eresult set
+     * @param rows - the number of rows extracted from the result set
      * @param multiErr - a collector of any errors that were captured during result set processing
      * @throws std::runtime_error for problems encountered when attemting to create the file
      *   or write into the file.

--- a/src/wbase/UberJobData.cc
+++ b/src/wbase/UberJobData.cc
@@ -44,6 +44,7 @@
 #include "util/Bug.h"
 #include "util/MultiError.h"
 #include "util/ResultFileName.h"
+#include "wbase/FileChannelShared.h"
 #include "wconfig/WorkerConfig.h"
 #include "wcontrol/Foreman.h"
 #include "wcontrol/WCzarInfoMap.h"
@@ -265,16 +266,16 @@ void UJTransmitCmd::action(util::CmdData* data) {
     http::Client client(_method, _url, requestStr, _headers);
     bool transmitSuccess = false;
     try {
-#if 1  //&&& For error path testing, seeting 0 here forces communication to use WorkerCzarComIssue.
         json const response = client.readAsJson();
         auto respMsg = protojson::ExecutiveRespMsg::createFromJson(response);
         if (respMsg->success) {
             transmitSuccess = true;
             if (respMsg->dataObsolete) {
-                // Delete the file and end this UberJob
+                // Mark the as obsolete and end this UberJob
                 ujPtr->cancelAllTasks();
-                // TODO: Delete the file, there's currently no code to delete a specific qId + ujId file
-                //       in FileChannelShared, but it should be added and called here.
+                // At this point, just deleting obsolete result files.
+                wbase::FileChannelShared::cleanUpResults(ujPtr->getCzarId(), ujPtr->getQueryId(),
+                                                         ujPtr->getUberJobId());
             }
             string note = response.at("note");
             if (!note.empty()) {
@@ -288,7 +289,6 @@ void UJTransmitCmd::action(util::CmdData* data) {
             // it.
             return;
         }
-#endif  //&&&
     } catch (exception const& ex) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) << " " << _requestContext << " failed, ex: " << ex.what());
     }

--- a/src/wbase/UberJobData.cc
+++ b/src/wbase/UberJobData.cc
@@ -37,6 +37,7 @@
 #include "http/Method.h"
 #include "http/RequestBodyJSON.h"
 #include "http/RequestQuery.h"
+#include "protojson/PwHideJson.h"
 #include "protojson/UberJobErrorMsg.h"
 #include "protojson/UberJobReadyMsg.h"
 #include "protojson/WorkerCzarComIssue.h"
@@ -264,26 +265,35 @@ void UJTransmitCmd::action(util::CmdData* data) {
     http::Client client(_method, _url, requestStr, _headers);
     bool transmitSuccess = false;
     try {
+#if 1  //&&& For error path testing, seeting 0 here forces communication to use WorkerCzarComIssue.
         json const response = client.readAsJson();
-        auto respMsg = protojson::ResponseMsg::createFromJson(response);
+        auto respMsg = protojson::ExecutiveRespMsg::createFromJson(response);
         if (respMsg->success) {
             transmitSuccess = true;
+            if (respMsg->dataObsolete) {
+                // Delete the file and end this UberJob
+                ujPtr->cancelAllTasks();
+                // TODO: Delete the file, there's currently no code to delete a specific qId + ujId file
+                //       in FileChannelShared, but it should be added and called here.
+            }
             string note = response.at("note");
-            if (note.empty()) {
-                LOGS(_log, LOG_LVL_INFO, response);
+            if (!note.empty()) {
+                LOGS(_log, LOG_LVL_INFO, protojson::pwHide(response));
             }
         } else {
-            LOGS(_log, LOG_LVL_WARN, cName(__func__) << " Transmit success=0 " << response);
+            LOGS(_log, LOG_LVL_WARN,
+                 cName(__func__) << " Transmit success=0 " << protojson::pwHide(response));
             respMsg->failedUpdateUberJobData(ujPtr);
             // There's no point in re-sending as the czar got the message and didn't like
             // it.
             return;
         }
+#endif  //&&&
     } catch (exception const& ex) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) << " " << _requestContext << " failed, ex: " << ex.what());
     }
     if (!transmitSuccess) {
-        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " resending!");
+        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " Transmit failed, adding to WorkerCzarComIssue");
         auto sPtr = _selfPtr;
         if (_foreman != nullptr && sPtr != nullptr) {
             // Do not reset _selfPtr as re-queuing may be needed several times.

--- a/src/wbase/UberJobData.cc
+++ b/src/wbase/UberJobData.cc
@@ -138,7 +138,7 @@ void UberJobData::responseError(util::MultiError& multiErr, int chunkId, bool ca
     if (_responseState == NOTHING) {
         _responseState = SENDING_ERROR;
     } else {
-        LOGS(_log, LOG_LVL_WARN,
+        LOGS(_log, LOG_LVL_DEBUG,
              cName(__func__) << " Already sending a different message. NOT sending [" << multiErr << "]");
         return;
     }

--- a/src/wcomms/HttpWorkerCzarModule.cc
+++ b/src/wcomms/HttpWorkerCzarModule.cc
@@ -262,44 +262,25 @@ json HttpWorkerCzarModule::_handleQueryStatus(std::string const& func) {
     auto const queriesAndChunks = foreman()->queriesAndChunks();
     vector<wbase::UserQueryInfo::Ptr> cancelledList;
     vector<wbase::UserQueryInfo::Ptr> deleteFilesList;
+    std::map<QueryId, std::map<UberJobId, TIMEPOINT>> deadUberJobsList;
     {
         // Cancelled queries where we want to keep the files
         lock_guard mapLg(wqsData->mapMtx);
-        for (auto const& [dkQid, dkTm] : wqsData->qIdDoneKeepFiles) {
-            auto qStats = queriesAndChunks->addQueryId(dkQid, czId);
-            if (qStats != nullptr) {
-                auto uqInfo = qStats->getUserQueryInfo();
-                if (uqInfo != nullptr) {
-                    if (!uqInfo->getCancelledByCzar()) {
-                        cancelledList.push_back(uqInfo);
-                    }
-                }
-            }
-        }
-        for (auto const& [dkQid, dkTm] : wqsData->qIdDoneDeleteFiles) {
-            auto qStats = queriesAndChunks->addQueryId(dkQid, czId);
-            if (qStats != nullptr) {
-                auto uqInfo = qStats->getUserQueryInfo();
-                if (uqInfo != nullptr) {
-                    if (!uqInfo->getCancelledByCzar()) {
-                        cancelledList.push_back(uqInfo);
-                    }
-                    deleteFilesList.push_back(uqInfo);
-                }
-            }
-        }
-    }
+        queriesAndChunks->buildCancelledAndDeletedLists(czId, wqsData->qIdDoneKeepFiles, true, cancelledList,
+                                                        deleteFilesList);
+        queriesAndChunks->buildCancelledAndDeletedLists(czId, wqsData->qIdDoneDeleteFiles, false,
+                                                        cancelledList, deleteFilesList);
 
-    // Cancel everything in the cancelled list.
-    for (auto const& canUqInfo : cancelledList) {
-        canUqInfo->cancelFromCzar();
+        // Need to make a list of these while the mutex is held,
+        // and then delete them after the mutex is released.
+        deadUberJobsList = wqsData->qIdDeadUberJobs;
     }
 
     // For dead UberJobs, add them to a list of dead uberjobs within UserQueryInfo.
     // UserQueryInfo will cancel the tasks in the uberjobs if they exist.
     // New UberJob Id's will be checked against the list, and immediately be
     // killed if they are on it. (see HttpWorkerCzarModule::_handleQueryJob)
-    for (auto const& [ujQid, ujIdMap] : wqsData->qIdDeadUberJobs) {
+    for (auto const& [ujQid, ujIdMap] : deadUberJobsList) {
         auto qStats = queriesAndChunks->addQueryId(ujQid, czId);
         if (qStats != nullptr) {
             auto uqInfo = qStats->getUserQueryInfo();
@@ -311,6 +292,11 @@ json HttpWorkerCzarModule::_handleQueryStatus(std::string const& func) {
                 }
             }
         }
+    }
+
+    // Cancel everything in the cancelled list.
+    for (auto const& canUqInfo : cancelledList) {
+        canUqInfo->cancelFromCzar();
     }
 
     // Delete files that should be deleted

--- a/src/wcomms/HttpWorkerCzarModule.cc
+++ b/src/wcomms/HttpWorkerCzarModule.cc
@@ -36,7 +36,9 @@
 #include "http/RequestQuery.h"
 #include "http/RequestBodyJSON.h"
 #include "mysql/MySqlUtils.h"
+#include "protojson/ResponseMsg.h"
 #include "protojson/UberJobMsg.h"
+#include "protojson/WorkerCzarComIssue.h"
 #include "protojson/WorkerQueryStatusData.h"
 #include "util/Command.h"
 #include "util/Error.h"
@@ -264,15 +266,17 @@ json HttpWorkerCzarModule::_handleQueryStatus(std::string const& func) {
     vector<wbase::UserQueryInfo::Ptr> deleteFilesList;
     std::map<QueryId, std::map<UberJobId, TIMEPOINT>> deadUberJobsList;
     {
-        // Cancelled queries where we want to keep the files
-        lock_guard mapLg(wqsData->mapMtx);
-        queriesAndChunks->buildCancelledAndDeletedLists(czId, wqsData->qIdDoneKeepFiles, true, cancelledList,
-                                                        deleteFilesList);
-        queriesAndChunks->buildCancelledAndDeletedLists(czId, wqsData->qIdDoneDeleteFiles, false,
-                                                        cancelledList, deleteFilesList);
+        // Need to make a lists of these while the mutex is held,
+        // and then use the lists to make changes after the mutex is released.
 
-        // Need to make a list of these while the mutex is held,
-        // and then delete them after the mutex is released.
+        lock_guard mapLg(wqsData->mapMtx);
+        // Cancelled queries where we want to keep the files
+        bool const keepFiles = true;
+        queriesAndChunks->buildCancelledAndDeletedLists(czId, wqsData->qIdDoneKeepFiles, keepFiles,
+                                                        cancelledList, deleteFilesList);
+        // Cancelled queries where the files can be deleted.
+        queriesAndChunks->buildCancelledAndDeletedLists(czId, wqsData->qIdDoneDeleteFiles, !keepFiles,
+                                                        cancelledList, deleteFilesList);
         deadUberJobsList = wqsData->qIdDeadUberJobs;
     }
 
@@ -288,6 +292,7 @@ json HttpWorkerCzarModule::_handleQueryStatus(std::string const& func) {
                 if (!uqInfo->getCancelledByCzar()) {
                     for (auto const& [ujId, tm] : ujIdMap) {
                         uqInfo->cancelUberJob(ujId);
+                        wbase::FileChannelShared::cleanUpResults(czId, uqInfo->getQueryId(), ujId);
                     }
                 }
             }
@@ -306,6 +311,10 @@ json HttpWorkerCzarModule::_handleQueryStatus(std::string const& func) {
         wbase::FileChannelShared::cleanUpResults(czIdToDelete, uqiPtr->getQueryId());
     }
     // Syntax errors in the message would throw invalid_argument, which is handled elsewhere.
+
+    // Remove associated entries from the associated WorkerCzarComIssue object.
+    auto wccIssue = wCzarInfo->getWorkerCzarComIssue();
+    wccIssue->clearFailedTransmitsForQids(wqsData->qIdDoneDeleteFiles);
 
     // Return a message containing lists of the queries that were cancelled.
     jsRet = wqsData->serializeResponseJson(foreman()->getWorkerStartupTime());

--- a/src/wcontrol/Foreman.cc
+++ b/src/wcontrol/Foreman.cc
@@ -116,7 +116,7 @@ Foreman::Foreman(wsched::BlendScheduler::Ptr const& scheduler, unsigned int pool
           _io_service(),
           _httpServer(qhttp::Server::create(_io_service, 0 /* grab the first available port */)),
           _wCzarInfoMap(WCzarInfoMap::create()),
-          _fqdn(util::get_current_host_fqdn()) {
+          _fqdn(util::get_current_host_fqdn_wait()) {
     // Make the chunk resource mgr
     // Creating backend makes a connection to the database for making temporary tables.
     // It will delete temporary tables that it can identify as being created by a worker.

--- a/src/wcontrol/WCzarInfoMap.cc
+++ b/src/wcontrol/WCzarInfoMap.cc
@@ -31,6 +31,7 @@
 
 // qserv headers
 #include "http/Client.h"
+#include "protojson/ResponseMsg.h"
 #include "protojson/WorkerCzarComIssue.h"
 #include "protojson/WorkerQueryStatusData.h"
 #include "util/Bug.h"
@@ -64,8 +65,10 @@ void WCzarInfo::czarMsgReceived(TIMEPOINT tm) {
     _lastTouch = tm;
     if (_alive.exchange(true) == false) {
         uniLock.unlock();
-        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " was dead and is now alive");
-        _workerCzarComIssue->setThoughtCzarWasDead(true);
+        auto msSinceEpoch = std::chrono::duration_cast<std::chrono::milliseconds>(tm.time_since_epoch());
+        uint64_t msDeadNowAliveTime = msSinceEpoch.count();
+        LOGS(_log, LOG_LVL_WARN, cName(__func__) << " was dead and is now alive ms=" << msDeadNowAliveTime);
+        _workerCzarComIssue->setThoughtCzarWasDeadTime(msDeadNowAliveTime);
     }
 }
 
@@ -109,9 +112,8 @@ void WCzarInfo::_sendMessage() {
     auto const method = http::Method::POST;
 
     unique_lock<mutex> uniLock(_wciMtx);
-    auto czInfo = _workerCzarComIssue->getCzarInfo();
     // If thoughtCzarWasDead is set now, it needs to be cleared on successful reception from czar.
-    bool needToClearThoughtCzarWasDead = _workerCzarComIssue->getThoughtCzarWasDead();
+    auto czInfo = _workerCzarComIssue->getCzarInfo();
     if (czInfo == nullptr) {
         LOGS(_log, LOG_LVL_ERROR, cName(__func__) << " czar info was null");
         return;
@@ -125,22 +127,43 @@ void WCzarInfo::_sendMessage() {
     auto requestStr = jsReq.dump();
     http::Client client(method, url, requestStr, headers);
     bool transmitSuccess = false;
+    size_t cleanupCount = 0;
+    vector<protojson::UberJobIdentifierType> ujDataObsoleteList;
+    vector<protojson::UberJobIdentifierType> ujParseErrorList;
     try {
         LOGS(_log, LOG_LVL_DEBUG, cName(__func__) << " read start");
         nlohmann::json const response = client.readAsJson();
         LOGS(_log, LOG_LVL_DEBUG, cName(__func__) << " read end");
-        auto respMsg = protojson::ResponseMsg::createFromJson(response);
+        auto respMsg = protojson::WorkerCzarComRespMsg::createFromJson(response);
         uniLock.lock();
         if (respMsg->success) {
             transmitSuccess = true;
-            if (needToClearThoughtCzarWasDead) {
-                _workerCzarComIssue->setThoughtCzarWasDead(false);
+            /// Read the value sent back by the czar. If it is greater than or equal
+            /// czDeadTime, then set dead time to zero.
+            auto localDeadTime = _workerCzarComIssue->getThoughtCzarWasDeadTime();
+            if (localDeadTime != 0) {
+                auto respDeadTime = respMsg->thoughtCzarWasDeadTime;
+                bool cleared = false;
+                if (respDeadTime >= _workerCzarComIssue->getThoughtCzarWasDeadTime()) {
+                    _workerCzarComIssue->setThoughtCzarWasDeadTime(0);
+                    cleared = true;
+                }
+                LOGS(_log, LOG_LVL_WARN,
+                     cName(__func__) << " ThoughtCzarWasDeadTime check local=" << localDeadTime
+                                     << " resp=" << respDeadTime << " cleared=" << cleared);
             }
-            _workerCzarComIssue->clearMapEntries(response);
+            tie(cleanupCount, ujDataObsoleteList, ujParseErrorList) =
+                    _workerCzarComIssue->clearMapEntries(response);
+            // TODO &&& mark everything in Obsolete list as obsolete
+            // TODO &&& kill everything in parseErrorlist and send failed messages for each ("Internal parse
+            // error in WorkerCzarComIssue")
         } else {
             LOGS(_log, LOG_LVL_WARN, cName(__func__) << " Transmit " << *respMsg);
             // There's no point in re-sending as the czar got the message and didn't like
             // it.
+            // TODO&&& ??? What to do here. It failed to parse. Start counting and consider the czar dead
+            // &&& if there are say 10 parse errors in a row. At that point, this worker and this czar
+            // &&& are hopelessly out of sink???
         }
     } catch (exception const& ex) {
         LOGS(_log, LOG_LVL_WARN, cName(__func__) + " " + requestStr + " failed, ex: " + ex.what());

--- a/src/wcontrol/WCzarInfoMap.cc
+++ b/src/wcontrol/WCzarInfoMap.cc
@@ -31,11 +31,13 @@
 
 // qserv headers
 #include "http/Client.h"
+#include "protojson/PwHideJson.h"
 #include "protojson/ResponseMsg.h"
 #include "protojson/WorkerCzarComIssue.h"
 #include "protojson/WorkerQueryStatusData.h"
 #include "util/Bug.h"
 #include "util/Histogram.h"
+#include "wbase/FileChannelShared.h"
 #include "wbase/UberJobData.h"
 #include "wconfig/WorkerConfig.h"
 #include "wcontrol/Foreman.h"
@@ -124,18 +126,25 @@ void WCzarInfo::_sendMessage() {
     auto jsReq = _workerCzarComIssue->toJson();
     uniLock.unlock();  // Must unlock before communication
 
+    // Send the request to the czar to be handled by
     auto requestStr = jsReq.dump();
     http::Client client(method, url, requestStr, headers);
     bool transmitSuccess = false;
+
     size_t cleanupCount = 0;
-    vector<protojson::UberJobIdentifierType> ujDataObsoleteList;
-    vector<protojson::UberJobIdentifierType> ujParseErrorList;
+    vector<protojson::UberJobIdentType> ujDataObsoleteList;
+    vector<protojson::UberJobIdentType> ujIdNotFoundErrorList;
     try {
         LOGS(_log, LOG_LVL_DEBUG, cName(__func__) << " read start");
         nlohmann::json const response = client.readAsJson();
         LOGS(_log, LOG_LVL_DEBUG, cName(__func__) << " read end");
         auto respMsg = protojson::WorkerCzarComRespMsg::createFromJson(response);
-        uniLock.lock();
+
+        // `response` json was created by WorkerCzarComRespMsg::toJson on the czar.
+        // The `response` from the czar needs to be used to remove the handled entries
+        // from the `failedTransmits` map and to determine if any result files are obsolete
+        // or if there were any parse errors.
+        uniLock.lock();  // re-lock _wciMtx to protect members.
         if (respMsg->success) {
             transmitSuccess = true;
             /// Read the value sent back by the czar. If it is greater than or equal
@@ -152,26 +161,49 @@ void WCzarInfo::_sendMessage() {
                      cName(__func__) << " ThoughtCzarWasDeadTime check local=" << localDeadTime
                                      << " resp=" << respDeadTime << " cleared=" << cleared);
             }
-            tie(cleanupCount, ujDataObsoleteList, ujParseErrorList) =
+            tie(cleanupCount, ujDataObsoleteList, ujIdNotFoundErrorList) =
                     _workerCzarComIssue->clearMapEntries(response);
-            // TODO &&& mark everything in Obsolete list as obsolete
-            // TODO &&& kill everything in parseErrorlist and send failed messages for each ("Internal parse
-            // error in WorkerCzarComIssue")
+
         } else {
-            LOGS(_log, LOG_LVL_WARN, cName(__func__) << " Transmit " << *respMsg);
+            ++_czarSentFailCount;
+            LOGS(_log, LOG_LVL_WARN,
+                 cName(__func__) << " Transmit czarSentFailCount=" << _czarSentFailCount
+                                 << " msg=" << *respMsg);
             // There's no point in re-sending as the czar got the message and didn't like
             // it.
-            // TODO&&& ??? What to do here. It failed to parse. Start counting and consider the czar dead
-            // &&& if there are say 10 parse errors in a row. At that point, this worker and this czar
-            // &&& are hopelessly out of sink???
+            // TODO:  What to do here? Ignore this until its a problem? Czar failed to parse original
+            //   message. Start counting and consider the czar dead when a threshold is reached?
         }
     } catch (exception const& ex) {
-        LOGS(_log, LOG_LVL_WARN, cName(__func__) + " " + requestStr + " failed, ex: " + ex.what());
+        ++_parseErrorCount;
+        LOGS(_log, LOG_LVL_WARN,
+             cName(__func__) << " " << protojson::pwHide(jsReq)
+                             << " failed, parseErrorCount=" << _parseErrorCount << " ex:" << ex.what());
     }
 
     if (!transmitSuccess) {
-        // If transmit fails, the message will be resent
+        // If transmit fails, the czar will send another message eventually.
         LOGS(_log, LOG_LVL_ERROR, cName(__func__) << " failed to send message");
+        return;
+    }
+
+    auto foreman = Foreman::getForeman();
+    if (foreman == nullptr) return;
+    auto queriesAndChunks = foreman->getQueriesAndChunks();
+    if (queriesAndChunks == nullptr) return;
+
+    // Set these files as obsolete (at this point they are just deleted, but that may change).
+    for (auto const& ujIdent : ujDataObsoleteList) {
+        LOGS(_log, LOG_LVL_INFO,
+             cName(__func__) << " marking qId=" << ujIdent.qId << "_ujId=" << ujIdent.ujId << " as obsolete");
+        wbase::FileChannelShared::cleanUpResults(ujIdent.czInfo->czId, ujIdent.qId, ujIdent.ujId);
+    }
+    // Delete files where there were parse errors.
+    for (auto const& ujIdent : ujIdNotFoundErrorList) {
+        LOGS(_log, LOG_LVL_INFO,
+             cName(__func__) << " deleting qId=" << ujIdent.qId << "_ujId=" << ujIdent.ujId
+                             << " due to parse error");
+        wbase::FileChannelShared::cleanUpResults(ujIdent.czInfo->czId, ujIdent.qId, ujIdent.ujId);
     }
 }
 

--- a/src/wcontrol/WCzarInfoMap.h
+++ b/src/wcontrol/WCzarInfoMap.h
@@ -101,6 +101,13 @@ private:
     /// true when running a thread to send a message to the czar
     /// with _sendMessage()
     std::atomic<bool> _msgThreadRunning{false};
+
+    /// If the system is working properly, these counts should be zero. If
+    /// they start climbing, it may indicate a problem that should be dealt with.
+    /// This is used to track how many times the czar has failed to handle a worker message.
+    std::atomic<int> _czarSentFailCount{0};
+    /// This is used to track how many times there's been a parse error.
+    std::atomic<int> _parseErrorCount{0};
 };
 
 /// Each worker talks to multiple czars and needs a WCzarInfo object for each czar,

--- a/src/wpublish/QueriesAndChunks.cc
+++ b/src/wpublish/QueriesAndChunks.cc
@@ -416,6 +416,28 @@ void QueriesAndChunks::examineAll() {
     LOGS(_log, LOG_LVL_DEBUG, "QueriesAndChunks::examineAll end");
 }
 
+void QueriesAndChunks::buildCancelledAndDeletedLists(
+        CzarId czarId, std::map<QueryId, TIMEPOINT> const& qIdFiles, bool keepFiles,
+        std::vector<std::shared_ptr<wbase::UserQueryInfo>>& cancelledList,
+        std::vector<std::shared_ptr<wbase::UserQueryInfo>>& deleteList) {
+    // see wcomms::HttpWorkerCzarModule::_handleQueryStatus
+    unique_lock<mutex> guardStats(_queryStatsMapMtx);
+    for (auto const& [dkQid, dkTm] : qIdFiles) {
+        auto qStats = _addQueryId(dkQid, czarId);
+        if (qStats != nullptr) {
+            auto uqInfo = qStats->getUserQueryInfo();
+            if (uqInfo != nullptr) {
+                if (!uqInfo->getCancelledByCzar()) {
+                    cancelledList.push_back(uqInfo);
+                }
+                if (!keepFiles) {
+                    deleteList.push_back(uqInfo);
+                }
+            }
+        }
+    }
+}
+
 nlohmann::json QueriesAndChunks::statusToJson(wbase::TaskSelector const& taskSelector) const {
     nlohmann::json status = nlohmann::json::object();
     {

--- a/src/wpublish/QueriesAndChunks.h
+++ b/src/wpublish/QueriesAndChunks.h
@@ -39,10 +39,15 @@
 
 // Qserv headers
 #include "global/intTypes.h"
+#include "protojson/WorkerQueryStatusData.h"
 #include "wbase/Task.h"
 #include "wpublish/QueryStatistics.h"
 
 // Forward declarations
+namespace lsst::qserv::protojson {
+class CzarContactInfo;
+}  // namespace lsst::qserv::protojson
+
 namespace lsst::qserv::wbase {
 struct TaskSelector;
 }  // namespace lsst::qserv::wbase

--- a/src/wpublish/QueriesAndChunks.h
+++ b/src/wpublish/QueriesAndChunks.h
@@ -202,6 +202,17 @@ public:
     /// @see _addQueryId
     QueryStatistics::Ptr addQueryId(QueryId qId, CzarId czarId);
 
+    /// Build lists of cancelled and deleted user queries based on the provided `qIdFiles` and `keepFiles`
+    /// flag.
+    /// @param qIdFiles - A map of files IDs to be cancelled or deleted.
+    /// @param keepfiles - If true, none of the files will be added to the delete list.
+    /// @param cancelledList - A vector to be populated with user queries that should be cancelled.
+    /// @param deleteList - A vector to be populated with user queries that should be deleted.
+    void buildCancelledAndDeletedLists(CzarId czarId, std::map<QueryId, TIMEPOINT> const& qIdFiles,
+                                       bool keepFiles,
+                                       std::vector<std::shared_ptr<wbase::UserQueryInfo>>& cancelledList,
+                                       std::vector<std::shared_ptr<wbase::UserQueryInfo>>& deleteList);
+
     void addTask(wbase::Task::Ptr const& task);
     void addTasks(std::vector<wbase::Task::Ptr> const& tasks, std::vector<util::Command::Ptr>& cmds);
     void queuedTask(wbase::Task::Ptr const& task);


### PR DESCRIPTION
The `WorkerCzarComIssue` message from the worker to the czar contains all UberJob file ready messages that failed to be transmitted to the czar.  If one of the failed transmits in the `WorkerCzarComIssue` had been completed or cancelled, it would cause the czar to tell the worker there was a parse error and none of the file ready messages would be removed from the worker's list. That would cause them all to be sent again in the next time the worker sent the `WorkerCzarComIssue` message, which would compound the problem.

The fix is to have better parsing and return a list that has more information about what the czar is doing with each UberJob in the list so the worker can make better decisions.