### PR TITLE
DM-54589: Qserv Replication system records incorrect timestamps of chunk replicas in the system's metadata database

### DIFF
--- a/src/replica/tests/testFileUtils.cc
+++ b/src/replica/tests/testFileUtils.cc
@@ -220,4 +220,26 @@ BOOST_AUTO_TEST_CASE(FileUtils_verifyFolders) {
     LOGS_INFO("FileUtils::verifyFolders test ends");
 }
 
+BOOST_AUTO_TEST_CASE(FileUtils_getSetMTime) {
+    LOGS_INFO("getMTime and setMTime test begins");
+    string const baseDir = "/tmp";
+    string const fileName =
+            FileUtils::createTemporaryFile(baseDir, "test-file-", "%%%%-%%%%-%%%%-%%%%", ".dat");
+
+    // Get the current modification time
+    time_t const mtime = getMTime(fileName);
+
+    // Set a new modification time
+    time_t const newMTime = mtime + 10;
+    setMTime(fileName, newMTime);
+
+    // Verify the modification time was updated
+    BOOST_CHECK_EQUAL(getMTime(fileName), newMTime);
+
+    // Clean up
+    std::error_code ec;
+    fs::remove(fileName, ec);
+    LOGS_INFO("getMTime and setMTime test ends");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/replica/util/FileUtils.cc
+++ b/src/replica/util/FileUtils.cc
@@ -27,10 +27,12 @@
 #include <cerrno>
 #include <cstring>
 #include <cstdio>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
 #include <system_error>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <unistd.h>
@@ -382,6 +384,38 @@ bool MultiFileCsComputeEngine::execute() {
         _processed[*_currentFileItr].reset(new FileCsComputeEngine(*_currentFileItr, _recordSizeBytes));
     }
     return false;
+}
+
+time_t getMTime(string const& fileName) {
+    if (fileName.empty()) {
+        throw invalid_argument("FileUtils::" + string(__func__) + "  empty file name passed into the method");
+    }
+    struct stat sb;
+    if (lstat(fileName.c_str(), &sb) == -1) {
+        throw runtime_error("FileUtils::" + string(__func__) + "  failed to access the file: " + fileName +
+                            ", error: '" + strerror(errno) + "', errno: " + to_string(errno) + ")");
+    }
+    return sb.st_mtime;
+}
+
+void setMTime(string const& fileName, time_t mtime) {
+    if (fileName.empty()) {
+        throw invalid_argument("FileUtils::" + string(__func__) + "  empty file name passed into the method");
+    }
+    struct stat sb;
+    if (lstat(fileName.c_str(), &sb) == -1) {
+        throw runtime_error("FileUtils::" + string(__func__) + "  failed to access the file: " + fileName +
+                            ", error: '" + strerror(errno) + "', errno: " + to_string(errno) + ")");
+    }
+    struct timespec times[2];
+    times[0] = sb.st_atim;  // keep the access time unchanged
+    times[1].tv_sec = mtime;
+    times[1].tv_nsec = 0;
+    if (utimensat(AT_FDCWD, fileName.c_str(), times, 0) == -1) {
+        throw runtime_error("FileUtils::" + string(__func__) +
+                            "  failed to set mtime for the file: " + fileName + ", error: '" +
+                            strerror(errno) + "', errno: " + to_string(errno) + ")");
+    }
 }
 
 }  // namespace lsst::qserv::replica

--- a/src/replica/util/FileUtils.h
+++ b/src/replica/util/FileUtils.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <time.h>
 #include <tuple>
 #include <vector>
 
@@ -297,6 +298,24 @@ private:
     /// Files which has been or are being processed
     std::map<std::string, std::unique_ptr<FileCsComputeEngine>> _processed;
 };
+
+/**
+ * Get mtime of a file.
+ * @param fileName the name of a file
+ * @return the mtime of the file
+ * @throws std::runtime_error if there was a problem with accessing the file
+ * @throws std::invalid_argument if the file name is empty
+ */
+time_t getMTime(std::string const& fileName);
+
+/**
+ * Set mtime of a file.
+ * @param fileName the name of a file
+ * @param mtime the mtime to be set for the file
+ * @throws std::runtime_error if there was a problem with accessing the file
+ * @throws std::invalid_argument if the file name is empty
+ */
+void setMTime(std::string const& fileName, time_t mtime);
 
 }  // namespace lsst::qserv::replica
 

--- a/src/replica/worker/FileServerConnection.cc
+++ b/src/replica/worker/FileServerConnection.cc
@@ -35,6 +35,7 @@
 #include "replica/config/Configuration.h"
 #include "replica/mysql/DatabaseMySQLUtils.h"
 #include "replica/services/ServiceProvider.h"
+#include "replica/util/FileUtils.h"
 
 // LSST headers
 #include "lsst/log/Log.h"
@@ -199,11 +200,11 @@ void FileServerConnection::_requestReceived(boost::system::error_code const& ec,
                          << ", code: " << to_string(fs_ec.value()) << ", error: " << fs_ec.message());
             break;
         }
-        mtime = fs::last_write_time(file, fs_ec).time_since_epoch().count();
-        if (fs_ec.value() != 0) {
+        try {
+            mtime = replica::getMTime(file.string());
+        } catch (exception const& ex) {
             LOGS(_log, LOG_LVL_ERROR,
-                 context << __func__ << "  failed to get file mtime of: " << file
-                         << ", code: " << to_string(fs_ec.value()) << ", error: " << fs_ec.message());
+                 context << __func__ << "  failed to get file mtime of: " << file << ", ex: " << ex.what());
             break;
         }
 

