### PR TITLE
DM-55529: disable clang-format check in CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
           --user-build-image ${{ needs.image-names.outputs.user-build-image }} \
           --pull-image \
           --push-image \
-          --clang-format CHECK \
+          --clang-format OFF \
           -j2
 
   compose-integration-tests:


### PR DESCRIPTION
A new version of `clang-format` has rolled out, and the older one was rotated off the alma distribution servers.  The newer version wants us to make many adjustments throughout the codebase to `*` and `&` alignment.

Turning off clang-format checking for the time being in CI -- after the upcoming DP2 release we will coordinate big-bang reformatting commits on going branches, move to the newer tooling, and re-enable.