### PR TITLE
DM-54822: Helm chart updates

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: "v2"
 type: "application"
 name: "qserv"
 description: "Qserv: a petascale parallel database"
-version: 2026.3.2-pre
-appVersion: "2026.3.2-pre"
+version: 2026.5.2-pre
+appVersion: "2026.5.2-pre"

--- a/deploy/helm/environments/usdf-dev.yaml
+++ b/deploy/helm/environments/usdf-dev.yaml
@@ -1,0 +1,34 @@
+qservImageName: ghcr.io/lsst/qserv:2026.5.1-rc1-40-gd22a65ccb
+mariadbImageName: ghcr.io/lsst/qserv-mariadb:2026.5.1-rc1
+sslProxyImageName: qserv/mysql-proxy-ssl:latest
+ingestHelperImageName: ghcr.io/lsst/qserv-build-base:2026.5.1-rc1-1-gfd3801377
+
+czars:
+  tier: [dev-czar]
+
+workers:
+  replicas: 70
+  tier: [int-worker, prod-worker]
+
+replication:
+  tier: [int-utility]
+
+ingest:
+  enable: true
+  tier: [int-utility]
+
+czarExternalService:
+  enable: true
+  type: LoadBalancer
+  annotations:
+    metallb.io/address-pool: sdf-dmz
+  allocateLoadBalancerNodePorts: false
+  loadBalancerIP: 134.79.23.221
+  loadBalancerSourceRanges:
+    - 35.232.79.62/32
+    - 34.135.212.179/32
+    - 35.225.239.81/32
+    - 34.121.239.92/32
+    - 134.79.0.0/16
+    - 172.16.0.0/12
+    - 172.24.49.51/32

--- a/deploy/helm/environments/usdf-int.yaml
+++ b/deploy/helm/environments/usdf-int.yaml
@@ -1,0 +1,34 @@
+qservImageName: ghcr.io/lsst/qserv:2026.5.1-rc1-40-gd22a65ccb
+mariadbImageName: ghcr.io/lsst/qserv-mariadb:2026.5.1-rc1
+sslProxyImageName: qserv/mysql-proxy-ssl:latest
+ingestHelperImageName: ghcr.io/lsst/qserv-build-base:2026.5.1-rc1-1-gfd3801377
+
+czars:
+  tier: [int-czar]
+
+workers:
+  replicas: 35
+  tier: [int-worker]
+
+replication:
+  tier: [int-utility]
+
+ingest:
+  enable: true
+  tier: [int-utility]
+
+czarExternalService:
+  enable: true
+  type: LoadBalancer
+  annotations:
+    metallb.io/address-pool: sdf-dmz
+  allocateLoadBalancerNodePorts: false
+  loadBalancerIP: 134.79.23.230
+  loadBalancerSourceRanges:
+    - 35.232.79.62/32
+    - 34.135.212.179/32
+    - 35.225.239.81/32
+    - 34.121.239.92/32
+    - 134.79.0.0/16
+    - 172.16.0.0/12
+    - 172.24.49.51/32

--- a/deploy/helm/environments/usdf-prod.yaml
+++ b/deploy/helm/environments/usdf-prod.yaml
@@ -1,0 +1,34 @@
+qservImageName: ghcr.io/lsst/qserv:2026.5.1-rc1-40-gd22a65ccb
+mariadbImageName: ghcr.io/lsst/qserv-mariadb:2026.5.1-rc1
+sslProxyImageName: qserv/mysql-proxy-ssl:latest
+ingestHelperImageName: ghcr.io/lsst/qserv-build-base:2026.5.1-rc1-1-gfd3801377
+
+czars:
+  tier: [prod-czar]
+
+workers:
+  replicas: 35
+  tier: [prod-worker]
+
+replication:
+  tier: [prod-utility]
+
+ingest:
+  enable: true
+  tier: [prod-utility]
+
+czarExternalService:
+  enable: true
+  type: LoadBalancer
+  annotations:
+    metallb.io/address-pool: sdf-dmz
+  allocateLoadBalancerNodePorts: false
+  loadBalancerIP: 134.79.23.229
+  loadBalancerSourceRanges:
+    - 35.232.79.62/32
+    - 34.135.212.179/32
+    - 35.225.239.81/32
+    - 34.121.239.92/32
+    - 134.79.0.0/16
+    - 172.16.0.0/12
+    - 172.24.49.51/32

--- a/deploy/helm/templates/czar-sts.yaml
+++ b/deploy/helm/templates/czar-sts.yaml
@@ -25,7 +25,7 @@ spec:
               - matchExpressions:
                   - key: qserv.lsst.io/tier
                     operator: In
