### PR TITLE
DM-55759: Add ssl-proxy container build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       user-build-image: ${{ steps.image-names.outputs.user-build-image }}
       run-base-image: ${{ steps.image-names.outputs.run-base-image }}
       mariadb-image: ${{ steps.image-names.outputs.mariadb-image }}
+      ssl-proxy-image: ${{ steps.image-names.outputs.ssl-proxy-image }}
       qserv-image: ${{ steps.image-names.outputs.qserv-image }}
 
     steps:
@@ -66,6 +67,7 @@ jobs:
           QSERV_USER_BUILD_IMAGE=$(./bin/qserv env --user-build-image)
           QSERV_RUN_BASE_IMAGE=$(./bin/qserv env --run-base-image)
           QSERV_MARIADB_IMAGE=$(./bin/qserv env --mariadb-image)
+          QSERV_SSL_PROXY_IMAGE=$(./bin/qserv env --ssl-proxy-image)
           QSERV_IMAGE=$(./bin/qserv env --qserv-image)
 
           {
@@ -73,6 +75,7 @@ jobs:
             echo "user-build-image=$QSERV_USER_BUILD_IMAGE"
             echo "run-base-image=$QSERV_RUN_BASE_IMAGE"
             echo "mariadb-image=$QSERV_MARIADB_IMAGE"
+            echo "ssl-proxy-image=$QSERV_SSL_PROXY_IMAGE"
             echo "qserv-image=$QSERV_IMAGE"
           } >> "$GITHUB_OUTPUT"
 
@@ -82,13 +85,14 @@ jobs:
             echo "| Build      | \`$QSERV_BUILD_IMAGE\`      |"
             echo "| Run Base   | \`$QSERV_RUN_BASE_IMAGE\`   |"
             echo "| MariaDB    | \`$QSERV_MARIADB_IMAGE\`    |"
+            echo "| SSL Proxy  | \`$QSERV_SSL_PROXY_IMAGE\`  |"
             echo "| Qserv      | \`$QSERV_IMAGE\`            |"
             echo ""
             echo "To use this build with the helm chart, use the following in \`values.yaml\`:"
             echo "\`\`\`yaml"
             echo "qservImageName: $QSERV_IMAGE"
             echo "mariadbImageName: $QSERV_MARIADB_IMAGE"
-            echo "sslProxyImageName: qserv/mysql-proxy-ssl:latest"
+            echo "sslProxyImageName: $QSERV_SSL_PROXY_IMAGE"
             echo "ingestHelperImageName: $QSERV_BUILD_IMAGE"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -194,6 +198,45 @@ jobs:
             echo "rebuilt=True" >> "$GITHUB_OUTPUT"
           fi
 
+  update-ssl-proxy-image:
+    name: Update SSL proxy image
+    runs-on: ubuntu-22.04
+    needs: image-names
+    steps:
+
+      - name: Install python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+
+      - name: Install python packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install click pyyaml requests
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.7
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # 0 is "all history and branch tags"
+
+      - name: Login to ghcr
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild and push ssl-proxy image if needed
+        run: |
+          if [[ $(./bin/qserv --log-level DEBUG image-exists ${{ needs.image-names.outputs.ssl-proxy-image }}) == "True" ]]; then
+            echo "SSL proxy image already in registry; skipping..."
+          else
+            ./bin/qserv --log-level DEBUG build-ssl-proxy-image --push-image --ssl-proxy-image ${{ needs.image-names.outputs.ssl-proxy-image }}
+          fi
+
   update-run-image:
     name: Update Qserv image
     runs-on: ubuntu-22.04
@@ -250,7 +293,7 @@ jobs:
   compose-integration-tests:
     name: Integration tests (compose)
     runs-on: ubuntu-22.04
-    needs: [image-names, update-mariadb-image, update-run-image]
+    needs: [image-names, update-mariadb-image, update-ssl-proxy-image, update-run-image]
     steps:
 
       - name: Install python

