### PR TITLE
DM-55697: backport DM-55691 to `xrd` branch

### DIFF
--- a/src/www/qserv/js/QservMonitoringDashboard.js
+++ b/src/www/qserv/js/QservMonitoringDashboard.js
@@ -226,6 +226,21 @@ function(CSSLoader,
                 } else {
                     Fwk.show('Status', 'Active Queries Monitor');
                 }
+                function updateInstanceId() {
+                    Fwk.web_service_GET(
+                        "/meta/version",
+                        {},
+                        (data) => {
+                            if (data.instance_id) {
+                                $(".navbar-brand").text("Qserv (" + data.instance_id + ")");
+                                document.title = data.instance_id;
+                            }
+                        },
+                        (msg) => { console.log("Failed to load instance ID:", msg); }
+                    );
+                }
+                updateInstanceId();
+                setInterval(updateInstanceId, 10000);
             }
         );
     });

--- a/src/www/qserv/js/QservMonitoringDashboard.js
+++ b/src/www/qserv/js/QservMonitoringDashboard.js
@@ -217,7 +217,7 @@ function(CSSLoader,
             }
         ];
         Fwk.build(
-            'Qserv',
+            'Qserv XRD',
             apps,
             function() {
                 let menus = parseURLParameters();
@@ -232,7 +232,7 @@ function(CSSLoader,
                         {},
                         (data) => {
                             if (data.instance_id) {
-                                $(".navbar-brand").text("Qserv (" + data.instance_id + ")");
+                                $(".navbar-brand").text("Qserv XRD (" + data.instance_id + ")");
                                 document.title = data.instance_id;
                             }
                         },


### PR DESCRIPTION
This backports the instance ID in navbar and browser tab fix to the `xrd` branch.  In addition, the navbar brand on this branch is now "Qserv XRD" instead of just "Qserv".