### PR TITLE
DM-54632: Eliminated obsolete code

### DIFF
--- a/src/cconfig/CzarConfig.h
+++ b/src/cconfig/CzarConfig.h
@@ -135,8 +135,6 @@ public:
      */
     int getXrootdCBThreadsInit() const { return _xrootdCBThreadsInit->getVal(); }
 
-    bool getQueryDistributionTestVer() const { return _queryDistributionTestVer->getVal(); }
-
     /*
      * @return A value of the "spread" parameter. This may improve a performance
      * of xrootd for catalogs with the large number of chunks. The default value
@@ -364,8 +362,6 @@ private:
             util::ConfigValTInt::create(_configValMap, "tuning", "xrootdCBThreadsMax", notReq, 500);
     CVTIntPtr _xrootdCBThreadsInit =
             util::ConfigValTInt::create(_configValMap, "tuning", "xrootdCBThreadsInit", notReq, 50);
-    CVTIntPtr _queryDistributionTestVer =
-            util::ConfigValTInt::create(_configValMap, "tuning", "queryDistributionTestVer", notReq, 0);
     CVTBoolPtr _notifyWorkersOnQueryFinish =
             util::ConfigValTBool::create(_configValMap, "tuning", "notifyWorkersOnQueryFinish", notReq, 1);
     CVTBoolPtr _notifyWorkersOnCzarRestart =

--- a/src/ccontrol/UserQuerySelect.cc
+++ b/src/ccontrol/UserQuerySelect.cc
@@ -423,33 +423,26 @@ void UserQuerySelect::_expandSelectStarInMergeStatment(std::shared_ptr<query::Se
 void UserQuerySelect::saveResultQuery() { _queryMetadata->saveResultQuery(_queryId, getResultQuery()); }
 
 void UserQuerySelect::_setupChunking() {
-    LOGS(_log, LOG_LVL_TRACE, "Setup chunking");
-    std::shared_ptr<qproc::IndexMap> im;
-    std::shared_ptr<IntSet const> eSet = _qSession->getEmptyChunks();
-    {
-        eSet = _qSession->getEmptyChunks();
-        if (!eSet) {
-            eSet = std::make_shared<IntSet>();
-            LOGS(_log, LOG_LVL_WARN, "Missing empty chunks info for dominantDbs");
-        }
-    }
-    // FIXME add operator<< for QuerySession
-    LOGS(_log, LOG_LVL_TRACE, "_qSession: " << _qSession);
+    LOGS(_log, LOG_LVL_TRACE, "Setup chunking  _qSession: " << _qSession);
     if (_qSession->hasChunks()) {
         auto areaRestrictors = _qSession->getAreaRestrictors();
         auto secIdxRestrictors = _qSession->getSecIdxRestrictors();
         css::StripingParams partStriping = _qSession->getDbStriping();
-
-        im = std::make_shared<qproc::IndexMap>(partStriping, _secondaryIndex);
+        auto const im = std::make_shared<qproc::IndexMap>(partStriping, _secondaryIndex);
         qproc::ChunkSpecVector csv;
         if (areaRestrictors != nullptr || secIdxRestrictors != nullptr) {
             csv = im->getChunks(areaRestrictors, secIdxRestrictors);
         } else {  // Unrestricted: full-sky
             csv = im->getAllChunks();
         }
-
         LOGS(_log, LOG_LVL_TRACE, "Chunk specs: " << util::printable(csv));
+
         // Filter out empty chunks
+        std::shared_ptr<IntSet const> eSet = _qSession->getEmptyChunks();
+        if (!eSet) {
+            eSet = std::make_shared<IntSet const>();
+            LOGS(_log, LOG_LVL_WARN, "Missing empty chunks info for dominantDbs");
+        }
         for (qproc::ChunkSpecVector::const_iterator i = csv.begin(), e = csv.end(); i != e; ++i) {
             if (eSet->count(i->chunkId) == 0) {  // chunk not in empty?
                 _qSession->addChunk(*i);

--- a/src/czar/Czar.cc
+++ b/src/czar/Czar.cc
@@ -152,7 +152,6 @@ Czar::Czar(string const& configFilePath, string const& czarName)
     int const xrootdSpread = _czarConfig->getXrootdSpread();
     LOGS(_log, LOG_LVL_INFO, "config xrootdSpread=" << xrootdSpread);
     XrdSsiProviderClient->SetSpread(xrootdSpread);
-    _queryDistributionTestVer = _czarConfig->getQueryDistributionTestVer();
 
     LOGS(_log, LOG_LVL_INFO, "Creating czar instance with name " << czarName);
     LOGS(_log, LOG_LVL_INFO, "Czar config: " << *_czarConfig);

--- a/src/czar/Czar.cc
+++ b/src/czar/Czar.cc
@@ -222,13 +222,8 @@ SubmitResult Czar::submitQuery(string const& query, map<string, string> const& h
     }
 
     // make new UserQuery
-    // this is atomic
-    ccontrol::UserQuery::Ptr uq;
-    {
-        lock_guard<mutex> lock(_mutex);
-        uq = _uqFactory->newUserQuery(query, defaultDb, getQdispSharedResources(), userQueryId, msgTableName,
-                                      resultDb);
-    }
+    ccontrol::UserQuery::Ptr const uq = _uqFactory->newUserQuery(query, defaultDb, getQdispSharedResources(),
+                                                                 userQueryId, msgTableName, resultDb);
 
     // Add logging context with query ID
     QSERV_LOGCONTEXT_QUERY(uq->getQueryId());

--- a/src/czar/Czar.h
+++ b/src/czar/Czar.h
@@ -113,10 +113,6 @@ public:
     /// Return a pointer to QdispSharedResources
     qdisp::SharedResources::Ptr getQdispSharedResources() { return _qdispSharedResources; }
 
-    /// @return true if trivial queries should be treated as
-    ///         interactive queries to stress test the czar.
-    bool getQueryDistributionTestVer() { return _queryDistributionTestVer; }
-
     /// @param queryId The unique identifier of the previously submitted user query
     /// @return The reconstructed info for the query
     SubmitResult getQueryInfo(QueryId queryId) const;
@@ -160,8 +156,6 @@ private:
     /// the PsuedoFifo to prevent czar from calling most recent requests,
     /// and any other resources for use by query executives.
     qdisp::SharedResources::Ptr _qdispSharedResources;
-
-    bool _queryDistributionTestVer;  ///< True if config says this is distribution test version.
 
     /// Reloads the log configuration file on log config file change.
     std::shared_ptr<util::FileMonitor> _logFileMonitor;

--- a/src/qana/CMakeLists.txt
+++ b/src/qana/CMakeLists.txt
@@ -31,7 +31,6 @@ FUNCTION(qana_tests)
         target_link_libraries(${TEST} PUBLIC
             cconfig
             ccontrol
-            czar
             parser
             qana
             qdisp

--- a/src/qana/ScanTablePlugin.cc
+++ b/src/qana/ScanTablePlugin.cc
@@ -40,7 +40,6 @@
 #include "lsst/log/Log.h"
 
 // Qserv headers
-#include "czar/Czar.h"
 #include "global/stringTypes.h"
 #include "proto/ScanTableInfo.h"
 #include "query/ColumnRef.h"
@@ -173,18 +172,8 @@ proto::ScanInfo ScanTablePlugin::_findScanTables(query::SelectStmt& stmt, query:
         }
     }
 
-    auto czar = czar::Czar::getCzar();
-    bool queryDistributionTestVer = (czar == nullptr) ? 0 : czar->getQueryDistributionTestVer();
-
     StringPairVector scanTables;
-    // Even trivial queries need to use full table scans to avoid crippling the czar
-    // with heaps of high priority, but very simple queries. Unless there are
-    // factors that greatly restrict how many chunks need to be read, it needs to be
-    // a table scan.
-    // For system testing, it is useful to see how the system handles large numbers
-    // trivial queries as the amount of work done by the workers is minimal. This
-    // highlights the cost of czar-worker communications.
-    if (!queryDistributionTestVer || hasSelectColumnRef) {
+    if (hasSelectColumnRef) {
         if (hasSecondaryKey) {
             LOGS(_log, LOG_LVL_TRACE, "**** Not a scan ****");
             // Not a scan? Leave scanTables alone

--- a/src/qproc/QuerySession.cc
+++ b/src/qproc/QuerySession.cc
@@ -128,7 +128,6 @@ std::shared_ptr<query::SelectStmt> QuerySession::parseQuery(std::string const& s
 void QuerySession::analyzeQuery(std::string const& sql, std::shared_ptr<query::SelectStmt> const& stmt) {
     _original = sql;
     _stmt = stmt;
-    _isFinal = false;
     _initContext();
     assert(_context.get());
 
@@ -288,9 +287,6 @@ std::shared_ptr<query::SelectStmt> QuerySession::getMergeStmt() const {
 }
 
 void QuerySession::finalize() {
-    if (_isFinal) {
-        return;
-    }
     QueryPluginPtrVector::iterator i;
     for (i = _plugins->begin(); i != _plugins->end(); ++i) {
         (**i).applyFinal(*_context);

--- a/src/qproc/QuerySession.h
+++ b/src/qproc/QuerySession.h
@@ -272,7 +272,6 @@ private:
     std::string _tmpTable;
     std::string _resultTable;
     std::string _error;
-    int _isFinal = 0;  ///< Has query analysis/optimization completed?
 
     ChunkSpecVector _chunks;                         ///< Chunk coverage
     std::shared_ptr<QueryPluginPtrVector> _plugins;  ///< Analysis plugin chain


### PR DESCRIPTION
There are three commits in this PR:

- Remove `queryDistributionTestVer` from modules `czar` and `cconfig`

  - The code represents an experimental attempt to speed up query dispatch based on feedback from workers. The eliminated code was never finished, nor did it mature into any working prototype.
  - Another problem with the removed code was that it was making the package `qana` directly dependent on the Qserv frontend module `czar`. This was not right from the dependency management standpoint.

- Remove `QuerySession.h:  int _isFinal`

  This member has no actual effect on the query processing

- Remove unnecessary mutex locking from:

  ```
    // make new UserQuery
    // this is atomic
    ccontrol::UserQuery::Ptr uq;
    {
        lock_guard<mutex> lock(_mutex);
        uq = _uqFactory->newUserQuery(query, defaultDb, getQdispSharedResources(), userQueryId, msgTableName,
                                      resultDb);
    }
  ```

  The current query creation code is thread-safe after migrating the CSS database connector to the thread-safe implementation.

A few notes:
- The lock is known not to affect the performance of the `mysql-proxy` frontend due to another lock within the proxy that serializes query submission.
- The lock removal improves the performance of the `http` frontend since it doesn’t have any additional locks
- The ANTL4-based query parser is still the major factor that serializes query submission for the large query texts in both frontends.