--- a/deploy/docker/ssl-proxy/Dockerfile
+++ b/deploy/docker/ssl-proxy/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.24-alpine3.21 AS build
+
+# Build proxy from source. This is a shallow clone of the repository to avoid downloading the entire history.
+# We clone from a specific SHA (would ideally use a release tag except this upstream repository has none) in
+# order to ensure that the build is reproducible and not affected by changes in the repository.
+
+RUN apk add --no-cache git
+
+RUN git init /tmp/mysql-proxy \
+    && cd /tmp/mysql-proxy/ \
+    && git fetch --depth 1 https://github.com/cppforlife/mysql-proxy 48650d9084fa404bd1d3bac2cc90f254e71ca73b \
+    && git checkout FETCH_HEAD \
+    && go build -v proxy.go
+
+# Second stage of build creates a small image with just base alpine and the compiled binary.
+
+FROM alpine:3.21
+
+COPY --from=build /tmp/mysql-proxy/proxy /usr/local/bin/

--- a/python/lsst/qserv/admin/qservCli/launch.py
+++ b/python/lsst/qserv/admin/qservCli/launch.py
@@ -45,6 +45,7 @@ base_image_build_subdir = "deploy/docker/base"
 user_build_image_subdir = "deploy/docker/build-user"
 run_image_build_subdir = "deploy/docker/run"
 mariadb_image_subdir = "deploy/docker/mariadb"
+ssl_proxy_image_subdir = "deploy/docker/ssl-proxy"
 
 mypy_cfg_file = "pyproject.toml"
 
@@ -646,6 +647,22 @@ def build_mariadb_image(
     )
     if push_image:
         images.push_image(mariadb_image, dry)
+
+
+def build_ssl_proxy_image(
+    ssl_proxy_image: str, qserv_root: str, dry: bool, push_image: bool, pull_image: bool
+) -> None:
+    """Build the ssl-proxy image."""
+    if pull_image and do_pull_image(ssl_proxy_image, dry):
+        return
+    images.build_image(
+        image_name=ssl_proxy_image,
+        run_dir=os.path.join(qserv_root, ssl_proxy_image_subdir),
+        target=None,
+        dry=dry,
+    )
+    if push_image:
+        images.push_image(ssl_proxy_image, dry)
 
 
 def bind_args(qserv_root: str, bind_names: list[str]) -> list[str]:

--- a/python/lsst/qserv/admin/qservCli/opt.py
+++ b/python/lsst/qserv/admin/qservCli/opt.py
@@ -184,8 +184,9 @@ class ImageName:
     user_dockerfile = "deploy/docker/build-user/Dockerfile"
     run_base_dockerfile = "deploy/docker/base/Dockerfile"
     mariadb_dockerfile = "deploy/docker/mariadb/Dockerfile"
+    ssl_proxy_dockerfile = "deploy/docker/ssl-proxy/Dockerfile"
 
-    image_types = ("qserv", "run-base", "mariadb", "build-base", "build-user")
+    image_types = ("qserv", "run-base", "mariadb", "build-base", "build-user", "ssl-proxy")
 
     def __init__(self, image: str):
         if image not in self.image_types:
@@ -237,6 +238,8 @@ class ImageName:
             return "ghcr.io/lsst/qserv-build-base"
         if self.image == "build-user":
             return f"ghcr.io/lsst/qserv-build-{getpass.getuser()}"
+        if self.image == "ssl-proxy":
+            return "ghcr.io/lsst/qserv-ssl-proxy"
         raise RuntimeError(f"Invalid image type: {self.image}")
 
     @property
@@ -273,6 +276,8 @@ class ImageName:
             return [self.base_dockerfile]
         if self.image == "build-user":
             return [self.base_dockerfile, self.user_dockerfile]
+        if self.image == "ssl-proxy":
+            return [self.ssl_proxy_dockerfile]
         raise RuntimeError(f"Invalid image type: {self.image}")
 
 
@@ -306,6 +311,11 @@ env_user_build_image = FlagEnvVal(
     "--user-build-image",
     "QSERV_USER_BUILD_IMAGE",
     ImageName("build-user").tagged_name,
+)
+env_ssl_proxy_image = FlagEnvVal(
+    "--ssl-proxy-image",
+    "QSERV_SSL_PROXY_IMAGE",
+    ImageName("ssl-proxy").tagged_name,
 )
 # qserv root default is derived by the relative path to the qserv folder from
 # the locaiton of this file.
