### PR TITLE
DM-55665: Use `qserv-xrd` as container base name when building on/from the `xrd` branch.

### DIFF
--- a/deploy/docker/build-user/Dockerfile
+++ b/deploy/docker/build-user/Dockerfile
@@ -12,7 +12,7 @@
 # account in the image. Values are provided at build time via the --build-arg option to `docker build`.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG QSERV_BUILD_BASE=ghcr.io/lsst/qserv-build-base:latest
+ARG QSERV_BUILD_BASE=ghcr.io/lsst/qserv-xrd-build-base:latest
 FROM ${QSERV_BUILD_BASE} AS qserv-build-user
 
 ARG USER

--- a/deploy/docker/run/Dockerfile
+++ b/deploy/docker/run/Dockerfile
@@ -11,7 +11,7 @@
 # can be overridden by passing '--build-arg QSERV_RUN_BASE=...' to 'docker build'.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG QSERV_RUN_BASE=ghcr.io/lsst/qserv-run-base:latest
+ARG QSERV_RUN_BASE=ghcr.io/lsst/qserv-xrd-run-base:latest
 FROM ${QSERV_RUN_BASE} AS qserv
 
 COPY --chown=qserv:qserv bin/ /usr/local/bin/

--- a/python/lsst/qserv/admin/qservCli/opt.py
+++ b/python/lsst/qserv/admin/qservCli/opt.py
@@ -228,15 +228,15 @@ class ImageName:
             The image name
         """
         if self.image == "qserv":
-            return "ghcr.io/lsst/qserv"
+            return "ghcr.io/lsst/qserv-xrd"
         if self.image == "run-base":
-            return "ghcr.io/lsst/qserv-run-base"
+            return "ghcr.io/lsst/qserv-xrd-run-base"
         if self.image == "mariadb":
-            return "ghcr.io/lsst/qserv-mariadb"
+            return "ghcr.io/lsst/qserv-xrd-mariadb"
         if self.image == "build-base":
-            return "ghcr.io/lsst/qserv-build-base"
+            return "ghcr.io/lsst/qserv-xrd-build-base"
         if self.image == "build-user":
-            return f"ghcr.io/lsst/qserv-build-{getpass.getuser()}"
+            return f"ghcr.io/lsst/qserv-xrd-build-{getpass.getuser()}"
         raise RuntimeError(f"Invalid image type: {self.image}")
 
     @property


### PR DESCRIPTION
Since we want to start doing coordinated releases from both `main` and `xrd`, we need distinct container names to avoid clashes/confusion.
