### PR TITLE
Returning async results no longer marks incorrect czarId as an error.

### DIFF
--- a/src/ccontrol/UserQueryAsyncResult.cc
+++ b/src/ccontrol/UserQueryAsyncResult.cc
@@ -77,7 +77,8 @@ void UserQueryAsyncResult::submit() {
     // if there are messages already it means the error was detected, stop right here
     if (_messageStore->messageCount() > 0) {
         LOGS(_log, LOG_LVL_WARN,
-             "UserQueryAsyncResult::submit giving up, messageCount=" << _messageStore->messageCount());
+             "UserQueryAsyncResult::" << __func__
+                                      << " submit giving up, messageCount=" << _messageStore->messageCount());
         return;
     }
 

--- a/src/ccontrol/UserQueryAsyncResult.cc
+++ b/src/ccontrol/UserQueryAsyncResult.cc
@@ -83,11 +83,9 @@ void UserQueryAsyncResult::submit() {
 
     // Presently we cannot return query results that originated from different czar
     if (_qInfo.czarId() != _czarId) {
-        // TODO: tell user which czar was it?
-        std::string message = "Query originated from different czar";
-        LOGS(_log, LOG_LVL_WARN, "UserQueryAsyncResult::submit giving up, message=" << message);
-        _messageStore->addErrorMessage("SYSTEM", message);
-        return;
+        LOGS(_log, LOG_LVL_WARN,
+             "UserQueryAsyncResult::submit Query originated from different czar=" << _qInfo.czarId()
+                                                                                  << " expected=" << _czarId);
     }
 
     // TODO: check user name, does not matter now as we are not keeping tack of users.

--- a/src/ccontrol/UserQuerySelect.cc
+++ b/src/ccontrol/UserQuerySelect.cc
@@ -823,9 +823,8 @@ void UserQuerySelect::_qMetaUpdateStatus(qmeta::QInfo::QStatus qStatus, size_t r
 }
 
 void UserQuerySelect::_qMetaUpdateMessages() {
-    auto msgStore = getMessageStore();
     try {
-        _queryMetadata->addQueryMessages(_queryId, msgStore);
+        _queryMetadata->addQueryMessages(_queryId, _messageStore);
     } catch (qmeta::SqlError const& ex) {
         LOGS(_log, LOG_LVL_ERROR, "UserQuerySelect::_qMetaUpdateMessages failed, ex: " << ex.what());
     }

--- a/src/czar/Czar.cc
+++ b/src/czar/Czar.cc
@@ -335,6 +335,10 @@ SubmitResult Czar::submitQuery(string const& query, map<string, string> const& h
         LOGS(_log, LOG_LVL_DEBUG, "submitting new query");
         uq->submit();
         ccontrol::QueryState qState = uq->join();
+        // TODO: try to get the _messageStore error in the message table.
+        //       See UserQuerySelect::_qMetaUpdateMessages(). That should probably be moveded
+        //       to UserQuery, give everything a default _queryId of -1 or 0 until the value can be
+        //       set properly. Also, should this only be done when a query fails?
         bool querySuccess = (qState == ccontrol::QueryState::SUCCESS);
         try {
             msgTable.unlock(uq, querySuccess);

--- a/src/partition/Chunker.h
+++ b/src/partition/Chunker.h
@@ -62,8 +62,8 @@ public:
     bool overlap = false;
 
     ChunkLocation() = default;
-    ChunkLocation(ChunkLocation const &) = default;
-    ChunkLocation &operator=(ChunkLocation const &) = default;
+    ChunkLocation(ChunkLocation const&) = default;
+    ChunkLocation& operator=(ChunkLocation const&) = default;
 
     ChunkLocation(int32_t chunkId_, int32_t subChunkId_, bool overlap_)
             : chunkId(chunkId_), subChunkId(subChunkId_), overlap(overlap_) {}
@@ -72,7 +72,7 @@ public:
     uint32_t hash() const { return std::hash<uint32_t>{}(static_cast<uint32_t>(chunkId)); }
 
     /// Order chunk locations by chunk ID.
-    bool operator<(ChunkLocation const &loc) const { return chunkId < loc.chunkId; }
+    bool operator<(ChunkLocation const& loc) const { return chunkId < loc.chunkId; }
 };
 
 /// A Chunker locates points according to the following simple partitioning scheme.
@@ -91,7 +91,7 @@ class Chunker {
 public:
     Chunker(double overlap, int32_t numStripes, int32_t numSubStripesPerStripe);
 
-    Chunker(ConfigStore const &config);
+    Chunker(ConfigStore const& config);
 
     ~Chunker();
 
@@ -104,36 +104,36 @@ public:
     SphericalBox const getSubChunkBounds(int32_t chunkId, int32_t subChunkId) const;
 
     /// Find the non-overlap location of the given position.
-    ChunkLocation const locate(std::pair<double, double> const &position) const;
+    ChunkLocation const locate(std::pair<double, double> const& position) const;
 
     /// Append the locations of the given position to the `locations` vector.
     /// If `chunkId` is negative, all locations are appended. Otherwise, only
     /// those in the corresponding chunk are appended.
-    void locate(std::pair<double, double> const &position, int32_t chunkId,
-                std::vector<ChunkLocation> &locations) const;
+    void locate(std::pair<double, double> const& position, int32_t chunkId,
+                std::vector<ChunkLocation>& locations) const;
 
     /// Return the IDs of all chunks overlapping the given box and belonging
     /// to the given node. The target node is specified as an integer in the
     /// range `[0, numNodes)` and a chunk with ID C belongs to the node given
     /// by hash(C) modulo `numNodes`.
-    std::vector<int32_t> const getChunksIn(SphericalBox const &region, uint32_t node,
+    std::vector<int32_t> const getChunksIn(SphericalBox const& region, uint32_t node,
                                            uint32_t numNodes) const;
 
     /// Return the IDs of all chunks overlapping the given box.
-    std::vector<int32_t> const getChunksIn(SphericalBox const &region) const {
+    std::vector<int32_t> const getChunksIn(SphericalBox const& region) const {
         return getChunksIn(region, 0u, 1u);
     }
 
     /// Append IDs for all sub-chunks of `chunkId` to `subChunks`.
-    void getSubChunks(std::vector<int32_t> &subChunks, int32_t chunkId) const;
+    void getSubChunks(std::vector<int32_t>& subChunks, int32_t chunkId) const;
 
     /// Define configuration variables for partitioning.
-    static void defineOptions(boost::program_options::options_description &opts);
+    static void defineOptions(boost::program_options::options_description& opts);
 
 private:
     // Disable copy construction and assignment.
-    Chunker(Chunker const &);
-    Chunker &operator=(Chunker const &);
+    Chunker(Chunker const&);
+    Chunker& operator=(Chunker const&);
 
     void _initialize(double overlap, int32_t numStripes, int32_t numSubStripesPerStripe);
 
@@ -154,7 +154,7 @@ private:
     }
 
     void _upDownOverlap(double lon, int32_t chunkId, int32_t stripe, int32_t subStripe,
-                        std::vector<ChunkLocation> &locations) const;
+                        std::vector<ChunkLocation>& locations) const;
 
     double _overlap;
     double _subStripeHeight;

--- a/src/partition/Csv.cc
+++ b/src/partition/Csv.cc
@@ -76,7 +76,7 @@ Dialect::Dialect(char delimiter, char escape, char quote)
     _validate();
 }
 
-Dialect::Dialect(std::string const &null, char delimiter, char escape, char quote)
+Dialect::Dialect(std::string const& null, char delimiter, char escape, char quote)
         : _null(null),
           _scanLut(new uint8_t[NUM_CHARS]),
           _delimiter(delimiter),
@@ -85,7 +85,7 @@ Dialect::Dialect(std::string const &null, char delimiter, char escape, char quot
     _validate();
 }
 
-Dialect::Dialect(ConfigStore const &config, std::string const &prefix)
+Dialect::Dialect(ConfigStore const& config, std::string const& prefix)
         : _null(), _scanLut(new uint8_t[NUM_CHARS]) {
     _delimiter = config.get<char>(prefix + "delimiter");
     if (config.flag(prefix + "no-quote")) {
@@ -109,7 +109,7 @@ Dialect::Dialect(ConfigStore const &config, std::string const &prefix)
     _validate();
 }
 
-Dialect::Dialect(Dialect const &dialect)
+Dialect::Dialect(Dialect const& dialect)
         : _null(dialect._null),
           _scanLut(new uint8_t[NUM_CHARS]),
           _nullHasSpecial(dialect._nullHasSpecial),
@@ -121,7 +121,7 @@ Dialect::Dialect(Dialect const &dialect)
 
 Dialect::~Dialect() {}
 
-Dialect &Dialect::operator=(Dialect const &dialect) {
+Dialect& Dialect::operator=(Dialect const& dialect) {
     if (this != &dialect) {
         _null = dialect._null;
         _nullHasSpecial = dialect._nullHasSpecial;
@@ -133,7 +133,7 @@ Dialect &Dialect::operator=(Dialect const &dialect) {
     return *this;
 }
 
-size_t Dialect::decode(char *buf, char const *value, size_t size) const {
+size_t Dialect::decode(char* buf, char const* value, size_t size) const {
     if (_quote == '\0' && _escape == '\0') {
         if (size > MAX_FIELD_SIZE) {
             throw std::runtime_error("CSV field value is too long to decode.");
@@ -175,7 +175,7 @@ size_t Dialect::decode(char *buf, char const *value, size_t size) const {
     return j;
 }
 
-size_t Dialect::encode(char *buf, char const *value, size_t size) const {
+size_t Dialect::encode(char* buf, char const* value, size_t size) const {
     if (value == 0) {
         std::memcpy(buf, _null.data(), _null.size());
         return _null.size();
@@ -265,7 +265,7 @@ size_t Dialect::encode(char *buf, char const *value, size_t size) const {
     return j;
 }
 
-void Dialect::defineOptions(po::options_description &opts, std::string const &prefix) {
+void Dialect::defineOptions(po::options_description& opts, std::string const& prefix) {
     opts.add_options()((prefix + "null").c_str(), po::value<std::string>(),
                        "NULL CSV field value string. Leaving this option unspecified "
                        "results in a dialect specific default - if quoting is enabled, "
@@ -287,7 +287,7 @@ void Dialect::defineOptions(po::options_description &opts, std::string const &pr
 // Scan the given string for occurrences of the CR, LF, escape, quote or
 // delimiter characters, and return a bitwise or of the HAS_xxx constants
 // indicating which were found.
-int Dialect::_scan(char const *value, size_t size) const {
+int Dialect::_scan(char const* value, size_t size) const {
     uint8_t flags = 0;
     for (size_t i = 0; i < size; ++i) {
         uint8_t c = static_cast<uint8_t>(value[i]);
@@ -363,9 +363,9 @@ Editor::Field::~Field() {
     }
 }
 
-Editor::Editor(Dialect const &inputDialect, Dialect const &outputDialect,
-               std::vector<std::string> const &inputFieldNames,
-               std::vector<std::string> const &outputFieldNames)
+Editor::Editor(Dialect const& inputDialect, Dialect const& outputDialect,
+               std::vector<std::string> const& inputFieldNames,
+               std::vector<std::string> const& outputFieldNames)
         : _inputDialect(inputDialect),
           _outputDialect(outputDialect),
           _dialectsMatch(_inputDialect == _outputDialect),
@@ -377,7 +377,7 @@ Editor::Editor(Dialect const &inputDialect, Dialect const &outputDialect,
     _initialize(inputFieldNames, outputFieldNames);
 }
 
-Editor::Editor(ConfigStore const &config)
+Editor::Editor(ConfigStore const& config)
         : _inputDialect(config, "in.csv."),
           _outputDialect(config, "out.csv."),
           _dialectsMatch(_inputDialect == _outputDialect),
@@ -403,7 +403,7 @@ Editor::Editor(ConfigStore const &config)
 
 Editor::~Editor() {}
 
-char const *Editor::readRecord(char const *const begin, char const *const end) {
+char const* Editor::readRecord(char const* const begin, char const* const end) {
     if (end <= begin || begin == 0) {
         throw std::runtime_error("Empty or invalid input line.");
     } else if (_numInputFields == 0) {
@@ -414,10 +414,10 @@ char const *Editor::readRecord(char const *const begin, char const *const end) {
     bool quoted = false;
     bool escaped = false;
     bool decode = false;
-    Field *f = _fields.get();
-    Field *fend = f + _numInputFields;
+    Field* f = _fields.get();
+    Field* fend = f + _numInputFields;
     f->inputValue = begin;
-    char const *cur = begin;
+    char const* cur = begin;
     for (; cur < end; ++cur) {
         char const c = *cur;
         if (c == '\n' || c == '\r') {
@@ -505,7 +505,7 @@ char const *Editor::readRecord(char const *const begin, char const *const end) {
     // Set output values for remaining fields to NULL.
     fend = _fields.get() + _numFields;
     for (++f; f != fend; ++f) {
-        std::string const &null = _outputDialect.getNull();
+        std::string const& null = _outputDialect.getNull();
         std::memcpy(f->outputValue, null.data(), null.size());
         f->outputSize = static_cast<uint16_t>(null.size());
         f->flags = 0;
@@ -520,15 +520,15 @@ char const *Editor::readRecord(char const *const begin, char const *const end) {
     return cur;
 }
 
-char *Editor::writeRecord(char *buf) const {
+char* Editor::writeRecord(char* buf) const {
     char decodeBuf[MAX_FIELD_SIZE];
     char encodeBuf[MAX_FIELD_SIZE];
     size_t size = 0;
     char const delimiter = _outputDialect.getDelimiter();
 
     for (int i = 0; i < _numOutputFields; ++i) {
-        Field const &f = _fields[_outputs[i]];
-        char const *val;
+        Field const& f = _fields[_outputs[i]];
+        char const* val;
         size_t sz;
         if (!f.inputValue || (f.flags & Field::EDITED) != 0) {
             // Output values are always encoded in the output dialect.
@@ -576,8 +576,8 @@ std::string const Editor::get(int i, bool decode) const {
     if (i < 0 || i >= _numInputFields) {
         throw std::runtime_error("Invalid input field.");
     }
-    Field const &f = _fields[i];
-    char const *val = f.inputValue;
+    Field const& f = _fields[i];
+    char const* val = f.inputValue;
     size_t sz = f.inputSize;
     if (decode) {
         if (_inputDialect.isNull(val, sz)) {
@@ -594,22 +594,22 @@ bool Editor::setNull(int i) {
     if (i < 0 || i >= _numFields) {
         return false;
     }
-    Field *f = &_fields[i];
+    Field* f = &_fields[i];
     if (!f->outputValue) {
         return false;
     }
-    std::string const &null = _outputDialect.getNull();
+    std::string const& null = _outputDialect.getNull();
     std::memcpy(f->outputValue, null.data(), null.size());
     f->outputSize = static_cast<uint16_t>(null.size());
     f->flags |= Field::EDITED;
     return true;
 }
 
-bool Editor::set(int i, std::string const &val) {
+bool Editor::set(int i, std::string const& val) {
     if (i < 0 || i >= _numFields) {
         return false;
     }
-    Field *f = &_fields[i];
+    Field* f = &_fields[i];
     if (!f->outputValue) {
         return false;
     }
@@ -622,7 +622,7 @@ bool Editor::set(int i, char c) {
     if (i < 0 || i >= _numFields) {
         return false;
     }
-    Field *f = &_fields[i];
+    Field* f = &_fields[i];
     if (!f->outputValue) {
         return false;
     }
@@ -637,7 +637,7 @@ bool Editor::set(int i, char c) {
         if (i < 0 || i >= _numFields) {                                                                     \
             return false;                                                                                   \
         }                                                                                                   \
-        Field *f = &_fields[i];                                                                             \
+        Field* f = &_fields[i];                                                                             \
         if (!f->outputValue) {                                                                              \
             return false;                                                                                   \
         }                                                                                                   \
@@ -668,7 +668,7 @@ IMPLEMENT_SET(double, .17g)
 #undef IMPLEMENT_SET_IMPL
 #undef IMPLEMENT_SET
 
-void Editor::defineOptions(po::options_description &opts) {
+void Editor::defineOptions(po::options_description& opts) {
     po::options_description in("\\___________ Input CSV format", 80);
     Dialect::defineOptions(in, "in.csv.");
     in.add_options()("in.csv.field", po::value<std::vector<std::string>>(),
@@ -688,38 +688,38 @@ void Editor::defineOptions(po::options_description &opts) {
     opts.add(in).add(out);
 }
 
-void Editor::_initialize(std::vector<std::string> const &inputFieldNames,
-                         std::vector<std::string> const &outputFieldNames) {
+void Editor::_initialize(std::vector<std::string> const& inputFieldNames,
+                         std::vector<std::string> const& outputFieldNames) {
     typedef std::pair<FieldMap::iterator, bool> Mapping;
 
     int i = 0;  // total number of fields
     for (; i < _numInputFields; ++i) {
-        std::string const &name = inputFieldNames[i];
+        std::string const& name = inputFieldNames[i];
         Mapping m = _fieldMap.insert(std::pair<std::string, int>(name, i));
         if (!m.second) {
             throw std::runtime_error(
                     "The input CSV field name list contains "
                     "duplicates.");
         }
-        Field *f = &_fields[i];
+        Field* f = &_fields[i];
         // Before the first readRecord() call, assign NULL to all input
         // fields.
-        std::string const &null = _inputDialect.getNull();
+        std::string const& null = _inputDialect.getNull();
         f->inputValue = null.data();
         f->inputSize = static_cast<uint16_t>(null.size());
     }
     for (int j = 0; j < _numOutputFields; ++j) {
-        std::string const &name = outputFieldNames[j];
+        std::string const& name = outputFieldNames[j];
         Mapping m = _fieldMap.insert(std::pair<std::string, int>(name, i));
         if (m.second) {
             // The output field name does not match any input field. Create
             // a new output field and assign NULL to the output value.
-            Field *f = &_fields[i];
-            f->outputValue = static_cast<char *>(std::malloc(MAX_FIELD_SIZE));
+            Field* f = &_fields[i];
+            f->outputValue = static_cast<char*>(std::malloc(MAX_FIELD_SIZE));
             if (!f->outputValue) {
                 throw std::bad_alloc();
             }
-            std::string const &null = _outputDialect.getNull();
+            std::string const& null = _outputDialect.getNull();
             std::memcpy(f->outputValue, null.data(), null.size());
             f->outputSize = static_cast<uint16_t>(null.size());
             _outputs[j] = i++;
@@ -727,11 +727,11 @@ void Editor::_initialize(std::vector<std::string> const &inputFieldNames,
             // The output field name matched an existing field -
             // make sure space is available for an output value.
             int k = m.first->second;
-            Field *f = &_fields[k];
+            Field* f = &_fields[k];
             if (!f->outputValue) {
                 // f is also an input field, so there is no need
                 // to set an output value here.
-                f->outputValue = static_cast<char *>(std::malloc(MAX_FIELD_SIZE));
+                f->outputValue = static_cast<char*>(std::malloc(MAX_FIELD_SIZE));
                 if (!f->outputValue) {
                     throw std::bad_alloc();
                 }
@@ -748,8 +748,8 @@ bool Editor::_get<bool>(int i) const {
     if (i < 0 || i >= _numInputFields) {
         throw std::runtime_error("Invalid input field");
     }
-    Field const &f = _fields[i];
-    char const *val = f.inputValue;
+    Field const& f = _fields[i];
+    char const* val = f.inputValue;
     size_t sz = f.inputSize;
     if (_inputDialect.isNull(val, sz)) {
         throw std::runtime_error("Input field value is NULL.");
@@ -760,7 +760,7 @@ bool Editor::_get<bool>(int i) const {
         val = buf;
     }
     // Trim leading and trailing whitespace.
-    char const *end = val + sz;
+    char const* end = val + sz;
     for (; val < end && isspace(*val); ++val) {
     }
     for (; end > val && isspace(end[-1]); --end) {
@@ -786,8 +786,8 @@ char Editor::_get<char>(int i) const {
     if (i < 0 || i >= _numInputFields) {
         throw std::runtime_error("Invalid input field");
     }
-    Field const &f = _fields[i];
-    char const *val = f.inputValue;
+    Field const& f = _fields[i];
+    char const* val = f.inputValue;
     size_t sz = f.inputSize;
     if (_inputDialect.isNull(val, sz)) {
         throw std::runtime_error("Input field value is NULL.");
@@ -810,12 +810,12 @@ char Editor::_get<char>(int i) const {
 // converted. This can lead to crashes or incorrect results. For example,
 // consider what happens when the field delimiter is a digit.
 
-Editor::CharConstPtrPair const Editor::_getFieldText(int i, char *buf) const {
+Editor::CharConstPtrPair const Editor::_getFieldText(int i, char* buf) const {
     if (i < 0 || i >= _numInputFields) {
         throw std::runtime_error("Invalid input field");
     }
-    Field const &f = _fields[i];
-    char const *val = f.inputValue;
+    Field const& f = _fields[i];
+    char const* val = f.inputValue;
     size_t sz = f.inputSize;
     if (_inputDialect.isNull(val, sz)) {
         throw std::runtime_error("Input field value is NULL.");
@@ -825,7 +825,7 @@ Editor::CharConstPtrPair const Editor::_getFieldText(int i, char *buf) const {
         val = buf;
         buf[sz] = '\0';
     }
-    char const *end = val + sz;
+    char const* end = val + sz;
     for (; val < end && isspace(*val); ++val) {
     }
     for (; end > val && isspace(end[-1]); --end) {
@@ -848,7 +848,7 @@ Editor::CharConstPtrPair const Editor::_getFieldText(int i, char *buf) const {
     U Editor::_get<U>(int i) const {                                             \
         char buf[MAX_FIELD_SIZE + 1];                                            \
         CharConstPtrPair f = _getFieldText(i, buf);                              \
-        char *e = 0;                                                             \
+        char* e = 0;                                                             \
         errno = 0;                                                               \
         V v = strto##suffix(f.first, &e, 10);                                    \
         if (e != f.second) {                                                     \
@@ -865,7 +865,7 @@ Editor::CharConstPtrPair const Editor::_getFieldText(int i, char *buf) const {
     U Editor::_get<U>(int i) const {                                             \
         char buf[MAX_FIELD_SIZE + 1];                                            \
         CharConstPtrPair f = _getFieldText(i, buf);                              \
-        char *e = 0;                                                             \
+        char* e = 0;                                                             \
         U u = strto##suffix(f.first, &e);                                        \
         if (e != f.second) {                                                     \
             throw std::runtime_error("Cannot convert field value to a C++ " #U); \

--- a/src/partition/Csv.h
+++ b/src/partition/Csv.h
@@ -96,7 +96,7 @@ public:
     /// Create a dialect with an explicit NULL string.
     /// To disable quoting, specify '\0' as the quote character. To disable
     /// escaping, specify '\0' as the escape character.
-    Dialect(std::string const &null, char delimiter, char escape, char quote);
+    Dialect(std::string const& null, char delimiter, char escape, char quote);
 
     /// Create a dialect. The NULL string is set to "NULL" if quoting
     /// is enabled, "\N" if escaping enabled, and "" otherwise. To disable
@@ -107,35 +107,35 @@ public:
     /// Build a dialect from configuration variables with names given by the
     /// concatenation of prefix and "null", "delimiter", "escape",
     /// "no-escape", "quote" and "no-quote".
-    Dialect(ConfigStore const &config, std::string const &prefix);
+    Dialect(ConfigStore const& config, std::string const& prefix);
 
-    Dialect(Dialect const &dialect);
+    Dialect(Dialect const& dialect);
 
     ~Dialect();
 
-    Dialect &operator=(Dialect const &dialect);
+    Dialect& operator=(Dialect const& dialect);
 
-    std::string const &getNull() const { return _null; }
+    std::string const& getNull() const { return _null; }
 
     char getDelimiter() const { return _delimiter; }
     char getEscape() const { return _escape; }
     char getQuote() const { return _quote; }
 
-    bool operator==(Dialect const &d) const {
+    bool operator==(Dialect const& d) const {
         return _null == d._null && _delimiter == d._delimiter && _escape == d._escape && _quote == d._quote;
     }
 
     /// Is the encoded field value identical to the NULL string?
-    bool isNull(char const *value, size_t size) const {
+    bool isNull(char const* value, size_t size) const {
         return _null.compare(0, _null.size(), value, size) == 0;
     }
     /// Decode a value encoded in this dialect into `buf` and return the
     /// number of characters written. No more than MAX_FIELD_SIZE characters
     /// are written - if more are required an exception is thrown. Leading
     /// and trailing whitespace is preserved.
-    size_t decode(char *buf, char const *value, size_t size) const;
+    size_t decode(char* buf, char const* value, size_t size) const;
     /// Decode a field encoded in this dialect.
-    std::string const decode(char const *value, size_t size) const {
+    std::string const decode(char const* value, size_t size) const {
         char buf[MAX_FIELD_SIZE];
         size = decode(buf, value, size);
         return std::string(buf, size);
@@ -144,16 +144,16 @@ public:
     /// Encode a field according to this dialect into `buf` and return the
     /// number of characters written. No more than MAX_FIELD_SIZE characters
     /// are written - if more are required an exception is thrown.
-    size_t encode(char *buf, char const *value, size_t size) const;
+    size_t encode(char* buf, char const* value, size_t size) const;
     /// Encode a value in this dialect.
-    std::string const encode(char const *value, size_t size) const {
+    std::string const encode(char const* value, size_t size) const {
         char buf[MAX_FIELD_SIZE];
         size = encode(buf, value, size);
         return std::string(buf, size);
     }
 
     /// Define configuration variables for specifying a dialect.
-    static void defineOptions(boost::program_options::options_description &opts, std::string const &prefix);
+    static void defineOptions(boost::program_options::options_description& opts, std::string const& prefix);
 
 private:
     static size_t const NUM_CHARS = 256;  // Number of distinct character values.
@@ -162,7 +162,7 @@ private:
 
     enum { HAS_CRLF = 0x1, HAS_DELIM = 0x2, HAS_QUOTE = 0x4, HAS_ESCAPE = 0x8 };
 
-    int _scan(char const *value, size_t size) const;
+    int _scan(char const* value, size_t size) const;
     void _validate();
 
     std::string _null;
@@ -206,10 +206,10 @@ private:
 /// drop CSV fields, while simultaneously performing CSV format conversion.
 class Editor {
 public:
-    Editor(Dialect const &inputDialect, Dialect const &outputDialect,
-           std::vector<std::string> const &inputFieldNames, std::vector<std::string> const &outputFieldNames);
+    Editor(Dialect const& inputDialect, Dialect const& outputDialect,
+           std::vector<std::string> const& inputFieldNames, std::vector<std::string> const& outputFieldNames);
 
-    Editor(ConfigStore const &config);
+    Editor(ConfigStore const& config);
 
     ~Editor();
 
@@ -220,24 +220,24 @@ public:
     /// input line must remain live until the next call to `readRecord()`
     /// or editor destruction, whichever comes first. Raw input is never
     /// modified.
-    char const *readRecord(char const *begin, char const *end);
+    char const* readRecord(char const* begin, char const* end);
 
     /// Write the combination of the current input fields and any edits
     /// performed to `buf`, returning a pointer to the character following the
     /// last character written. At most `MAX_LINE_SIZE` bytes are written -
     /// if the output record is longer, an exception is thrown.
-    char *writeRecord(char *buf) const;
+    char* writeRecord(char* buf) const;
 
     // -- Metadata ----
 
-    Dialect const &getInputDialect() const { return _inputDialect; }
-    Dialect const &getOutputDialect() const { return _outputDialect; }
+    Dialect const& getInputDialect() const { return _inputDialect; }
+    Dialect const& getOutputDialect() const { return _outputDialect; }
 
     /// Return the number of input fields `readRecord()` expects to find in
     /// a line of text.
     int getNumInputFields() const { return _numInputFields; }
     /// Return an index for the named field or -1 if no such field exists.
-    int getFieldIndex(std::string const &name) const {
+    int getFieldIndex(std::string const& name) const {
         FieldMap::const_iterator i = _fieldMap.find(name);
         return i == _fieldMap.end() ? -1 : i->second;
     }
@@ -245,7 +245,7 @@ public:
     ///@{
     /// Is the given field an input field?
     bool isInputField(int i) const { return i >= 0 && i < _numInputFields; }
-    bool isInputField(std::string const &name) const { return isInputField(getFieldIndex(name)); }
+    bool isInputField(std::string const& name) const { return isInputField(getFieldIndex(name)); }
     ///@}
 
     // -- Field access ----
@@ -258,17 +258,17 @@ public:
         if (i < 0 || i >= _numInputFields) {
             return true;
         }
-        Field const &f = _fields[i];
+        Field const& f = _fields[i];
         return _inputDialect.isNull(f.inputValue, f.inputSize);
     }
-    bool isNull(std::string const &name) const { return isNull(getFieldIndex(name)); }
+    bool isNull(std::string const& name) const { return isNull(getFieldIndex(name)); }
     ///@}
 
     ///@{
     /// Return the value of an input field value as a string. The decode flag
     /// controls whether the encoded value is decoded prior to return.
     std::string const get(int i, bool decode) const;
-    std::string const get(std::string const &name, bool decode) const {
+    std::string const get(std::string const& name, bool decode) const {
         return get(getFieldIndex(name), decode);
     }
     ///@}
@@ -281,7 +281,7 @@ public:
         return _get<T>(i);
     }
     template <typename T>
-    T get(std::string const &name) const {
+    T get(std::string const& name) const {
         return get<T>(getFieldIndex(name));
     }
     ///@}
@@ -292,13 +292,13 @@ public:
     /// Set the value of an output field to NULL. Return true if the field was
     /// set, and false if it is not an output field and cannot be modified.
     bool setNull(int i);
-    bool setNull(std::string const &name) { return setNull(getFieldIndex(name)); }
+    bool setNull(std::string const& name) { return setNull(getFieldIndex(name)); }
     ///@}
 
     ///@{
     /// Set the value of an output field. Return true if the field was set,
     /// and false if it is not an output field and cannot be modified.
-    bool set(int i, std::string const &value);
+    bool set(int i, std::string const& value);
     bool set(int i, bool value) { return set(i, value ? '\1' : '\0'); }
     bool set(int i, char value);
     bool set(int i, int value);
@@ -311,28 +311,28 @@ public:
     bool set(int i, double value);
 
     template <typename T>
-    bool set(std::string const &name, T value) {
+    bool set(std::string const& name, T value) {
         return set(getFieldIndex(name), value);
     }
     ///@}
 
     /// Define configuration variables for CSV editing.
-    static void defineOptions(boost::program_options::options_description &opts);
+    static void defineOptions(boost::program_options::options_description& opts);
 
 private:
     // Disable copy construction and assignment.
-    Editor(Editor const &);
-    Editor &operator=(Editor const &);
+    Editor(Editor const&);
+    Editor& operator=(Editor const&);
 
-    typedef std::pair<char const *, char const *> CharConstPtrPair;
+    typedef std::pair<char const*, char const*> CharConstPtrPair;
     typedef boost::unordered_map<std::string, int> FieldMap;
 
     struct Field {
         static uint16_t const DECODE = 0x01;
         static uint16_t const EDITED = 0x02;
 
-        char const *inputValue;
-        char *outputValue;
+        char const* inputValue;
+        char* outputValue;
         uint16_t inputSize;
         uint16_t outputSize;
         uint16_t flags;
@@ -341,9 +341,9 @@ private:
         ~Field();
     };
 
-    void _initialize(std::vector<std::string> const &inputFieldNames,
-                     std::vector<std::string> const &outputFieldNames);
-    CharConstPtrPair const _getFieldText(int i, char *buf) const;
+    void _initialize(std::vector<std::string> const& inputFieldNames,
+                     std::vector<std::string> const& outputFieldNames);
+    CharConstPtrPair const _getFieldText(int i, char* buf) const;
     template <typename T>
     T _get(int i) const;
 

--- a/src/partition/FileUtils.cc
+++ b/src/partition/FileUtils.cc
@@ -46,7 +46,7 @@ namespace fs = boost::filesystem;
 
 namespace lsst::partition {
 
-InputFile::InputFile(fs::path const &path) : _path(path), _fd(-1), _sz(-1) {
+InputFile::InputFile(fs::path const& path) : _path(path), _fd(-1), _sz(-1) {
     struct ::stat st;
     int fd = ::open(path.string().c_str(), O_RDONLY);
     if (fd == -1) {
@@ -72,8 +72,8 @@ InputFile::~InputFile() {
     }
 }
 
-void InputFile::read(void *buf, off_t off, size_t sz) const {
-    uint8_t *cur = static_cast<uint8_t *>(buf);
+void InputFile::read(void* buf, off_t off, size_t sz) const {
+    uint8_t* cur = static_cast<uint8_t*>(buf);
     while (sz > 0) {
         ssize_t n = ::pread(_fd, cur, sz, off);
         if (n == 0) {
@@ -91,12 +91,12 @@ void InputFile::read(void *buf, off_t off, size_t sz) const {
     }
 }
 
-void InputFile::read(void *buf, off_t off, size_t sz, int & /*bufferSize*/,
-                     ConfigParamArrow const & /*params*/) const {
+void InputFile::read(void* buf, off_t off, size_t sz, int& /*bufferSize*/,
+                     ConfigParamArrow const& /*params*/) const {
     read(buf, off, sz);
 }
 
-InputFileArrow::InputFileArrow(fs::path const &path, off_t blockSize)
+InputFileArrow::InputFileArrow(fs::path const& path, off_t blockSize)
         : InputFile(path), _path(path), _fd(-1), _sz(-1) {
     struct ::stat st;
 
@@ -131,9 +131,9 @@ InputFileArrow::~InputFileArrow() {
 
 int InputFileArrow::getBatchNumber() const { return _batchReader->getTotalBatchNumber(); }
 
-void InputFileArrow::read(void *buf, off_t off, size_t sz, int &csvBufferSize,
-                          ConfigParamArrow const &params) const {
-    uint8_t *cur = static_cast<uint8_t *>(buf);
+void InputFileArrow::read(void* buf, off_t off, size_t sz, int& csvBufferSize,
+                          ConfigParamArrow const& params) const {
+    uint8_t* cur = static_cast<uint8_t*>(buf);
 
     auto const success =
             _batchReader->readNextBatch_Table2CSV(cur, csvBufferSize, params.columns, params.optionalColumns,
@@ -151,7 +151,7 @@ void InputFileArrow::read(void *buf, off_t off, size_t sz, int &csvBufferSize,
     }
 }
 
-OutputFile::OutputFile(fs::path const &path, bool truncate) : _path(path), _fd(-1) {
+OutputFile::OutputFile(fs::path const& path, bool truncate) : _path(path), _fd(-1) {
     int flags = O_CREAT | O_WRONLY;
     if (truncate) {
         flags |= O_TRUNC;
@@ -182,11 +182,11 @@ OutputFile::~OutputFile() {
     }
 }
 
-void OutputFile::append(void const *buf, size_t sz) {
+void OutputFile::append(void const* buf, size_t sz) {
     if (!buf || sz == 0) {
         return;
     }
-    char const *b = static_cast<char const *>(buf);
+    char const* b = static_cast<char const*>(buf);
     while (sz > 0) {
         ssize_t n = ::write(_fd, b, sz);
         if (n < 0) {
@@ -212,13 +212,13 @@ BufferedAppender::~BufferedAppender() {
     _cur = 0;
 }
 
-void BufferedAppender::append(void const *buf, size_t size) {
+void BufferedAppender::append(void const* buf, size_t size) {
     if (!_file) {
         throw std::logic_error(
                 std::string("BufferedAppender: append() called after "
                             "close() and/or before open().\n"));
     }
-    uint8_t const *b = static_cast<uint8_t const *>(buf);
+    uint8_t const* b = static_cast<uint8_t const*>(buf);
     while (size > 0) {
         size_t n = std::min(size, static_cast<size_t>(_end - _cur));
         ::memcpy(_cur, b, n);
@@ -232,13 +232,13 @@ void BufferedAppender::append(void const *buf, size_t size) {
     }
 }
 
-void BufferedAppender::open(fs::path const &path, bool truncate) {
+void BufferedAppender::open(fs::path const& path, bool truncate) {
     close();
-    OutputFile *f = new OutputFile(path, truncate);
+    OutputFile* f = new OutputFile(path, truncate);
     if (!_buf) {
         // Allocate buffer.
         size_t sz = static_cast<size_t>(_end - _buf);
-        uint8_t *buf = static_cast<uint8_t *>(malloc(sz));
+        uint8_t* buf = static_cast<uint8_t*>(malloc(sz));
         if (!buf) {
             delete f;
             throw std::bad_alloc();

--- a/src/partition/FileUtils.h
+++ b/src/partition/FileUtils.h
@@ -50,8 +50,8 @@ struct ConfigParamArrow {
     std::string str_escape;
     bool quote = false;
 
-    ConfigParamArrow(std::vector<std::string> const &columns, std::set<std::string> const &optionalColumns,
-                     std::string const &vnull, std::string const &vdelimiter, std::string const &vescape,
+    ConfigParamArrow(std::vector<std::string> const& columns, std::set<std::string> const& optionalColumns,
+                     std::string const& vnull, std::string const& vdelimiter, std::string const& vescape,
                      bool vquote)
             : columns(columns),
               optionalColumns(optionalColumns),
@@ -61,8 +61,8 @@ struct ConfigParamArrow {
               quote(vquote) {}
 
     ConfigParamArrow() = default;
-    ConfigParamArrow(const ConfigParamArrow &v) = default;
-    ConfigParamArrow &operator=(const ConfigParamArrow &) = delete;
+    ConfigParamArrow(const ConfigParamArrow& v) = default;
+    ConfigParamArrow& operator=(const ConfigParamArrow&) = delete;
 };
 
 typedef struct ConfigParamArrow ConfigParamArrow;
@@ -70,25 +70,25 @@ typedef struct ConfigParamArrow ConfigParamArrow;
 /// An input file. Safe for use from multiple threads.
 class InputFile {
 public:
-    explicit InputFile(boost::filesystem::path const &path);
+    explicit InputFile(boost::filesystem::path const& path);
     virtual ~InputFile();
 
     // Disable copy construction and assignment.
-    InputFile(InputFile const &) = delete;
-    InputFile &operator=(InputFile const &) = delete;
+    InputFile(InputFile const&) = delete;
+    InputFile& operator=(InputFile const&) = delete;
 
     /// Return the size of the input file.
     off_t size() const { return _sz; }
 
     /// Return the path of the input file.
-    boost::filesystem::path const &path() const { return _path; }
+    boost::filesystem::path const& path() const { return _path; }
 
     // Needed in derived class InputFileArrow
     virtual int getBatchNumber() const { return -1; }
 
     /// Read a range of bytes into `buf`.
-    void read(void *buf, off_t off, size_t sz) const;
-    virtual void read(void *buf, off_t off, size_t sz, int &bufferSize, ConfigParamArrow const &params) const;
+    void read(void* buf, off_t off, size_t sz) const;
+    virtual void read(void* buf, off_t off, size_t sz, int& bufferSize, ConfigParamArrow const& params) const;
 
 private:
     mutable char _msg[1024];
@@ -100,18 +100,18 @@ private:
 
 class InputFileArrow : public InputFile {
 public:
-    InputFileArrow(boost::filesystem::path const &path, off_t blockSize);
+    InputFileArrow(boost::filesystem::path const& path, off_t blockSize);
     virtual ~InputFileArrow();
 
     // Disable copy construction and assignment.
-    InputFileArrow(InputFileArrow const &) = delete;
-    InputFileArrow &operator=(InputFileArrow const &) = delete;
+    InputFileArrow(InputFileArrow const&) = delete;
+    InputFileArrow& operator=(InputFileArrow const&) = delete;
 
     virtual int getBatchNumber() const override;
 
     /// Read a range of bytes into `buf`.
-    virtual void read(void *buf, off_t off, size_t sz, int &bufferSize,
-                      ConfigParamArrow const &params) const override;
+    virtual void read(void* buf, off_t off, size_t sz, int& bufferSize,
+                      ConfigParamArrow const& params) const override;
 
 private:
     mutable char _msg[1024];
@@ -130,18 +130,18 @@ public:
     /// Open the given file for writing, creating it if necessary.
     /// Setting `truncate` to true will cause the file to be overwritten
     /// if it already exists.
-    OutputFile(boost::filesystem::path const &path, bool truncate);
+    OutputFile(boost::filesystem::path const& path, bool truncate);
     ~OutputFile();
 
     // Disable copy construction and assignment.
-    OutputFile(OutputFile const &) = delete;
-    OutputFile &operator=(OutputFile const &) = delete;
+    OutputFile(OutputFile const&) = delete;
+    OutputFile& operator=(OutputFile const&) = delete;
 
     /// Return the path of the output file.
-    boost::filesystem::path const &path() const { return _path; }
+    boost::filesystem::path const& path() const { return _path; }
 
     /// Append `size` bytes from `buf` to the file.
-    void append(void const *buf, size_t size);
+    void append(void const* buf, size_t size);
 
 private:
     mutable char _msg[1024];
@@ -159,33 +159,33 @@ public:
     ~BufferedAppender();
 
     /// Append `size` bytes from `buf` to the currently open file.
-    void append(void const *buf, size_t size);
+    void append(void const* buf, size_t size);
 
     /// Is there a currently open file? If not, calling `append()` is forbidden.
     bool isOpen() const { return _file != 0; }
 
     /// Close the currently open file and open a new one.
-    void open(boost::filesystem::path const &path, bool truncate);
+    void open(boost::filesystem::path const& path, bool truncate);
 
     /// Write any buffered data to the currently open file and close it.
     void close();
 
 private:
     // Disable copy-construction and assignment.
-    BufferedAppender(BufferedAppender const &);
-    BufferedAppender &operator=(BufferedAppender const &);
+    BufferedAppender(BufferedAppender const&);
+    BufferedAppender& operator=(BufferedAppender const&);
 
-    uint8_t *_buf;
-    uint8_t *_end;
-    uint8_t *_cur;
-    OutputFile *_file;
+    uint8_t* _buf;
+    uint8_t* _end;
+    uint8_t* _cur;
+    OutputFile* _file;
 };
 
 // TODO(smm): the functions below should be moved to their own header.
 
 /// Encode a 32 bit integer as a little-endian sequence of 4 bytes. Return
 /// `buf + 4`.
-inline uint8_t *encode(uint8_t *buf, uint32_t x) {
+inline uint8_t* encode(uint8_t* buf, uint32_t x) {
     buf[0] = static_cast<uint8_t>(x & 0xff);
     buf[1] = static_cast<uint8_t>((x >> 8) & 0xff);
     buf[2] = static_cast<uint8_t>((x >> 16) & 0xff);
@@ -194,7 +194,7 @@ inline uint8_t *encode(uint8_t *buf, uint32_t x) {
 }
 /// Encode a 64 bit integer as a little-endian sequence of 8 bytes. Return
 /// `buf + 8`.
-inline uint8_t *encode(uint8_t *buf, uint64_t x) {
+inline uint8_t* encode(uint8_t* buf, uint64_t x) {
     buf[0] = static_cast<uint8_t>(x & 0xff);
     buf[1] = static_cast<uint8_t>((x >> 8) & 0xff);
     buf[2] = static_cast<uint8_t>((x >> 16) & 0xff);
@@ -207,18 +207,18 @@ inline uint8_t *encode(uint8_t *buf, uint64_t x) {
 }
 
 template <typename T>
-inline T decode(uint8_t const *) {
+inline T decode(uint8_t const*) {
     BOOST_STATIC_ASSERT(sizeof(T) == 0);
 }
 /// Decode a little-endian sequence of 4 bytes to a 32-bit integer.
 template <>
-inline uint32_t decode<uint32_t>(uint8_t const *buf) {
+inline uint32_t decode<uint32_t>(uint8_t const* buf) {
     return static_cast<uint32_t>(buf[0]) | (static_cast<uint32_t>(buf[1]) << 8) |
            (static_cast<uint32_t>(buf[2]) << 16) | (static_cast<uint32_t>(buf[3]) << 24);
 }
 /// Decode a little-endian sequence of 8 bytes to a 64-bit integer.
 template <>
-inline uint64_t decode<uint64_t>(uint8_t const *buf) {
+inline uint64_t decode<uint64_t>(uint8_t const* buf) {
     return static_cast<uint64_t>(buf[0]) | (static_cast<uint64_t>(buf[1]) << 8) |
            (static_cast<uint64_t>(buf[2]) << 16) | (static_cast<uint64_t>(buf[3]) << 24) |
            (static_cast<uint64_t>(buf[4]) << 32) | (static_cast<uint64_t>(buf[5]) << 40) |

--- a/src/partition/Geometry.cc
+++ b/src/partition/Geometry.cc
@@ -101,7 +101,7 @@ Vector3d const NY(0.0, -1.0, 0.0);
 Vector3d const NZ(0.0, 0.0, -1.0);
 
 // Vertex triplet for each HTM root triangle.
-Vector3d const *const htmRootVert[24] = {
+Vector3d const* const htmRootVert[24] = {
         &X,  &NZ, &Y,   // S0
         &Y,  &NZ, &NX,  // S1
         &NX, &NZ, &NY,  // S2
@@ -113,7 +113,7 @@ Vector3d const *const htmRootVert[24] = {
 };
 
 // Return the number of the HTM root triangle containing v.
-inline uint32_t rootNumFor(Vector3d const &v) {
+inline uint32_t rootNumFor(Vector3d const& v) {
     if (v(2) < 0.0) {
         // S0, S1, S2, S3
         if (v(1) > 0.0) {
@@ -166,7 +166,7 @@ double maxAlpha(double r, double centerLat) {
     return DEG_PER_RAD * std::fabs(atan(y / x));
 }
 
-uint32_t htmId(Vector3d const &v, int level) {
+uint32_t htmId(Vector3d const& v, int level) {
     // See http://research.microsoft.com/apps/pubs/default.aspx?id=64531
     if (level < 0 || level > HTM_MAX_LEVEL) {
         throw std::runtime_error("Invalid HTM subdivision level.");
@@ -240,7 +240,7 @@ int htmLevel(uint32_t id) {
     return static_cast<int>(level >> 1);
 }
 
-Vector3d const cartesian(std::pair<double, double> const &lonLat) {
+Vector3d const cartesian(std::pair<double, double> const& lonLat) {
     double lon = lonLat.first * RAD_PER_DEG;
     double lat = lonLat.second * RAD_PER_DEG;
     double sinLon = std::sin(lon);
@@ -250,7 +250,7 @@ Vector3d const cartesian(std::pair<double, double> const &lonLat) {
     return Vector3d(cosLon * cosLat, sinLon * cosLat, sinLat);
 }
 
-std::pair<double, double> const spherical(Vector3d const &v) {
+std::pair<double, double> const spherical(Vector3d const& v) {
     std::pair<double, double> sc(0.0, 0.0);
     double d2 = v(0) * v(0) + v(1) * v(1);
     if (d2 != 0.0) {
@@ -269,7 +269,7 @@ std::pair<double, double> const spherical(Vector3d const &v) {
     return sc;
 }
 
-double angSep(Vector3d const &v0, Vector3d const &v1) {
+double angSep(Vector3d const& v0, Vector3d const& v1) {
     double cs = v0.dot(v1);
     Vector3d n = v0.cross(v1);
     double ss = n.norm();
@@ -329,7 +329,7 @@ SphericalTriangle::SphericalTriangle(uint32_t id) : _m(), _mi() {
     _mi = _m.inverse();
 }
 
-SphericalTriangle::SphericalTriangle(Vector3d const &v0, Vector3d const &v1, Vector3d const &v2)
+SphericalTriangle::SphericalTriangle(Vector3d const& v0, Vector3d const& v1, Vector3d const& v2)
         : _m(), _mi() {
     _m.col(0) = v0;
     _m.col(1) = v1;
@@ -427,10 +427,10 @@ double SphericalTriangle::area() const {
 namespace {
 
 // Intersect the input spherical convex polygon with the given half-space.
-size_t intersect(Vector3d const *inVe,   // input (vertex, edge) pair array
+size_t intersect(Vector3d const* inVe,   // input (vertex, edge) pair array
                  size_t numVerts,        // # of input vertices
-                 Vector3d const &plane,  // plane normal of half-space
-                 Vector3d *outVe)        // output (vertex, edge) pair array
+                 Vector3d const& plane,  // plane normal of half-space
+                 Vector3d* outVe)        // output (vertex, edge) pair array
 {
     assert(numVerts > 1 && inVe != 0 && outVe != 0);
     size_t i = 0, j = numVerts - 1, n = 0;
@@ -540,7 +540,7 @@ double LonRangeList::extent() const {
 }
 
 // Compute the area of the input polygon intersected with zmin <= z <= zmax.
-double zArea(Vector3d const *inVe,  // input (vertex, edge) pair array
+double zArea(Vector3d const* inVe,  // input (vertex, edge) pair array
              size_t numVerts,       // # of input vertices
              double zmin, double zmax) {
     // A = 2πχ(M) - Σ αᵥ - Σ cos(φᵤ) ∆θᵤ      (see above)
@@ -560,7 +560,7 @@ double zArea(Vector3d const *inVe,  // input (vertex, edge) pair array
         double z = inVe[2 * i](2);
         // n is parallel to the edge plane normal (but does not necessarily
         // have unit norm).
-        Vector3d const &n = inVe[2 * j + 1];
+        Vector3d const& n = inVe[2 * j + 1];
         if (z >= zmin && z <= zmax) {
             // Vertex i is in z-range; compute and accumulate turning angle αᵥ
             // at vertex v = i. Here αᵥ is just the angle between the normal
@@ -695,7 +695,7 @@ double zArea(Vector3d const *inVe,  // input (vertex, edge) pair array
 
 }  // unnamed namespace
 
-double SphericalTriangle::intersectionArea(SphericalBox const &box) const {
+double SphericalTriangle::intersectionArea(SphericalBox const& box) const {
     if (box.getLonMin() == box.getLonMax() || box.getLatMin() >= 90.0 - EPSILON_DEG ||
         box.getLatMax() <= -90.0 - +EPSILON_DEG) {
         // box is degenerate or very small.
@@ -711,8 +711,8 @@ double SphericalTriangle::intersectionArea(SphericalBox const &box) const {
     }
     Vector3d veBuf0[(3 + 2) * 2];
     Vector3d veBuf1[(3 + 2) * 2];
-    Vector3d *in = veBuf0;
-    Vector3d *out = veBuf1;
+    Vector3d* in = veBuf0;
+    Vector3d* out = veBuf1;
     size_t numVerts = 3;
     // Populate in with (vertex, edge) pairs.
     in[0] = vertex(0);
@@ -774,7 +774,7 @@ SphericalBox::SphericalBox(double lonMin, double lonMax, double latMin, double l
     _latMax = clampLat(latMax);
 }
 
-SphericalBox::SphericalBox(Vector3d const &v0, Vector3d const &v1, Vector3d const &v2) {
+SphericalBox::SphericalBox(Vector3d const& v0, Vector3d const& v1, Vector3d const& v2) {
     // Find the bounding circle of the triangle.
     Vector3d cv = v0 + v1 + v2;
     double r = angSep(cv, v0);
@@ -839,7 +839,7 @@ double SphericalBox::area() const {
     return RAD_PER_DEG * getLonExtent() * (std::sin(RAD_PER_DEG * _latMax) - std::sin(RAD_PER_DEG * _latMin));
 }
 
-void SphericalBox::htmIds(std::vector<uint32_t> &ids, int level) const {
+void SphericalBox::htmIds(std::vector<uint32_t>& ids, int level) const {
     if (level < 0 || level > HTM_MAX_LEVEL) {
         throw std::runtime_error("Invalid HTM subdivision level.");
     }
@@ -855,10 +855,10 @@ void SphericalBox::htmIds(std::vector<uint32_t> &ids, int level) const {
 // Slow method for finding triangles overlapping a box. For the subdivision
 // levels and box sizes encountered in practice, this is very unlikely to be
 // a performance problem.
-void SphericalBox::_findIds(std::vector<uint32_t> &ids,  // Storage for overlapping triangle IDs.
+void SphericalBox::_findIds(std::vector<uint32_t>& ids,  // Storage for overlapping triangle IDs.
                             uint32_t id,                 // HTM ID of triangle `m`.
                             int level,                   // Number of recursions remaining.
-                            Matrix3d const &m) const     // Triangle vertices.
+                            Matrix3d const& m) const     // Triangle vertices.
 {
     if (!intersects(SphericalBox(m.col(0), m.col(1), m.col(2)))) {
         return;

--- a/src/partition/Geometry.h
+++ b/src/partition/Geometry.h
@@ -81,14 +81,14 @@ double reduceLon(double lon);
 double maxAlpha(double r, double centerLat);
 
 /// Compute the HTM ID of `v`.
-uint32_t htmId(Vector3d const &v, int level);
+uint32_t htmId(Vector3d const& v, int level);
 
 /// Return the HTM subdivision level of `id` or -1 if `id` is invalid.
 int htmLevel(uint32_t id);
 
 /// Return the unit 3-vector corresponding to the given spherical
 /// coordinates (in degrees).
-Vector3d const cartesian(std::pair<double, double> const &lonLat);
+Vector3d const cartesian(std::pair<double, double> const& lonLat);
 
 inline Vector3d const cartesian(double lon, double lat) {
     return cartesian(std::pair<double, double>(lon, lat));
@@ -96,14 +96,14 @@ inline Vector3d const cartesian(double lon, double lat) {
 
 /// Return the longitude and latitude angles (in degrees) corresponding
 /// to the given 3-vector.
-std::pair<double, double> const spherical(Vector3d const &v);
+std::pair<double, double> const spherical(Vector3d const& v);
 
 inline std::pair<double, double> const spherical(double x, double y, double z) {
     return spherical(Vector3d(x, y, z));
 }
 
 /// Return the angular separation between `v0` and `v1` in radians.
-double angSep(Vector3d const &v0, Vector3d const &v1);
+double angSep(Vector3d const& v0, Vector3d const& v1);
 
 class SphericalBox;
 
@@ -160,17 +160,17 @@ public:
     explicit SphericalTriangle(uint32_t htmId);
 
     /// Construct the triangle with the given vertices.
-    SphericalTriangle(Vector3d const &v0, Vector3d const &v1, Vector3d const &v2);
+    SphericalTriangle(Vector3d const& v0, Vector3d const& v1, Vector3d const& v2);
 
     /// Get the i-th vertex (i = 0,1,2). No bounds checking is performed.
-    Vector3d const &vertex(int i) const { return _m.col(i); }
+    Vector3d const& vertex(int i) const { return _m.col(i); }
 
     /// Get the matrix that converts from cartesian to
     /// spherical barycentric coordinates.
-    Matrix3d const &getBarycentricTransform() const { return _mi; }
+    Matrix3d const& getBarycentricTransform() const { return _mi; }
     /// Get the matrix that converts from spherical barycentric
     /// to cartesian coordinates.
-    Matrix3d const &getCartesianTransform() const { return _m; }
+    Matrix3d const& getCartesianTransform() const { return _m; }
 
     /// Compute the area of the triangle in steradians.
     double area() const;
@@ -179,7 +179,7 @@ public:
     /// with a spherical box. The routine is not fully general - for simplicity
     /// of implementation, spherical boxes with RA extent strictly between 180
     /// and 360 degrees are not supported.
-    double intersectionArea(SphericalBox const &box) const;
+    double intersectionArea(SphericalBox const& box) const;
 
 private:
     /// [V0 V1 V2], where column vectors V0, V1, V2 are the triangle
@@ -204,7 +204,7 @@ public:
     SphericalBox(double lonMin, double lonMax, double latMin, double latMax);
 
     /// Create a conservative bounding box for a spherical triangle.
-    SphericalBox(Vector3d const &v0, Vector3d const &v1, Vector3d const &v2);
+    SphericalBox(Vector3d const& v0, Vector3d const& v1, Vector3d const& v2);
 
     /// Expand the box by the given radius.
     void expand(double radius);
@@ -242,12 +242,12 @@ public:
         return lon >= _lonMin && lon <= _lonMax;
     }
 
-    bool contains(std::pair<double, double> const &position) const {
+    bool contains(std::pair<double, double> const& position) const {
         return contains(position.first, position.second);
     }
 
     /// Does this box intersect the given box?
-    bool intersects(SphericalBox const &box) const {
+    bool intersects(SphericalBox const& box) const {
         if (isEmpty() || box.isEmpty()) {
             return false;
         } else if (box._latMin > _latMax || box._latMax < _latMin) {
@@ -265,10 +265,10 @@ public:
 
     /// Compute a conservative approximation to the list of HTM triangles
     /// potentially overlapping this box and store them in `ids`.
-    void htmIds(std::vector<uint32_t> &ids, int level) const;
+    void htmIds(std::vector<uint32_t>& ids, int level) const;
 
 private:
-    void _findIds(std::vector<uint32_t> &ids, uint32_t id, int level, Matrix3d const &m) const;
+    void _findIds(std::vector<uint32_t>& ids, uint32_t id, int level, Matrix3d const& m) const;
 
     double _lonMin;
     double _lonMax;

--- a/src/partition/InputLines.cc
+++ b/src/partition/InputLines.cc
@@ -39,18 +39,18 @@ namespace lsst::partition {
 
 namespace {
 
-typedef std::pair<char *, char *> CharPtrPair;
+typedef std::pair<char*, char*> CharPtrPair;
 
 struct LineFragmentStorage {
     size_t size;
     char buf[MAX_LINE_SIZE];
 
-    LineFragmentStorage(size_t sz, char *b) : size(sz) { std::memcpy(buf, b, sz); }
+    LineFragmentStorage(size_t sz, char* b) : size(sz) { std::memcpy(buf, b, sz); }
 };
 
 // One side of a line split in two by a block boundary.
 struct LineFragment {
-    LineFragmentStorage *data;
+    LineFragmentStorage* data;
 
     LineFragment() : data(0) {}
     ~LineFragment() {
@@ -63,17 +63,17 @@ struct LineFragment {
     // caller is absolved of any responsibility for the line. The second
     // call will fail and return the data stored by the first call. In this
     // case, the caller is responsible for the line.
-    LineFragmentStorage *tryStore(LineFragmentStorage *newval) {
+    LineFragmentStorage* tryStore(LineFragmentStorage* newval) {
         assert(newval != 0);
 #if __GNUC__ && ((__SIZEOF_POINTER__ == 4 && __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4) || \
                  (__SIZEOF_POINTER__ == 8 && __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8))
-        LineFragmentStorage *oldval = 0;
+        LineFragmentStorage* oldval = 0;
         return __sync_val_compare_and_swap(&data, oldval, newval);
 #else
 #warning CAS not supported on this platform - falling back to locking.
         static boost::mutex m;
         boost::lock_guard<boost::mutex> lock(m);
-        LineFragmentStorage *oldval = data;
+        LineFragmentStorage* oldval = data;
         if (oldval == 0) {
             data = newval;
         }
@@ -92,14 +92,14 @@ struct Block {
 
     Block() : file(), offset(0), size(0), head(), tail() {}
 
-    CharPtrPair const read(char *buf, bool skipFirstLine, ConfigParamArrow const &params);
+    CharPtrPair const read(char* buf, bool skipFirstLine, ConfigParamArrow const& params);
 };
 
 // Read a file block and handle the lines crossing its boundaries.
-CharPtrPair const Block::read(char *buf, bool skipFirstLine, ConfigParamArrow const &configArrow) {
+CharPtrPair const Block::read(char* buf, bool skipFirstLine, ConfigParamArrow const& configArrow) {
     // Read into buf, leaving space for a line on either side of the block.
-    char *readBeg = buf + MAX_LINE_SIZE;
-    char *readEnd = readBeg + size;
+    char* readBeg = buf + MAX_LINE_SIZE;
+    char* readEnd = readBeg + size;
 
     // Arrow/Parquet : retrieve the real size of the arrow CSV block
     int bufferSize = 0;
@@ -112,7 +112,7 @@ CharPtrPair const Block::read(char *buf, bool skipFirstLine, ConfigParamArrow co
     // The responsibility for returning a line which crosses the beginning
     // or end of this block lies with the last thread to encounter the
     // line.
-    char *beg = readBeg;
+    char* beg = readBeg;
     if (head || skipFirstLine) {
         // Scan past the first line.
         for (; beg < readEnd && *beg != '\n' && *beg != '\r'; ++beg) {
@@ -137,8 +137,8 @@ CharPtrPair const Block::read(char *buf, bool skipFirstLine, ConfigParamArrow co
             // This is not the first block in the enclosing file. If the
             // initial part of the first line has already been read by the
             // reader of the previous block, return the entire line in buf.
-            LineFragmentStorage *right = new LineFragmentStorage(static_cast<size_t>(beg - readBeg), readBeg);
-            LineFragmentStorage *left = head->tryStore(right);
+            LineFragmentStorage* right = new LineFragmentStorage(static_cast<size_t>(beg - readBeg), readBeg);
+            LineFragmentStorage* left = head->tryStore(right);
             if (left != 0) {
                 beg = readBeg - left->size;
                 std::memcpy(beg, left->buf, left->size);
@@ -146,7 +146,7 @@ CharPtrPair const Block::read(char *buf, bool skipFirstLine, ConfigParamArrow co
             }
         }
     }
-    char *end = readEnd;
+    char* end = readEnd;
     if (tail) {
         // This is not the last block in the enclosing file -
         // scan to the beginning of the last line.
@@ -157,8 +157,8 @@ CharPtrPair const Block::read(char *buf, bool skipFirstLine, ConfigParamArrow co
         }
         // If the trailing part of the last line has already been read by
         // the reader of the following block, return the entire line in buf.
-        LineFragmentStorage *left = new LineFragmentStorage(static_cast<size_t>(readEnd - end), end);
-        LineFragmentStorage *right = tail->tryStore(left);
+        LineFragmentStorage* left = new LineFragmentStorage(static_cast<size_t>(readEnd - end), end);
+        LineFragmentStorage* right = tail->tryStore(left);
         if (right != 0) {
             std::memcpy(readEnd, right->buf, right->size);
             end = readEnd + right->size;
@@ -169,7 +169,7 @@ CharPtrPair const Block::read(char *buf, bool skipFirstLine, ConfigParamArrow co
 }
 
 // Split a file into a series of blocks.
-std::vector<Block> const split(fs::path const &path, off_t blockSize) {
+std::vector<Block> const split(fs::path const& path, off_t blockSize) {
     std::vector<Block> blocks;
     Block b;
 
@@ -220,9 +220,9 @@ std::vector<Block> const split(fs::path const &path, off_t blockSize) {
 
 class InputLines::Impl {
 public:
-    Impl(std::vector<fs::path> const &paths, size_t blockSize, bool skipFirstLine);
-    Impl(std::vector<fs::path> const &paths, size_t blockSize, bool skipFirstLine,
-         ConfigParamArrow const &config);
+    Impl(std::vector<fs::path> const& paths, size_t blockSize, bool skipFirstLine);
+    Impl(std::vector<fs::path> const& paths, size_t blockSize, bool skipFirstLine,
+         ConfigParamArrow const& config);
     ~Impl() {}
 
     size_t getBlockSize() const { return _blockSize; }
@@ -232,13 +232,13 @@ public:
         return _blockCount == 0;
     }
 
-    CharPtrPair const read(char *buf);
+    CharPtrPair const read(char* buf);
 
 private:
     BOOST_STATIC_ASSERT(MAX_LINE_SIZE < 1 * MiB);
 
-    Impl(Impl const &);
-    Impl &operator=(Impl const &);
+    Impl(Impl const&);
+    Impl& operator=(Impl const&);
 
     size_t const _blockSize;
     bool const _skipFirstLine;
@@ -254,7 +254,7 @@ private:
     char _pad1[CACHE_LINE_SIZE];
 };
 
-InputLines::Impl::Impl(std::vector<fs::path> const &paths, size_t blockSize, bool skipFirstLine)
+InputLines::Impl::Impl(std::vector<fs::path> const& paths, size_t blockSize, bool skipFirstLine)
         : _blockSize(std::min(std::max(blockSize, 1 * MiB), 1 * GiB)),
           _skipFirstLine(skipFirstLine),
           _configArrow(ConfigParamArrow()),
@@ -263,8 +263,8 @@ InputLines::Impl::Impl(std::vector<fs::path> const &paths, size_t blockSize, boo
           _queue(),
           _paths(paths) {}
 
-InputLines::Impl::Impl(std::vector<fs::path> const &paths, size_t blockSize, bool skipFirstLine,
-                       ConfigParamArrow const &config)
+InputLines::Impl::Impl(std::vector<fs::path> const& paths, size_t blockSize, bool skipFirstLine,
+                       ConfigParamArrow const& config)
         : _blockSize(std::min(std::max(blockSize, 1 * MiB), 1 * GiB)),
           _skipFirstLine(skipFirstLine),
           _configArrow(config),
@@ -273,7 +273,7 @@ InputLines::Impl::Impl(std::vector<fs::path> const &paths, size_t blockSize, boo
           _queue(),
           _paths(paths) {}
 
-CharPtrPair const InputLines::Impl::read(char *buf) {
+CharPtrPair const InputLines::Impl::read(char* buf) {
     boost::unique_lock<boost::mutex> lock(_mutex);
     while (_blockCount > 0) {
         if (!_queue.empty()) {
@@ -318,16 +318,16 @@ CharPtrPair const InputLines::Impl::read(char *buf) {
         }
     }
     // All lines have been read.
-    return CharPtrPair(static_cast<char *>(0), static_cast<char *>(0));
+    return CharPtrPair(static_cast<char*>(0), static_cast<char*>(0));
 }
 
 // Method delegation.
 
-InputLines::InputLines(std::vector<fs::path> const &paths, size_t blockSize, bool skipFirstLine)
+InputLines::InputLines(std::vector<fs::path> const& paths, size_t blockSize, bool skipFirstLine)
         : _impl(std::make_shared<Impl>(paths, blockSize, skipFirstLine)) {}
 
-InputLines::InputLines(std::vector<fs::path> const &paths, size_t blockSize, bool skipFirstLine,
-                       ConfigParamArrow const &configArrow)
+InputLines::InputLines(std::vector<fs::path> const& paths, size_t blockSize, bool skipFirstLine,
+                       ConfigParamArrow const& configArrow)
         : _impl(std::make_shared<Impl>(paths, blockSize, skipFirstLine, configArrow)) {}
 
 size_t InputLines::getBlockSize() const { return _impl ? _impl->getBlockSize() : 0; }
@@ -336,11 +336,11 @@ size_t InputLines::getMinimumBufferCapacity() const { return _impl ? _impl->getM
 
 bool InputLines::empty() const { return _impl ? _impl->empty() : true; }
 
-CharPtrPair const InputLines::read(char *buf) {
+CharPtrPair const InputLines::read(char* buf) {
     if (_impl) {
         return _impl->read(buf);
     }
-    return CharPtrPair(static_cast<char *>(0), static_cast<char *>(0));
+    return CharPtrPair(static_cast<char*>(0), static_cast<char*>(0));
 }
 
 }  // namespace lsst::partition

--- a/src/partition/MapReduce.h
+++ b/src/partition/MapReduce.h
@@ -63,15 +63,15 @@ template <typename K>
 struct Record {
     K key;
     uint32_t size;
-    char *data;
+    char* data;
 
     Record() : key(), size(0), data(0) {}
-    explicit Record(K const &k) : key(k), size(0), data(0) {}
+    explicit Record(K const& k) : key(k), size(0), data(0) {}
 
     /// Return a hash of the record key.
     uint32_t hash() const { return key.hash(); }
 
-    bool operator<(Record const &r) const { return key < r.key; }
+    bool operator<(Record const& r) const { return key < r.key; }
 };
 
 /// An append-only record silo.
@@ -97,9 +97,9 @@ public:
     size_t getBytesUsed() const { return _bytesUsed; }
 
     /// Order silos by memory usage, from largest to smallest.
-    bool operator<(Silo const &silo) const { return silo._bytesUsed < _bytesUsed; }
+    bool operator<(Silo const& silo) const { return silo._bytesUsed < _bytesUsed; }
 
-    std::vector<Record> const &getRecords() const { return _records; }
+    std::vector<Record> const& getRecords() const { return _records; }
 
     void reserve(size_t cap) { _records.reserve(cap); }
 
@@ -112,14 +112,14 @@ public:
     /// Add a record to the silo, using `Editor::writeRecord()` to produce
     /// the record text. Passing in the editor allows records to be written
     /// directly to silo memory, avoiding a copy.
-    void add(K const &key, csv::Editor const &editor);
+    void add(K const& key, csv::Editor const& editor);
     /// Add a record to the silo.
-    void add(K const &key, char const *data, uint32_t size);
+    void add(K const& key, char const* data, uint32_t size);
 
 private:
     // Disable copy construction and assignment.
-    Silo(Silo const &);
-    Silo &operator=(Silo const &);
+    Silo(Silo const&);
+    Silo& operator=(Silo const&);
 
     void _grow();
 
@@ -127,9 +127,9 @@ private:
 
     std::vector<Record> _records;
     size_t _bytesUsed;
-    char *_head;  // Head of linked allocation list.
-    char *_cur;
-    char *_end;  // End of current allocation.
+    char* _head;  // Head of linked allocation list.
+    char* _cur;
+    char* _end;  // End of current allocation.
 
     char _pad1[CACHE_LINE_SIZE];
 };
@@ -138,9 +138,9 @@ template <typename K>
 Silo<K>::~Silo() {
     // Traverse linked-list, freeing each allocation. Forward
     // pointers are located at the beginning of each allocation.
-    char *head = _head;
+    char* head = _head;
     while (head) {
-        char *next = *reinterpret_cast<char **>(head);
+        char* next = *reinterpret_cast<char**>(head);
         std::free(head);
         head = next;
     }
@@ -156,15 +156,15 @@ void Silo<K>::clear() {
     if (_head) {
         // Set data insertion point to the beginning of the
         // first allocation.
-        _cur = _head + sizeof(char *);
+        _cur = _head + sizeof(char*);
         _end = _head + ALLOC_SIZE;
     }
 }
 
 template <typename K>
-void Silo<K>::add(K const &key, csv::Editor const &editor) {
-    char *buf = _cur;
-    char *end = _end;
+void Silo<K>::add(K const& key, csv::Editor const& editor) {
+    char* buf = _cur;
+    char* end = _end;
     if (end - buf < MAX_LINE_SIZE) {
         // The size of the line being written isn't known in advance, so
         // the silo must always present MAX_LINE_SIZE or more contiguous
@@ -183,12 +183,12 @@ void Silo<K>::add(K const &key, csv::Editor const &editor) {
 }
 
 template <typename K>
-void Silo<K>::add(K const &key, char const *data, uint32_t size) {
+void Silo<K>::add(K const& key, char const* data, uint32_t size) {
     if (size > MAX_LINE_SIZE) {
         throw std::runtime_error("Record too long.");
     }
-    char *buf = _cur;
-    char *end = _end;
+    char* buf = _cur;
+    char* end = _end;
     if (static_cast<uint32_t>(end - buf) < size) {
         _grow();
         buf = _cur;
@@ -207,26 +207,26 @@ template <typename K>
 void Silo<K>::_grow() {
     // [_cur, _end) has no room for data, so either advance to the next
     // allocation in the linked-list, or append a new allocation at the tail.
-    char *tail = 0;
-    char *next = 0;
+    char* tail = 0;
+    char* next = 0;
     if (_end) {
         tail = _end - ALLOC_SIZE;
-        next = *reinterpret_cast<char **>(tail);
+        next = *reinterpret_cast<char**>(tail);
     }
     if (!next) {
-        next = static_cast<char *>(std::malloc(ALLOC_SIZE));
+        next = static_cast<char*>(std::malloc(ALLOC_SIZE));
         if (!next) {
             throw std::bad_alloc();
         }
         if (tail) {
-            *reinterpret_cast<char **>(tail) = next;
+            *reinterpret_cast<char**>(tail) = next;
         }
-        *reinterpret_cast<char **>(next) = 0;
+        *reinterpret_cast<char**>(next) = 0;
         if (!_head) {
             _head = next;
         }
     }
-    _cur = next + sizeof(char *);
+    _cur = next + sizeof(char*);
     _end = next + ALLOC_SIZE;
 }
 
@@ -304,7 +304,7 @@ namespace detail {
 /// Comparator for shared pointers to `Silo`s.
 template <typename K>
 struct SiloPtrCmp {
-    bool operator()(std::shared_ptr<Silo<K> > const &s, std::shared_ptr<Silo<K> > const &t) const {
+    bool operator()(std::shared_ptr<Silo<K> > const& s, std::shared_ptr<Silo<K> > const& t) const {
         return *s < *t;
     }
 };
@@ -325,7 +325,7 @@ struct SortedRecordRange {
 
     /// Order sorted ranges by their minimum records,
     /// from largest to smallest.
-    bool operator<(SortedRecordRange const &r) const { return *r.cur < *cur; }
+    bool operator<(SortedRecordRange const& r) const { return *r.cur < *cur; }
 };
 
 /// CRTP base-class containing the meat of the map-reduce implementation.
@@ -336,21 +336,21 @@ class JobBase {
 public:
     typedef WorkerT Worker;
 
-    JobBase(ConfigStore const &config);
+    JobBase(ConfigStore const& config);
     ~JobBase();
 
     void run(InputLines input);
     void operator()();
 
-    static void defineOptions(boost::program_options::options_description &opts);
+    static void defineOptions(boost::program_options::options_description& opts);
 
 private:
-    JobBase(JobBase const &);
-    JobBase &operator=(JobBase const &);
+    JobBase(JobBase const&);
+    JobBase& operator=(JobBase const&);
 
     void _work();
     void _cleanup();
-    void _fail(std::exception const &ex);
+    void _fail(std::exception const& ex);
 
     typedef typename Worker::Key Key;
     typedef detail::SortedRecordRange<Key> SortedRecordRange;
@@ -360,7 +360,7 @@ private:
     typedef detail::SiloPtrCmp<Key> SiloPtrCmp;
     typedef typename std::vector<SiloPtr>::const_iterator SiloPtrIter;
 
-    ConfigStore const *_config;
+    ConfigStore const* _config;
 
     InputLines _input;
     size_t _threshold;
@@ -383,11 +383,11 @@ private:
 
     // DerivedT is responsible for storing worker results. Note
     // that _mutex is locked when this is called.
-    void _storeResultImpl(Worker &worker) { static_cast<DerivedT *>(this)->_storeResult(worker); }
+    void _storeResultImpl(Worker& worker) { static_cast<DerivedT*>(this)->_storeResult(worker); }
 };
 
 template <typename DerivedT, typename WorkerT>
-JobBase<DerivedT, WorkerT>::JobBase(ConfigStore const &config)
+JobBase<DerivedT, WorkerT>::JobBase(ConfigStore const& config)
         : _config(&config),
           _threshold(0),
           _numWorkers(config.get<uint32_t>("mr.num-workers")),
@@ -420,7 +420,7 @@ void JobBase<DerivedT, WorkerT>::_cleanup() {
 }
 
 template <typename DerivedT, typename WorkerT>
-void JobBase<DerivedT, WorkerT>::_fail(std::exception const &ex) {
+void JobBase<DerivedT, WorkerT>::_fail(std::exception const& ex) {
     boost::unique_lock<boost::mutex> lock(_mutex);
     if (!_failed) {
         // Mark job as failed, and set error message.
@@ -449,7 +449,7 @@ void JobBase<DerivedT, WorkerT>::run(InputLines input) {
         for (; i < _numWorkers - 1; ++i) {
             threads[i] = boost::thread(boost::ref(*this));
         }
-    } catch (std::exception const &ex) {
+    } catch (std::exception const& ex) {
         _fail(ex);
     }
     // The caller participates in job execution, avoiding thread
@@ -473,13 +473,13 @@ template <typename DerivedT, typename WorkerT>
 void JobBase<DerivedT, WorkerT>::operator()() {
     try {
         _work();
-    } catch (std::exception const &ex) {
+    } catch (std::exception const& ex) {
         _fail(ex);
     }
 }
 
 template <typename DerivedT, typename WorkerT>
-void JobBase<DerivedT, WorkerT>::defineOptions(boost::program_options::options_description &opts) {
+void JobBase<DerivedT, WorkerT>::defineOptions(boost::program_options::options_description& opts) {
     namespace po = boost::program_options;
     po::options_description mr("\\_________________ Map-Reduce", 80);
     mr.add_options()("mr.block-size", po::value<size_t>()->default_value(4),
@@ -503,7 +503,7 @@ void JobBase<DerivedT, WorkerT>::defineOptions(boost::program_options::options_d
 template <typename DerivedT, typename WorkerT>
 void JobBase<DerivedT, WorkerT>::_work() {
     // Pre-allocate disk read buffer.
-    std::shared_ptr<char> buffer(static_cast<char *>(std::malloc(_input.getMinimumBufferCapacity())),
+    std::shared_ptr<char> buffer(static_cast<char*>(std::malloc(_input.getMinimumBufferCapacity())),
                                  std::free);
     if (!buffer) {
         throw std::bad_alloc();
@@ -541,7 +541,7 @@ void JobBase<DerivedT, WorkerT>::_work() {
             SiloPtr silo = _silos.back();
             _silos.pop_back();
             lock.unlock();
-            std::pair<char *, char *> data = _input.read(buffer.get());
+            std::pair<char*, char*> data = _input.read(buffer.get());
             if (data.first == 0 && data.second == 0) {
                 // No input left.
                 silo->sort();
@@ -601,7 +601,7 @@ void JobBase<DerivedT, WorkerT>::_work() {
         std::make_heap(ranges.begin(), ranges.end());
         while (!ranges.empty()) {
             std::pop_heap(ranges.begin(), ranges.end());
-            SortedRecordRange *r = &ranges.back();
+            SortedRecordRange* r = &ranges.back();
             RecordIter i = r->cur;
             r->advance();
             if (i->hash() % _numWorkers == rank) {
@@ -650,7 +650,7 @@ template <typename WorkerT, typename ResultT>
 class JobImpl : private JobBase<JobImpl<WorkerT, ResultT>, WorkerT> {
     typedef JobBase<JobImpl<WorkerT, ResultT>, WorkerT> Base;
 
-    void _storeResult(WorkerT &w) {
+    void _storeResult(WorkerT& w) {
         std::shared_ptr<ResultT> r = w.result();
         if (!_result) {
             _result = r;
@@ -665,7 +665,7 @@ class JobImpl : private JobBase<JobImpl<WorkerT, ResultT>, WorkerT> {
     friend class JobBase<JobImpl<WorkerT, ResultT>, WorkerT>;
 
 public:
-    explicit JobImpl(ConfigStore const &config) : Base(config) {}
+    explicit JobImpl(ConfigStore const& config) : Base(config) {}
 
     std::shared_ptr<ResultT> const run(InputLines input) {
         try {
@@ -687,13 +687,13 @@ template <typename WorkerT>
 class JobImpl<WorkerT, void> : private JobBase<JobImpl<WorkerT, void>, WorkerT> {
     typedef JobBase<JobImpl<WorkerT, void>, WorkerT> Base;
 
-    void _storeResult(WorkerT &) {}
+    void _storeResult(WorkerT&) {}
 
     // Allow JobBase to call _storeResult.
     friend class JobBase<JobImpl<WorkerT, void>, WorkerT>;
 
 public:
-    explicit JobImpl(ConfigStore const &config) : Base(config) {}
+    explicit JobImpl(ConfigStore const& config) : Base(config) {}
 
     void run(InputLines input) { Base::run(input); }
 
@@ -724,7 +724,7 @@ public:
 template <typename WorkerT>
 class Job : public detail::JobImpl<WorkerT, typename WorkerT::Result> {
 public:
-    explicit Job(ConfigStore const &config) : detail::JobImpl<WorkerT, typename WorkerT::Result>(config) {}
+    explicit Job(ConfigStore const& config) : detail::JobImpl<WorkerT, typename WorkerT::Result>(config) {}
 };
 
 }  // namespace lsst::partition

--- a/src/partition/sph-duplicate2.cc
+++ b/src/partition/sph-duplicate2.cc
@@ -57,7 +57,7 @@ namespace {
 class CmdLineOptions {
 private:
     template <typename T>
-    T _getMandatoryOption(std::string const &name, po::variables_map const &vm) {
+    T _getMandatoryOption(std::string const& name, po::variables_map const& vm) {
         if (!vm.count(name)) throw new std::invalid_argument("missing command line option: " + name);
 
         return vm[name].as<T>();
@@ -74,7 +74,7 @@ public:
     /**
      * @return 'false' if the appplication was run in the 'hel' mode.
      */
-    bool parse(int argc, char const *const *argv) {
+    bool parse(int argc, char const* const* argv) {
         po::options_description desc(
                 "\n"
                 "DESCRIPTION\n"
@@ -203,10 +203,10 @@ public:
 
 private:
     /// Copy constructor (not allowed)
-    CmdLineOptions(CmdLineOptions const &);
+    CmdLineOptions(CmdLineOptions const&);
 
     /// Assignment operator (ot allowed)
-    CmdLineOptions &operator=(CmdLineOptions const &);
+    CmdLineOptions& operator=(CmdLineOptions const&);
 
 public:
     bool verbose;
@@ -255,7 +255,7 @@ struct RaDecl {
  *
  * @return the translated coordinates
  */
-RaDecl transformRaDecl(double ra, double decl, part::SphericalBox const &box) {
+RaDecl transformRaDecl(double ra, double decl, part::SphericalBox const& box) {
     RaDecl coord{ra, decl};
 
     coord.ra += opt.raShift;
@@ -273,7 +273,7 @@ private:
 
 public:
     /// Construct the generator for the specified table
-    PrimaryKeyGenerator(CmdLineOptions const &opt, std::string const &table) : _opt(opt), _table(table) {}
+    PrimaryKeyGenerator(CmdLineOptions const& opt, std::string const& table) : _opt(opt), _table(table) {}
 
     ~PrimaryKeyGenerator() {}
 
@@ -295,7 +295,7 @@ public:
     }
 
     /// Allocate and return the next key in a series
-    uint64_t next(uint64_t const oldId, RaDecl const &coord) {
+    uint64_t next(uint64_t const oldId, RaDecl const& coord) {
         // Compute new ID for the shifted RA/DECL using the requested
         // algorithm.
 
@@ -366,10 +366,10 @@ private:
     PrimaryKeyGenerator();
 
     /// Assignment operator (is disabled)
-    PrimaryKeyGenerator &operator=(PrimaryKeyGenerator const &lhs);
+    PrimaryKeyGenerator& operator=(PrimaryKeyGenerator const& lhs);
 
 private:
-    CmdLineOptions const &_opt;
+    CmdLineOptions const& _opt;
     std::string _table;
 
     HtmIdMap _maxId;
@@ -393,7 +393,7 @@ public:
     virtual ~ColDef() {}
 
     /// Load column definitions from a file
-    void load(std::string const &filename) {
+    void load(std::string const& filename) {
         std::ifstream infile(filename, std::ifstream::in);
         std::string name;
         for (int colnum = 0; std::getline(infile, name); colnum++) {
@@ -410,7 +410,7 @@ protected:
     ColDef() : maxLen(0) {}
 
     /// Evaluate the column
-    virtual void _evaluateColumn(std::string const &name, int colnum) = 0;
+    virtual void _evaluateColumn(std::string const& name, int colnum) = 0;
 
     /// Validator for the definitions
     /**
@@ -420,10 +420,10 @@ protected:
 
 private:
     /// Copy constructor (is disabled)
-    ColDef(ColDef const &);
+    ColDef(ColDef const&);
 
     /// Assignment operator (is disabled)
-    ColDef &operator=(ColDef const &lhs);
+    ColDef& operator=(ColDef const& lhs);
 
 public:
     std::vector<std::string> columns;
@@ -442,7 +442,7 @@ public:
 
 protected:
     /// Evaluate the column
-    virtual void _evaluateColumn(std::string const &name, int colnum) {
+    virtual void _evaluateColumn(std::string const& name, int colnum) {
         if ("deepSourceId" == name) {
             idxDeepSourceId = colnum;
         } else if ("ra" == name) {
@@ -463,10 +463,10 @@ protected:
 
 private:
     /// Copy constructor (is disabled)
-    ColDefObject(ColDefObject const &);
+    ColDefObject(ColDefObject const&);
 
     /// Assignment operator (is disabled)
-    ColDefObject &operator=(ColDefObject const &lhs);
+    ColDefObject& operator=(ColDefObject const& lhs);
 
 public:
     int idxDeepSourceId;
@@ -499,7 +499,7 @@ public:
 
 protected:
     /// Evaluate the column
-    virtual void _evaluateColumn(std::string const &name, int colnum) {
+    virtual void _evaluateColumn(std::string const& name, int colnum) {
         if ("id" == name) {
             idxId = colnum;
         } else if ("coord_ra" == name) {
@@ -528,10 +528,10 @@ protected:
 
 private:
     /// Copy constructor (is disabled)
-    ColDefSource(ColDefSource const &);
+    ColDefSource(ColDefSource const&);
 
     /// Assignment operator (is disabled)
-    ColDefSource &operator=(ColDefSource const &lhs);
+    ColDefSource& operator=(ColDefSource const& lhs);
 
 public:
     int idxId;
@@ -557,7 +557,7 @@ public:
 
 protected:
     /// Evaluate the column
-    virtual void _evaluateColumn(std::string const &name, int colnum) {
+    virtual void _evaluateColumn(std::string const& name, int colnum) {
         if ("deepSourceId" == name) {
             idxDeepSourceId = colnum;
         } else if ("chunkId" == name) {
@@ -572,10 +572,10 @@ protected:
 
 private:
     /// Copy constructor (is disabled)
-    ColDefForcedSource(ColDefForcedSource const &);
+    ColDefForcedSource(ColDefForcedSource const&);
 
     /// Assignment operator (is disabled)
-    ColDefForcedSource &operator=(ColDefForcedSource const &lhs);
+    ColDefForcedSource& operator=(ColDefForcedSource const& lhs);
 
 public:
     int idxDeepSourceId;
@@ -587,7 +587,7 @@ public:
 ColDefForcedSource coldefForcedSource;
 
 /// Write a row into a stream
-void writeRow(std::vector<std::string> const &tokens, std::ofstream &os) {
+void writeRow(std::vector<std::string> const& tokens, std::ofstream& os) {
     if (opt.dryRun) return;
 
     for (size_t idx = 0; idx < tokens.size(); ++idx) {
@@ -609,7 +609,7 @@ ObjectIdTransformMap objIdTransformInput, objIdTransformDuplicate;
 std::set<uint64_t> objIdOutOfBox;
 
 /// Duplicate the next row of the chunk's Object table
-size_t duplicateObjectRow(std::string &line, part::SphericalBox const &box, std::ofstream &os) {
+size_t duplicateObjectRow(std::string& line, part::SphericalBox const& box, std::ofstream& os) {
     // Split the input line into tokens and store them
     // in a temporrary array at positions which are supposed to match
     // the correposnding ColDef
@@ -636,7 +636,7 @@ size_t duplicateObjectRow(std::string &line, part::SphericalBox const &box, std:
     double decl(0.);
 
     int idx = 0;
-    for (std::string const &token : tokens) {
+    for (std::string const& token : tokens) {
         if (coldefObject.idxDeepSourceId == idx) {
             deepSourceId = boost::lexical_cast<uint64_t>(token);
         } else if (coldefObject.idxRa == idx) {
@@ -712,7 +712,7 @@ size_t duplicateObjectRow(std::string &line, part::SphericalBox const &box, std:
 }
 
 /// Duplicate all rows of the chunk's Object table
-std::pair<size_t, size_t> duplicateObject(part::SphericalBox const &box) {
+std::pair<size_t, size_t> duplicateObject(part::SphericalBox const& box) {
     std::string const inFileName = opt.indir + "/Object_" + std::to_string(opt.chunkId) + ".txt",
                       outFileName = opt.outdir + "/Object_" + std::to_string(opt.chunkId) + ".txt";
 
@@ -733,7 +733,7 @@ std::pair<size_t, size_t> duplicateObject(part::SphericalBox const &box) {
 }
 
 /// Duplicate the next row of the chunk's Source table
-size_t duplicateSourceRow(std::string &line, part::SphericalBox const &box, std::ofstream &os) {
+size_t duplicateSourceRow(std::string& line, part::SphericalBox const& box, std::ofstream& os) {
     // Split the input line into tokens and store them
     // in a temporrary array at positions which are supposed to match
     // the correposnding ColDef
@@ -764,7 +764,7 @@ size_t duplicateSourceRow(std::string &line, part::SphericalBox const &box, std:
     double cluster_coord_decl(0.);
 
     int idx = 0;
-    for (std::string const &token : tokens) {
+    for (std::string const& token : tokens) {
         if (coldefSource.idxId == idx) {
             id = boost::lexical_cast<uint64_t>(token);
         } else if (coldefSource.idxCoordRa == idx) {
@@ -872,7 +872,7 @@ size_t duplicateSourceRow(std::string &line, part::SphericalBox const &box, std:
 }
 
 /// Duplicate all rows of the chunk's Source table
-std::pair<size_t, size_t> duplicateSource(part::SphericalBox const &box) {
+std::pair<size_t, size_t> duplicateSource(part::SphericalBox const& box) {
     std::string const inFileName = opt.indir + "/Source_" + std::to_string(opt.chunkId) + ".txt",
                       outFileName = opt.outdir + "/Source_" + std::to_string(opt.chunkId) + ".txt";
 
@@ -890,7 +890,7 @@ std::pair<size_t, size_t> duplicateSource(part::SphericalBox const &box) {
 }
 
 /// Duplicate the next row of the chunk's ForcedSource table
-size_t duplicateForcedSourceRow(std::string &line, part::SphericalBox const &box, std::ofstream &os) {
+size_t duplicateForcedSourceRow(std::string& line, part::SphericalBox const& box, std::ofstream& os) {
     // Split the input line into tokens and store them
     // in a temporrary array at positions which are supposed to match
     // the correposnding ColDef
@@ -915,7 +915,7 @@ size_t duplicateForcedSourceRow(std::string &line, part::SphericalBox const &box
     uint64_t deepSourceId(0ULL);
 
     int idx = 0;
-    for (std::string const &token : tokens) {
+    for (std::string const& token : tokens) {
         if (coldefForcedSource.idxDeepSourceId == idx) {
             deepSourceId = boost::lexical_cast<uint64_t>(token);
         }
@@ -966,7 +966,7 @@ size_t duplicateForcedSourceRow(std::string &line, part::SphericalBox const &box
 }
 
 /// Duplicate all rows of the chunk's ForcedSource table
-std::pair<size_t, size_t> duplicateForcedSource(part::SphericalBox const &box) {
+std::pair<size_t, size_t> duplicateForcedSource(part::SphericalBox const& box) {
     std::string const inFileName = opt.indir + "/ForcedSource_" + std::to_string(opt.chunkId) + ".txt",
                       outFileName = opt.outdir + "/ForcedSource_" + std::to_string(opt.chunkId) + ".txt";
 
@@ -992,7 +992,7 @@ void duplicate() {
     }
 
     part::Chunker chunker(opt.overlap, opt.numStripes, opt.numSubStripesPerStripe);
-    part::SphericalBox const &box(chunker.getChunkBounds(opt.chunkId));
+    part::SphericalBox const& box(chunker.getChunkBounds(opt.chunkId));
 
     if (opt.verbose)
         std::cout << "\n"
@@ -1023,7 +1023,7 @@ void duplicate() {
 }
 }  // namespace
 
-int main(int argc, char const *const *argv) {
+int main(int argc, char const* const* argv) {
     try {
         if (!::opt.parse(argc, argv)) return EXIT_FAILURE;
 
@@ -1035,7 +1035,7 @@ int main(int argc, char const *const *argv) {
         // Process the chunk(s)
         ::duplicate();
 
-    } catch (std::exception const &ex) {
+    } catch (std::exception const& ex) {
         std::cerr << ex.what() << std::endl;
         return EXIT_FAILURE;
     }

--- a/src/partition/tests/mapReduce.cc
+++ b/src/partition/tests/mapReduce.cc
@@ -53,7 +53,7 @@ unsigned int const NUM_LINES = 1024 * 1024;
 
 /// Generate CSV files containing a total of NUM_LINES lines, where
 /// each line consists of a single line number.
-void buildInput(TempFile const &t1, TempFile const &t2) {
+void buildInput(TempFile const& t1, TempFile const& t2) {
     char buf[17];
     unsigned int line;
     BufferedAppender a(1 * MiB);
@@ -74,7 +74,7 @@ void buildInput(TempFile const &t1, TempFile const &t2) {
 struct Key {
     uint32_t line;
     uint32_t hash() const { return line; }
-    bool operator<(Key const &k) const { return line < k.line; }
+    bool operator<(Key const& k) const { return line < k.line; }
 };
 
 // 2-bits per line that indicate whether a line has been mapped/reduced.
@@ -99,7 +99,7 @@ public:
         _reduced[line] = true;
     }
 
-    void merge(Lines const &lines) {
+    void merge(Lines const& lines) {
         _failed = _failed || lines._failed;
         for (size_t i = 0; i < NUM_LINES; ++i) {
             if (lines._mapped[i]) {
@@ -134,9 +134,9 @@ private:
 
 class Worker : public WorkerBase<Key, Lines> {
 public:
-    Worker(ConfigStore const &config) : _editor(config), _lines(new Lines()) {}
+    Worker(ConfigStore const& config) : _editor(config), _lines(new Lines()) {}
 
-    void map(char const *beg, char const *end, Silo &silo) {
+    void map(char const* beg, char const* end, Silo& silo) {
         Key k;
         while (beg < end) {
             beg = _editor.readRecord(beg, end);
@@ -156,7 +156,7 @@ public:
 
     shared_ptr<Lines> const result() { return _lines; }
 
-    static void defineOptions(po::options_description &opts) { csv::Editor::defineOptions(opts); }
+    static void defineOptions(po::options_description& opts) { csv::Editor::defineOptions(opts); }
 
 private:
     csv::Editor _editor;
@@ -168,7 +168,7 @@ typedef Job<Worker> TestJob;
 }  // unnamed namespace
 
 BOOST_AUTO_TEST_CASE(MapReduceTest) {
-    char const *argv[4] = {
+    char const* argv[4] = {
             "dummy",
             "--in.csv.field=line",
             "--mr.pool-size=8",
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(MapReduceTest) {
         argv[3] = s.c_str();
         po::variables_map vm;
         // Older boost versions (1.41) require the const_cast.
-        po::store(po::parse_command_line(4, const_cast<char **>(argv), options), vm);
+        po::store(po::parse_command_line(4, const_cast<char**>(argv), options), vm);
         po::notify(vm);
         ConfigStore config;
         config.add(vm);

--- a/src/query/testRepr.cc
+++ b/src/query/testRepr.cc
@@ -75,11 +75,11 @@ BOOST_AUTO_TEST_CASE(Factory) {
 // and the tree is constructed via a push down list.  The aim here
 // was to keep the specification parser as simple as possible...
 
-const std::string RenderedBoolTermFromRPN(const char **rpn) {
+const std::string RenderedBoolTermFromRPN(const char** rpn) {
     BoolTerm::PtrVector pdl;
     int opcount;
 
-    for (const char **t = rpn; *t; ++t) {
+    for (const char** t = rpn; *t; ++t) {
         if (sscanf(*t, "%d", &opcount) == 1) {
             ;
         } else if (!strcmp(*t, "AND")) {
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
     // |   +-- A
     // |   +-- B
     // +-- C
-    const char *test0[] = {"C", "B", "A", "2", "AND", "2", "AND", nullptr};
+    const char* test0[] = {"C", "B", "A", "2", "AND", "2", "AND", nullptr};
     BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test0), "A AND B AND C");
 
     // AND
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
     // |   +-- A
     // |   +-- B
     // +-- C
-    const char *test1[] = {"C", "B", "A", "2", "OR", "2", "AND", nullptr};
+    const char* test1[] = {"C", "B", "A", "2", "OR", "2", "AND", nullptr};
     BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test1), "(A OR B) AND C");
 
     // OR
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
     // |   +-- A
     // |   +-- B
     // +-- C
-    const char *test2[] = {"C", "B", "A", "2", "AND", "2", "OR", nullptr};
+    const char* test2[] = {"C", "B", "A", "2", "AND", "2", "OR", nullptr};
     BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test2), "A AND B OR C");
 
     // OR
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
     // |   +-- A
     // |   +-- B
     // +-- C
-    const char *test3[] = {"C", "B", "A", "2", "OR", "2", "OR", nullptr};
+    const char* test3[] = {"C", "B", "A", "2", "OR", "2", "OR", nullptr};
     BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test3), "A OR B OR C");
 
     // AND
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
     // |   +-- C
     // |   +-- D
     // +-- E
-    const char *test4[] = {"E", "D", "C", "B", "3", "OR", "A", "3", "AND", nullptr};
+    const char* test4[] = {"E", "D", "C", "B", "3", "OR", "A", "3", "AND", nullptr};
     BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test4), "A AND (B OR C OR D) AND E");
 
     // OR
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(BoolTermRenderParens) {
     // |   +-- C
     // |   +-- D
     // +-- E
-    const char *test5[] = {"E", "D", "C", "B", "3", "AND", "A", "3", "OR", nullptr};
+    const char* test5[] = {"E", "D", "C", "B", "3", "AND", "A", "3", "OR", nullptr};
     BOOST_CHECK_EQUAL(RenderedBoolTermFromRPN(test5), "A OR B AND C AND D OR E");
 }
 

--- a/src/util/DynamicWorkQueue.cc
+++ b/src/util/DynamicWorkQueue.cc
@@ -42,22 +42,22 @@ struct DynamicWorkQueue::Queue {
     // Queue creation time in seconds since the Epoch.
     double createTime;
     // Opaque handle used to look up the Queue for a session by DynamicWorkQueue.
-    void const *session;
+    void const* session;
     // Singly linked list of callables.
-    DynamicWorkQueue::Callable *head;
-    DynamicWorkQueue::Callable *tail;
+    DynamicWorkQueue::Callable* head;
+    DynamicWorkQueue::Callable* tail;
 
-    Queue(void const *handle) : numThreads(0), session(handle), head(nullptr), tail(nullptr) {
+    Queue(void const* handle) : numThreads(0), session(handle), head(nullptr), tail(nullptr) {
         struct ::timeval t;
         ::gettimeofday(&t, nullptr);
         createTime = t.tv_sec + 0.000001 * t.tv_usec;
     }
 
     ~Queue() {
-        Callable *c = head;
+        Callable* c = head;
         head = tail = nullptr;
         while (c) {
-            Callable *next = c->_next;
+            Callable* next = c->_next;
             delete c;
             c = next;
         }
@@ -66,7 +66,7 @@ struct DynamicWorkQueue::Queue {
     bool empty() const { return head == nullptr; }
 
     // Take ownership of a Callable and add it to the end of the queue.
-    void put(Callable *c) {
+    void put(Callable* c) {
         if (c) {
             if (tail) {
                 tail->_next = c;
@@ -79,10 +79,10 @@ struct DynamicWorkQueue::Queue {
 
     // Remove a Callable from the beginning of the queue and relinquish
     // ownership of it. If the queue is empty, nullptr is returned.
-    Callable *take() {
-        Callable *c = head;
+    Callable* take() {
+        Callable* c = head;
         if (c) {
-            Callable *next = c->_next;
+            Callable* next = c->_next;
             head = next;
             if (next == nullptr) {
                 tail = nullptr;
@@ -92,8 +92,8 @@ struct DynamicWorkQueue::Queue {
     }
 
     // Remove and relinquish ownership for all Callable objects in the queue.
-    Callable *takeAll() {
-        Callable *c = head;
+    Callable* takeAll() {
+        Callable* c = head;
         head = tail = nullptr;
         return c;
     }
@@ -101,8 +101,8 @@ struct DynamicWorkQueue::Queue {
 
 // Order queue pointers lexicographically by
 // (active thread count, queue creation time, queue memory address).
-bool DynamicWorkQueue::QueuePtrCmp::operator()(DynamicWorkQueue::Queue const *x,
-                                               DynamicWorkQueue::Queue const *y) const {
+bool DynamicWorkQueue::QueuePtrCmp::operator()(DynamicWorkQueue::Queue const* x,
+                                               DynamicWorkQueue::Queue const* y) const {
     if (x->numThreads < y->numThreads) {
         return true;
     } else if (x->numThreads == y->numThreads) {
@@ -117,9 +117,9 @@ bool DynamicWorkQueue::QueuePtrCmp::operator()(DynamicWorkQueue::Queue const *x,
 
 // Wraps a DynamicWorkQueue reference and implements the work scheduling loop.
 struct DynamicWorkQueue::Runner {
-    Runner(DynamicWorkQueue &queue) : wq(queue) {}
+    Runner(DynamicWorkQueue& queue) : wq(queue) {}
     void operator()();
-    DynamicWorkQueue &wq;
+    DynamicWorkQueue& wq;
 };
 
 void DynamicWorkQueue::Runner::operator()() {
@@ -134,7 +134,7 @@ void DynamicWorkQueue::Runner::operator()() {
         }
         // The first set element is the oldest of the queues with the smallest
         // active thread count.
-        Queue *q = *wq._nonEmptyQueues.begin();
+        Queue* q = *wq._nonEmptyQueues.begin();
         // Remove q from _nonEmptyQueues prior to updating it - this is
         // necessary because the queues may be reordered by the update.
         //
@@ -184,7 +184,7 @@ void DynamicWorkQueue::Runner::operator()() {
     }
 }
 
-void DynamicWorkQueue::_startRunner(DynamicWorkQueue &dwq) {
+void DynamicWorkQueue::_startRunner(DynamicWorkQueue& dwq) {
     Runner r(dwq);
     r();
 }
@@ -223,7 +223,7 @@ DynamicWorkQueue::~DynamicWorkQueue() {
     _sessions.clear();
 }
 
-void DynamicWorkQueue::add(void const *session, DynamicWorkQueue::Callable *callable) {
+void DynamicWorkQueue::add(void const* session, DynamicWorkQueue::Callable* callable) {
     std::lock_guard<std::mutex> lock(_mutex);
     if (_shouldIncreaseThreadCount()) {
         std::thread t(_startRunner, std::ref(*this));
@@ -247,7 +247,7 @@ void DynamicWorkQueue::add(void const *session, DynamicWorkQueue::Callable *call
         // thread is created, and Runner decrements it before exiting.
         _numThreads += 1;
     }
-    Queue *q = nullptr;
+    Queue* q = nullptr;
     SessionQueueMap::iterator i = _sessions.find(session);
     if (i != _sessions.end()) {
         // There is an existing queue for session.
@@ -272,13 +272,13 @@ void DynamicWorkQueue::add(void const *session, DynamicWorkQueue::Callable *call
     _workAvailable.notify_one();
 }
 
-void DynamicWorkQueue::cancelQueued(void const *session) {
-    Callable *c = nullptr;
+void DynamicWorkQueue::cancelQueued(void const* session) {
+    Callable* c = nullptr;
     {
         std::lock_guard<std::mutex> lock(_mutex);
         SessionQueueMap::iterator i = _sessions.find(session);
         if (i != _sessions.end()) {
-            Queue *q = i->second;
+            Queue* q = i->second;
             c = q->takeAll();
             _nonEmptyQueues.erase(q);
             if (q->numThreads == 0) {
@@ -289,7 +289,7 @@ void DynamicWorkQueue::cancelQueued(void const *session) {
         }
     }
     while (c) {
-        Callable *next = c->_next;
+        Callable* next = c->_next;
         c->cancel();  // TODO: what if cancel() throws?
         delete c;
         c = next;

--- a/src/util/DynamicWorkQueue.h
+++ b/src/util/DynamicWorkQueue.h
@@ -44,7 +44,7 @@ namespace lsst::qserv::util {
 class DynamicWorkQueue {
     struct Queue;
     struct QueuePtrCmp {
-        bool operator()(Queue const *, Queue const *) const;
+        bool operator()(Queue const*, Queue const*) const;
     };
     struct Runner;
 
@@ -67,7 +67,7 @@ public:
         virtual void cancel() {}
 
     private:
-        Callable *_next;  // Embedded singly linked-list pointer; not owned.
+        Callable* _next;  // Embedded singly linked-list pointer; not owned.
         friend class DynamicWorkQueue;
         friend struct DynamicWorkQueue::Queue;
     };
@@ -81,21 +81,21 @@ public:
 
     /// Add `callable` to the queue, associating it with `session`.
     /// Ownership of `callable` is transfered from the caller to the queue.
-    void add(void const *session, Callable *callable);
+    void add(void const* session, Callable* callable);
 
     /// Remove and `cancel()` any `Callable` objects associated with `session`
     /// from this queue.
-    void cancelQueued(void const *session);
+    void cancelQueued(void const* session);
 
 private:
     // Disable copy-construction and assignment.
-    DynamicWorkQueue(DynamicWorkQueue const &);
-    DynamicWorkQueue &operator=(DynamicWorkQueue const &);
+    DynamicWorkQueue(DynamicWorkQueue const&);
+    DynamicWorkQueue& operator=(DynamicWorkQueue const&);
 
-    static void _startRunner(DynamicWorkQueue &dwq);
+    static void _startRunner(DynamicWorkQueue& dwq);
 
-    typedef std::map<void const *, Queue *> SessionQueueMap;
-    typedef std::set<Queue *, QueuePtrCmp> QueueSet;
+    typedef std::map<void const*, Queue*> SessionQueueMap;
+    typedef std::set<Queue*, QueuePtrCmp> QueueSet;
 
     // Call only while holding a lock on _mutex.
     bool _shouldIncreaseThreadCount() const;

--- a/src/util/FileMonitor.cc
+++ b/src/util/FileMonitor.cc
@@ -81,7 +81,7 @@ void FileMonitor::_checkLoop() {
 
         int i = 0;
         while (i < length) {
-            struct inotify_event *event = (struct inotify_event *)&buffer[i];
+            struct inotify_event* event = (struct inotify_event*)&buffer[i];
             LOGS(_log, LOG_LVL_DEBUG, "FileMonitor inotify event i=" << i << " event len=" << event->len);
             bool reread = false;
             string msg = "FileMonitor::checkLoop got event " + to_string(event->mask);


### PR DESCRIPTION
This would be very short, except clang-format made unrelated changes. The only changes that matter here are in ccontrol.