@@ -515,6 +525,7 @@ qserv_env_vals = FlagEnvVals(
         env_user_build_image,
         env_run_base_image,
         env_mariadb_image,
+        env_ssl_proxy_image,
         env_qserv_root,
         env_qserv_build_root,
         env_project,
@@ -603,6 +614,14 @@ option_mariadb_image = partial(
     env_mariadb_image.opt,
     help=env_mariadb_image.help("The name of the mariadb image."),
     default=env_mariadb_image.val(),
+)
+
+
+option_ssl_proxy_image = partial(
+    click.option,
+    env_ssl_proxy_image.opt,
+    help=env_ssl_proxy_image.help("The name of the ssl-proxy image."),
+    default=env_ssl_proxy_image.val(),
 )
 
 

--- a/python/lsst/qserv/admin/qservCli/qserv_cli.py
+++ b/python/lsst/qserv/admin/qservCli/qserv_cli.py
@@ -53,6 +53,7 @@ from .opt import (
     env_ltd_password,
     env_ltd_user,
     env_mariadb_image,
+    env_ssl_proxy_image,
     env_qserv_image,
     env_run_base_image,
     env_user_build_image,
@@ -76,6 +77,7 @@ from .opt import (
     option_make,
     option_mariadb_image,
     option_mypy,
+    option_ssl_proxy_image,
     option_outdir,
     option_project,
     option_pull_image,
@@ -102,6 +104,7 @@ help_order = [
     "build-user-build-image",
     "build-run-base-image",
     "build-mariadb-image",
+    "build-ssl-proxy-image",
     "build-images",
     "build",
     "build-docs",
@@ -148,12 +151,14 @@ def qserv() -> None:
 @click.option(env_user_build_image.opt, is_flag=True)
 @click.option(env_run_base_image.opt, is_flag=True)
 @click.option(env_mariadb_image.opt, is_flag=True)
+@click.option(env_ssl_proxy_image.opt, is_flag=True)
 def show_qserv_environment(
     qserv_image: bool,
     build_image: bool,
     user_build_image: bool,
     run_base_image: bool,
     mariadb_image: bool,
+    ssl_proxy_image: bool,
 ) -> None:
     """Show qserv environment variables and default option values.
 
@@ -171,7 +176,9 @@ def show_qserv_environment(
         click.echo(env_run_base_image.val())
     if mariadb_image:
         click.echo(env_mariadb_image.val())
-    if any((qserv_image, build_image, user_build_image, run_base_image, mariadb_image)):
+    if ssl_proxy_image:
+        click.echo(env_ssl_proxy_image.val())
+    if any((qserv_image, build_image, user_build_image, run_base_image, mariadb_image, ssl_proxy_image)):
         return
     click.echo("Environment variables used for options:")
     click.echo(qserv_env_vals.describe())
@@ -366,6 +373,25 @@ def build_mariadb_image(
     "Build the mariadb image."
     launch.build_mariadb_image(
         mariadb_image=mariadb_image,
+        push_image=push_image,
+        pull_image=pull_image,
+        qserv_root=qserv_root,
+        dry=dry,
+    )
+
+
+@qserv.command()
+@option_ssl_proxy_image(help=env_ssl_proxy_image.help("The name of the ssl-proxy image to create."))
+@option_push_image()
+@option_pull_image()
+@option_qserv_root()
+@option_dry()
+def build_ssl_proxy_image(
+    ssl_proxy_image: str, qserv_root: str, push_image: bool, pull_image: bool, dry: bool
+) -> None:
+    "Build the ssl-proxy image."
+    launch.build_ssl_proxy_image(
+        ssl_proxy_image=ssl_proxy_image,
         push_image=push_image,
         pull_image=pull_image,
         qserv_root=qserv_root,


### PR DESCRIPTION
Previously, this module was built "by hand" by Igor, and posted on dockerhub.

This captures the container Dockerfile into the repo and the build and publishing into CI, and makes management of this container congruent with other containers in the application.  The container will now be posted as a version-tagged build artifact on ghcr, alongside the other application containers.