--- a/src/replica/worker/WorkerFindAllRequest.cc
+++ b/src/replica/worker/WorkerFindAllRequest.cc
@@ -132,12 +132,15 @@ bool WorkerFindAllRequest::execute() {
                                                          ", code: " + to_string(ec.value()) +
                                                          ", error: " + ec.message());
 
-                    time_t const mtime = fs::last_write_time(entry.path(), ec).time_since_epoch().count();
-                    errorContext = errorContext ||
-                                   reportErrorIf(ec.value() != 0, ProtocolStatusExt::FILE_MTIME,
-                                                 "failed to read file mtime: " + entry.path().string() +
-                                                         ", error: " + ec.message());
-
+                    time_t mtime = 0;
+                    try {
+                        mtime = replica::getMTime(entry.path().string());
+                    } catch (exception const& ex) {
+                        errorContext = errorContext ||
+                                       reportErrorIf(true, ProtocolStatusExt::FILE_MTIME,
+                                                     "failed to read file mtime: " + entry.path().string() +
+                                                             ", ex: " + ex.what());
+                    }
                     unsigned const chunk = get<1>(parsed);
                     chunk2fileInfoCollection[chunk].emplace_back(ReplicaInfo::FileInfo({
                             entry.path().filename().string(), size, mtime,

--- a/src/replica/worker/WorkerFindRequest.cc
+++ b/src/replica/worker/WorkerFindRequest.cc
@@ -156,11 +156,15 @@ bool WorkerFindRequest::execute() {
                                    reportErrorIf(ec.value() != 0, ProtocolStatusExt::FILE_SIZE,
                                                  "failed to read file size: " + path.string() + ", code: " +
                                                          to_string(ec.value()) + ", error: " + ec.message());
-                    const time_t mtime = fs::last_write_time(path, ec).time_since_epoch().count();
-                    errorContext = errorContext ||
-                                   reportErrorIf(ec.value() != 0, ProtocolStatusExt::FILE_MTIME,
-                                                 "failed to read file mtime: " + path.string() + ", code: " +
-                                                         to_string(ec.value()) + ", error: " + ec.message());
+                    time_t mtime = 0;
+                    try {
+                        mtime = replica::getMTime(path.string());
+                    } catch (exception const& ex) {
+                        errorContext =
+                                errorContext || reportErrorIf(true, ProtocolStatusExt::FILE_MTIME,
+                                                              "failed to read file mtime: " + path.string() +
+                                                                      ", ex: " + ex.what());
+                    }
                     fileInfoCollection.emplace_back(ReplicaInfo::FileInfo({
                             file, size, mtime, "", /* cs */
                             0,                     /* beginTransferTime */
@@ -209,11 +213,15 @@ bool WorkerFindRequest::execute() {
             for (auto&& file : fileNames) {
                 const fs::path path(file);
                 uint64_t const size = _csComputeEnginePtr->bytes(file);
-                time_t const mtime = fs::last_write_time(path, ec).time_since_epoch().count();
-                errorContext = errorContext || reportErrorIf(ec.value() != 0, ProtocolStatusExt::FILE_MTIME,
-                                                             "failed to read file mtime: " + path.string() +
-                                                                     ", code: " + to_string(ec.value()) +
-                                                                     ", error: " + ec.message());
+                time_t mtime = 0;
+                try {
+                    mtime = replica::getMTime(path.string());
+                } catch (exception const& ex) {
+                    errorContext =
+                            errorContext || reportErrorIf(true, ProtocolStatusExt::FILE_MTIME,
+                                                          "failed to read file mtime: " + path.string() +
+                                                                  ", ex: " + ex.what());
+                }
                 fileInfoCollection.emplace_back(ReplicaInfo::FileInfo({
                         path.filename().string(), size, mtime, to_string(_csComputeEnginePtr->cs(file)),
                         0,   /* beginTransferTime */

--- a/src/replica/worker/WorkerReplicationRequest.cc
+++ b/src/replica/worker/WorkerReplicationRequest.cc
@@ -449,11 +449,14 @@ bool WorkerReplicationRequest::_finalize(replica::Lock const& lock) {
                 reportErrorIf(ec.value() != 0, ProtocolStatusExt::FILE_RENAME,
                               "failed to rename file: " + tmpFile.string() + " into " + outFile.string() +
                                       ", code: " + to_string(ec.value()) + ", error: " + ec.message());
-        fs::last_write_time(outFile, fs::file_time_type(std::chrono::seconds(_file2descr[file].mtime)), ec);
-        errorContext = errorContext ||
-                       reportErrorIf(ec.value() != 0, ProtocolStatusExt::FILE_MTIME,
-                                     "failed to change 'mtime' of file: " + tmpFile.string() +
-                                             ", code: " + to_string(ec.value()) + ", error: " + ec.message());
+        try {
+            replica::setMTime(outFile.string(), _file2descr[file].mtime);
+        } catch (exception const& ex) {
+            errorContext =
+                    errorContext || reportErrorIf(true, ProtocolStatusExt::FILE_MTIME,
+                                                  "failed to change 'mtime' of file: " + outFile.string() +
+                                                          ", ex: " + ex.what());
+        }
     }
     if (errorContext.failed) {
         setStatus(lock, ProtocolStatus::FAILED, errorContext.extendedStatus);


### PR DESCRIPTION
The bug was maxde when migrating Qserv code from `boost::filesystem` to `std::filesystem`. A problem with the migration path is that an implementation of the new library introduces a new type of clock that has an "Epoch" unrelated to the customary UNIX Epoch. Working with the new library requires writing complex code that would be difficult to comprehend.

Migrated the code to use the straightforward C language implementation instead of the complex API of the `std::filesystem` and std::chrono libraries. Added two simple methods for obtaining and setting values of the files' `mtime`.