### PR TITLE
DM-54798: The Controller should not terminate the process after failed self-registration

### DIFF
--- a/src/replica/apps/MasterControllerHttpApp.cc
+++ b/src/replica/apps/MasterControllerHttpApp.cc
@@ -371,8 +371,7 @@ void MasterControllerHttpApp::_registryUpdateLoop() {
             json const response = client.readAsJson();
             if (0 == response.at("success").get<int>()) {
                 string const error = response.at("error").get<string>();
-                LOGS(_log, LOG_LVL_ERROR, requestContext + " was denied, error: '" + error + "'.");
-                abort();
+                LOGS(_log, LOG_LVL_WARN, requestContext + " was denied, error: '" + error + "'.");
             }
         } catch (exception const& ex) {
             LOGS(_log, LOG_LVL_WARN, requestContext + " failed, ex: " + ex.what());


### PR DESCRIPTION
The Controller still posts warnings into the log stream upon self-registration failures and makes another registration attempt after the configurable timeout.