### PR TITLE
DM-55153: Try to create czar transfer dir and httpczar tmp dirs if missing

### DIFF
--- a/src/czar/Czar.cc
+++ b/src/czar/Czar.cc
@@ -24,6 +24,7 @@
 #include "czar/Czar.h"
 
 // System headers
+#include <filesystem>
 #include <stdexcept>
 #include <sys/time.h>
 #include <thread>
@@ -75,6 +76,7 @@
 #include "util/TimeUtils.h"
 
 using namespace std;
+namespace fs = std::filesystem;
 
 // This macro is used to convert empty strings into "0" in order to avoid
 // problems with calling std::atoi() when the string is empty.
@@ -215,13 +217,25 @@ Czar::Czar(string const& configFilePath, string const& czarName)
     // NOTE: This steps should be done after constructing the query factory where
     //       the name of the Czar gets translated into a numeric identifier.
     _czarConfig->setId(_uqFactory->userQuerySharedResources()->czarId);
-
     auto const czarId = _czarConfig->id();
+
     size_t const MB_SIZE_BYTES = 1024 * 1024;
     size_t maxResultTableSizeBytes = _czarConfig->getMaxTableSizeMB() * MB_SIZE_BYTES;
     size_t maxMemToUse = _czarConfig->getMaxTransferMemMB() * MB_SIZE_BYTES;
     string const transferDirectory = _czarConfig->getTransferDir();
     std::size_t const transferMinBytesInMem = _czarConfig->getTransferMinMBInMem() * MB_SIZE_BYTES;
+
+    std::error_code ec;
+    bool const created = fs::create_directories(transferDirectory, ec);
+    if (ec) {
+        LOGS(_log, LOG_LVL_ERROR,
+             "Failed to create transfer directory " << transferDirectory << ", error: " << ec.message());
+        throw std::system_error(ec, "Failed to create transfer directory " + transferDirectory);
+    }
+    if (created) {
+        LOGS(_log, LOG_LVL_INFO, "Created transfer directory " << transferDirectory);
+    }
+
     mysql::TransferTracker::setup(maxMemToUse, transferDirectory, transferMinBytesInMem,
                                   maxResultTableSizeBytes, czarId);
 
@@ -230,7 +244,6 @@ Czar::Czar(string const& configFilePath, string const& czarName)
     // The id will be used as the high-watermark for queries that need to be cancelled.
     // All queries that have identifiers that are strictly less than this one will
     // be affected by the operation.
-    //
     if (_czarConfig->notifyWorkersOnCzarRestart()) {
         try {
             QueryId lastQId = _lastQueryIdBeforeRestart();

--- a/src/czar/qserv-czar-http.cc
+++ b/src/czar/qserv-czar-http.cc
@@ -24,6 +24,7 @@
  */
 
 // System headers
+#include <filesystem>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
@@ -42,6 +43,7 @@
 #include "czar/HttpCzarSvc.h"
 
 using namespace std;
+namespace fs = std::filesystem;
 namespace po = boost::program_options;
 namespace cconfig = lsst::qserv::cconfig;
 namespace czar = lsst::qserv::czar;
@@ -134,6 +136,7 @@ int main(int argc, char* argv[]) {
         cout << argv[0] << " [options]\n\n" << ::help << "\n\n" << desc << endl;
         return 0;
     }
+
     bool const verbose = vm.count("verbose") > 0;
 
     std::stringstream os;
@@ -155,6 +158,18 @@ int main(int argc, char* argv[]) {
     if (verbose) {
         cout << os.str();
     }
+
+    std::error_code ec;
+    bool const created = fs::create_directories(httpCzarConfig.tmpDir, ec);
+    if (ec) {
+        LOGS(_log, LOG_LVL_ERROR,
+             "Failed to create temporary directory " << httpCzarConfig.tmpDir << ", error: " << ec.message());
+        return EXIT_FAILURE;
+    }
+    if (created) {
+        LOGS(_log, LOG_LVL_INFO, "Created temporary directory " << httpCzarConfig.tmpDir);
+    }
+
     try {
         auto const czar = czar::Czar::createCzar(configFilePath, czarName);
         // Set the user and password for the HTTP service.


### PR DESCRIPTION
Very simple code to call `std::filesystem::create_directories` on these two config-parameterized locations at czar construction and in http czar application `main`.  Deemed helpful in k8s environments where volume mounts will have been arranged, but directories within may not be created on fresh storage deployments.