### PR TITLE
DM-54599: validateDominantDbs() is called more frequently than seems necessary 

### DIFF
--- a/src/ccontrol/UserQuerySelect.cc
+++ b/src/ccontrol/UserQuerySelect.cc
@@ -33,11 +33,6 @@
  *
  * getRestrictors() -- retrieve restrictors to be passed to spatial region selection code in another layer.
  *
- * validateDominantDbs() -- validate the "dominantDbs", that is, the databases whose
- * partitioning will be used for chunking and dispatch. Note that the dominantDbs are required to have
- * the same striping parameters to allow joins between them, so it is not sufficient to just validate
- * that they are present in the CSS, but they must also have compatible striping parameters.
- *
  * getDbStriping() -- retrieve the striping parameters of the dominantDb.
  *
  * getError() -- See if there are errors
@@ -429,13 +424,7 @@ void UserQuerySelect::saveResultQuery() { _queryMetadata->saveResultQuery(_query
 
 void UserQuerySelect::_setupChunking() {
     LOGS(_log, LOG_LVL_TRACE, "Setup chunking");
-    // Do not throw exceptions here, set _errorExtra .
     std::shared_ptr<qproc::IndexMap> im;
-    if (!_qSession->validateDominantDbs()) {
-        // TODO: Revisit this for L3
-        throw UserQueryError(getQueryIdString() + " Couldn't determine dominantDbs for dispatch");
-    }
-
     std::shared_ptr<IntSet const> eSet = _qSession->getEmptyChunks();
     {
         eSet = _qSession->getEmptyChunks();

--- a/src/qproc/QuerySession.cc
+++ b/src/qproc/QuerySession.cc
@@ -141,6 +141,11 @@ void QuerySession::analyzeQuery(std::string const& sql, std::shared_ptr<query::S
         LOGS(_log, LOG_LVL_TRACE, "Query Plugins applied: " << *this);
         LOGS(_log, LOG_LVL_TRACE, "ORDER BY clause for result query: " << getResultOrderBy());
 
+        // Besides analysing an explicit result of the operation, allow catching CSS exceptions
+        // that may be thrown by the method.
+        if (!_validateDominantDbs()) {
+            _error = "Dominant databases validation failed";
+        }
     } catch (QueryProcessingBug& b) {
         _error = std::string("QuerySession bug:") + b.what();
     } catch (qana::AnalysisError& e) {
@@ -216,7 +221,13 @@ bool QuerySession::containsTable(std::string const& dbName, std::string const& t
     return _context->containsTable(dbName, tableName);
 }
 
-bool QuerySession::validateDominantDbs() const {
+bool QuerySession::_validateDominantDbs() const {
+    if (_skipDominatDbsValidation) {
+        LOGS(_log, LOG_LVL_DEBUG,
+             "QuerySession::" << __func__ << ": Skipping dominant DB validation in unit test");
+        return true;
+    }
+
     if (_context->dominantDbs.empty()) {
         LOGS(_log, LOG_LVL_WARN, "QuerySession::" << __func__ << ": no dominant dbs specified");
         return false;
@@ -245,20 +256,12 @@ bool QuerySession::validateDominantDbs() const {
     return true;
 }
 
-css::StripingParams QuerySession::getDbStriping() const {
-    if (!validateDominantDbs()) {
-        throw std::logic_error("QuerySession::" + std::string(__func__) + ": Invalid dominant databases");
-    }
-    return _context->getDbStriping();
-}
+css::StripingParams QuerySession::getDbStriping() const { return _context->getDbStriping(); }
 
 std::shared_ptr<IntSet const> QuerySession::getEmptyChunks() {
     if (_css == nullptr) {
         LOGS(_log, LOG_LVL_WARN, "QuerySession::" << __func__ << " no _css");
         return nullptr;
-    }
-    if (!validateDominantDbs()) {
-        throw std::logic_error("QuerySession::" + std::string(__func__) + ": Invalid dominant databases");
     }
     std::shared_ptr<IntSet> result = std::make_shared<IntSet>();
     for (auto const& dbName : _context->dominantDbs) {
@@ -298,7 +301,7 @@ void QuerySession::finalize() {
     }
 }
 
-QuerySession::QuerySession(Test& t) : _css(t.css), _defaultDb(t.defaultDb) {
+QuerySession::QuerySession(Test& t) : _css(t.css), _defaultDb(t.defaultDb), _skipDominatDbsValidation(true) {
     sql::SqlConfig sqlConfig(t.sqlConfig);
     _databaseModels = DatabaseModels::create(sqlConfig, sqlConfig);
     _initContext();
@@ -442,10 +445,6 @@ std::ostream& operator<<(std::ostream& out, QuerySession const& querySession) {
 ChunkQuerySpec::Ptr QuerySession::buildChunkQuerySpec(query::QueryTemplate::Vect const& queryTemplates,
                                                       ChunkSpec const& chunkSpec,
                                                       bool fillInChunkIdTag) const {
-    if (!validateDominantDbs()) {
-        throw std::logic_error("QuerySession::" + std::string(__func__) + ": Invalid dominant databases");
-    }
-
     // Any dominant database (if there is more than one) works here. Note that after the previously made
     // validation step, there should be at least one such database, and if there are more than one, then
     // all databases ara guaranteeded to have the same striping parameters. The only role if the database

--- a/src/qproc/QuerySession.h
+++ b/src/qproc/QuerySession.h
@@ -133,17 +133,6 @@ public:
     bool containsTable(std::string const& dbName, std::string const& tableName) const;
 
     /**
-     * Validate that the dominant databases specified in the query context are registered
-     * in CSS and compatible with each other.
-     * @note Dominant databases are the databases that will be used for query
-     *  dispatch. They are distinct from the default database, which is what is
-     *  used for unqualified table and column references.
-     * @return true if the dominant databases are valid, false otherwise. If false is returned,
-     *  details will be logged.
-     */
-    bool validateDominantDbs() const;
-
-    /**
      * Get the striping parameters of any dominant database found in the query.
      * @note That all dominant databases are required to have the same striping parameters, so it does
      *  not matter which one we get the parameters for, as long as it is a dominant database.
@@ -217,6 +206,17 @@ private:
     void _generateConcrete();
     void _applyConcretePlugins();
 
+    /**
+     * Validate that the dominant databases specified in the query context are registered
+     * in CSS and compatible with each other.
+     * @note Dominant databases are the databases that will be used for query
+     *  dispatch. They are distinct from the default database, which is what is
+     *  used for unqualified table and column references.
+     * @return true if the dominant databases are valid, false otherwise. If false is returned,
+     *  details will be logged.
+     */
+    bool _validateDominantDbs() const;
+
     std::vector<std::string> _buildChunkQueries(query::QueryTemplate::Vect const& queryTemplates,
                                                 ChunkSpec const& chunkSpec) const;
     std::shared_ptr<ChunkQuerySpec> _buildFragment(query::QueryTemplate::Vect const& queryTemplates,
@@ -280,6 +280,11 @@ private:
     /// Maximum number of chunks in an interactive query.
     int const _interactiveChunkLimit = 10;  // Value of 10 only used in unit tests.
     bool _scanInteractive = true;           ///< True if the query can be considered interactive.
+
+    /// Whether to validate the dominant databases against CSS. This is set true for unit tests
+    /// that construct QuerySessions without CSS access, and thus can't validate the dominant
+    /// databases, and false for all other use cases.
+    bool const _skipDominatDbsValidation = false;
 };
 
 /**


### PR DESCRIPTION
The PR addresses a design problem of the original implementation. The new implementation:
- Pushed dominant DB validation into the query analysis stage
- Made the validator a private method of the QuerySession class
- Eliminated all other calls to the validator
- Adjusted unit tests to skip the validations since this operation requires non-trivial CSS