-                    values: [ czar ]
+                    values: [ dev-czar ]
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -48,7 +48,7 @@ spec:
       containers:
         - name: mariadb
           image: {{ .Values.mariadbImageName | quote }}
-          imagePullPolicy: {{ .Values.mariadbimagePullPolicy | quote }}
+          imagePullPolicy: {{ .Values.mariadbImagePullPolicy | quote }}
           ports:
             - name: mysql
               containerPort: 3306

--- a/deploy/helm/templates/czar-sts.yaml
+++ b/deploy/helm/templates/czar-sts.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceName: {{ include "qserv.name" . }}-czar
   replicas: {{ .Values.czars.replicas }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       {{- include "qserv.selectorLabels" . | nindent 6 }}
@@ -18,6 +18,7 @@ spec:
         {{- include "qserv.labels" . | nindent 8 }}
         app.kubernetes.io/component: czar
     spec:
+      {{- if .Values.czars.tier }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -25,7 +26,7 @@ spec:
               - matchExpressions:
                   - key: qserv.lsst.io/tier
                     operator: In
-                    values: [ dev-czar ]
+                    values: {{ .Values.czars.tier | toJson }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -40,6 +41,7 @@ spec:
                     operator: In
                     values: [ czar ]
               topologyKey: kubernetes.io/hostname
+      {{- end }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/helm/templates/ingest-sts.yaml
+++ b/deploy/helm/templates/ingest-sts.yaml
@@ -26,7 +26,7 @@ spec:
               - matchExpressions:
                 - key: qserv.lsst.io/tier
                   operator: In
-                  values: [ utility ]
+                  values: [ int-utility ]
       containers:
         - name: nginx
           image: nginx:latest

--- a/deploy/helm/templates/ingest-sts.yaml
+++ b/deploy/helm/templates/ingest-sts.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   serviceName: {{ include "qserv.name" . }}-ingest
   replicas: 1
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       {{- include "qserv.selectorLabels" . | nindent 6 }}
@@ -19,14 +19,16 @@ spec:
         {{- include "qserv.labels" . | nindent 8 }}
         app.kubernetes.io/component: ingest
     spec:
+      {{- if .Values.ingest.tier }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: qserv.lsst.io/tier
-                  operator: In
-                  values: [ int-utility ]
+                  - key: qserv.lsst.io/tier
+                    operator: In
+                    values: {{ .Values.ingest.tier | toJson }}
+      {{- end }}
       containers:
         - name: nginx
           image: nginx:latest

--- a/deploy/helm/templates/registry-deploy.yaml
+++ b/deploy/helm/templates/registry-deploy.yaml
@@ -29,7 +29,7 @@ spec:
               - matchExpressions:
                   - key: qserv.lsst.io/tier
                     operator: In
-                    values: [ utility ]
+                    values: [ int-utility ]
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/helm/templates/registry-deploy.yaml
+++ b/deploy/helm/templates/registry-deploy.yaml
@@ -57,6 +57,9 @@ spec:
               --auth-key="$(cat /secrets/auth-key)"
               --admin-auth-key="$(cat /secrets/admin-auth-key)"
               --debug
+          resources:
+            requests:
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/deploy/helm/templates/registry-deploy.yaml
+++ b/deploy/helm/templates/registry-deploy.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "qserv.labels" . | nindent 8 }}
         app.kubernetes.io/component: registry
     spec:
+      {{- if .Values.replication.tier }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,7 +30,8 @@ spec:
               - matchExpressions:
                   - key: qserv.lsst.io/tier
                     operator: In
-                    values: [ int-utility ]
+                    values: {{ .Values.replication.tier | toJson }}
+      {{- end }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/helm/templates/repl-sts.yaml
+++ b/deploy/helm/templates/repl-sts.yaml
@@ -110,6 +110,9 @@ spec:
               --qserv-sync-timeout=600
               --controller-ingest-job-monitor-ival-sec=1
               --controller-auto-register-workers=1
+              --xrootd-auto-notify=0
+              --qserv-sync-disable
+              --worker-evict-timeout=1800
               --purge
               --debug
           resources:

--- a/deploy/helm/templates/repl-sts.yaml
+++ b/deploy/helm/templates/repl-sts.yaml
@@ -25,7 +25,7 @@ spec:
               - matchExpressions:
                 - key: qserv.lsst.io/tier
                   operator: In
-                  values: [ utility ]
+                  values: [ int-utility ]
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/helm/templates/repl-sts.yaml
+++ b/deploy/helm/templates/repl-sts.yaml
@@ -112,6 +112,9 @@ spec:
               --controller-auto-register-workers=1
               --purge
               --debug
+          resources:
+            requests:
+              memory: 1Gi
           volumeMounts:
             - name: repl-data
               mountPath: /qserv/data

--- a/deploy/helm/templates/repl-sts.yaml
+++ b/deploy/helm/templates/repl-sts.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceName: {{ include "qserv.name" . }}-repl
   replicas: 1
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       {{- include "qserv.selectorLabels" . | nindent 6 }}
@@ -18,14 +18,16 @@ spec:
         {{- include "qserv.labels" . | nindent 8 }}
         app.kubernetes.io/component: repl
     spec:
+      {{- if .Values.replication.tier }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: qserv.lsst.io/tier
-                  operator: In
-                  values: [ int-utility ]
+                  - key: qserv.lsst.io/tier
+                    operator: In
+                    values: {{ .Values.replication.tier | toJson }}
+      {{- end }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/helm/templates/repl-svc.yaml
+++ b/deploy/helm/templates/repl-svc.yaml
@@ -14,4 +14,5 @@ spec:
     - name: http
       port: 25081
       targetPort: http
+  publishNotReadyAddresses: true
   {{- end }}

--- a/deploy/helm/templates/worker-sts.yaml
+++ b/deploy/helm/templates/worker-sts.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceName: {{ include "qserv.name" . }}-worker
   replicas: {{ .Values.workers.replicas }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       {{- include "qserv.selectorLabels" . | nindent 6 }}
@@ -18,6 +18,7 @@ spec:
         {{- include "qserv.labels" . | nindent 8 }}
         app.kubernetes.io/component: worker
     spec:
+      {{- if .Values.workers.tier }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -25,7 +26,7 @@ spec:
               - matchExpressions:
                   - key: qserv.lsst.io/tier
                     operator: In
-                    values: [ int-worker, prod-worker ]
+                    values: {{ .Values.workers.tier | toJson }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -40,6 +41,7 @@ spec:
                     operator: In
                     values: [ worker ]
               topologyKey: kubernetes.io/hostname
+      {{- end }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/helm/templates/worker-sts.yaml
+++ b/deploy/helm/templates/worker-sts.yaml
@@ -25,7 +25,7 @@ spec:
               - matchExpressions:
                   - key: qserv.lsst.io/tier
                     operator: In
-                    values: [ worker ]
+                    values: [ int-worker, prod-worker ]
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,7 +1,7 @@
-qservImageName: ghcr.io/lsst/qserv:2026.2.2-rc1-48-gbf7de83f1
-mariadbImageName: ghcr.io/lsst/qserv-mariadb:2026.2.2-rc1
+qservImageName: ghcr.io/lsst/qserv:2026.5.1-rc1-40-gd22a65ccb
+mariadbImageName: ghcr.io/lsst/qserv-mariadb:2026.5.1-rc1
 sslProxyImageName: qserv/mysql-proxy-ssl:latest
-ingestHelperImageName: ghcr.io/lsst/qserv-build-base:2026.2.2-rc1-46-gf129c37c1
+ingestHelperImageName: ghcr.io/lsst/qserv-build-base:2026.5.1-rc1-1-gfd3801377
 
 qservImagePullPolicy: IfNotPresent
 mariadbImagePullPolicy: IfNotPresent
@@ -9,42 +9,34 @@ sslProxyImagePullPolicy: IfNotPresent
 ingestHelperPullPolicy: IfNotPresent
 
 mode: full  # full | db-only
+podManagementPolicy: Parallel  # Parallel | OrderedReady
 
 czars:
   replicas: 1
+  # tier: []
   storage:
     class: rubin-qserv-storage
     size: 5Ti
 
 workers:
-  replicas: 72
+  replicas: 5
+  # tier: []
   storage:
     class: rubin-qserv-storage
     size: 10Ti
 
 replication:
+  # tier: []
   storage:
     class: rubin-qserv-storage
     size: 2Ti
 
 ingest:
-  enable: true
+  enable: false
+  # tier: []
   storage:
     class: rubin-qserv-storage
     size: 200Gi
 
 czarExternalService:
-  enable: true
-  type: LoadBalancer
-  annotations:
-    metallb.io/address-pool: sdf-dmz
-  allocateLoadBalancerNodePorts: false
-  loadBalancerIP: 134.79.23.221
-  loadBalancerSourceRanges:
-    - 35.232.79.62/32
-    - 34.135.212.179/32
-    - 35.225.239.81/32
-    - 34.121.239.92/32
-    - 134.79.0.0/16
-    - 172.16.0.0/12
-    - 172.24.49.51/32
+  enable: false


### PR DESCRIPTION
Support `-prod`, `-int`, and `-dev` deployments within one vcluster at USDF, plus misc. other small chart updates.