### PR TITLE
DM-55010: Helm fixes for http-czar

### DIFF
--- a/.code-workspace
+++ b/.code-workspace
@@ -9,7 +9,10 @@
             "**/bin/entrypoint": "python",
             "**/bin/qserv": "python",
             "**/bin/qserv-kraken": "python",
-            "**/bin/qserv-smig": "python"
+            "**/bin/qserv-smig": "python",
+            "**/templates/*.yaml": "helm",
+            "**/templates/**/*.yaml": "helm",
+            "**/templates/*.tpl": "helm"
         },
         "python.analysis.extraPaths": [
             "./python"

--- a/deploy/helm/templates/czar-sts.yaml
+++ b/deploy/helm/templates/czar-sts.yaml
@@ -152,7 +152,7 @@ spec:
               --threads=16
               --worker-ingest-threads=16
               --ssl-cert-file=/certs/czar/tls.crt
-              --ssl-private-key-file=.certs/czar/tls.key
+              --ssl-private-key-file=/certs/czar/tls.key
               --tmp-dir=/qserv/data/ingest
               --verbose
           volumeMounts:

--- a/deploy/helm/templates/czar-svc.yaml
+++ b/deploy/helm/templates/czar-svc.yaml
@@ -6,9 +6,11 @@ metadata:
     {{- include "qserv.labels" . | nindent 4 }}
 spec:
   clusterIP: "None"
+  publishNotReadyAddresses: true
   selector:
     {{- include "qserv.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: czar
+  {{- if (include "qserv.enable" . | fromYaml).replication }}
   ports:
     - name: czar-http
       port: 4048
@@ -16,3 +18,4 @@ spec:
     - name: mysql-proxy-ssl
       port: 4040
       targetPort: mysql-proxy-ssl
+  {{- end }}

--- a/deploy/helm/templates/repl-svc.yaml
+++ b/deploy/helm/templates/repl-svc.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "qserv.labels" . | nindent 4 }}
 spec:
   clusterIP: "None"
+  publishNotReadyAddresses: true
   selector:
     {{- include "qserv.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: repl
@@ -14,5 +15,4 @@ spec:
     - name: http
       port: 25081
       targetPort: http
-  publishNotReadyAddresses: true
   {{- end }}


### PR DESCRIPTION
* Correct bad ssl key file path arg for http-czar
* Add `publishNotReadyAddresses: true` for czar svc
* Reorder keys in svc yamls for consistency
* Clue vscode for syntax awareness in helm charts
