### PR TITLE
DM-55786: ScanTablePlugin misclassifies `SELECT *` queries

### DIFF
--- a/src/qana/ScanTablePlugin.cc
+++ b/src/qana/ScanTablePlugin.cc
@@ -73,11 +73,10 @@ void ScanTablePlugin::applyFinal(query::QueryContext& context) {
 
 struct getPartitioned : public query::TableRef::FuncC {
     getPartitioned(StringPairVector& sVector_) : sList(sVector_) {}
-    virtual void operator()(query::TableRef const& tRef) {
+    void operator()(query::TableRef const& tRef) override {
         StringPair entry(tRef.getDb(), tRef.getTable());
-        if (found.end() != found.find(entry)) return;
+        if (!found.insert(entry).second) return;
         sList.push_back(entry);
-        found.insert(entry);
     }
     std::set<StringPair> found;
     StringPairVector& sList;
@@ -87,8 +86,8 @@ struct getPartitioned : public query::TableRef::FuncC {
 StringPairVector filterPartitioned(query::TableRefList const& tList) {
     StringPairVector vector;
     getPartitioned gp(vector);
-    for (query::TableRefList::const_iterator i = tList.begin(), e = tList.end(); i != e; ++i) {
-        (**i).apply(gp);
+    for (auto const& tableRef : tList) {
+        tableRef->apply(gp);
     }
     return vector;
 }
@@ -118,12 +117,10 @@ protojson::ScanInfo::Ptr ScanTablePlugin::_findScanTables(query::SelectStmt& stm
     // the presence of a small-valued LIMIT should be enough to
     // de-classify a query as a scanning query.
 
-    bool hasSelectColumnRef = false;  // Requires row-reading for
-                                      // results
+    bool hasSelectColumnRef = false;  // Requires row-reading for results
     bool hasWhereColumnRef = false;   // Makes count(*) non-trivial
-    bool hasSecondaryKey = false;     // Using secondaryKey to restrict
-                                      // coverage, e.g., via objectId=123
-                                      // or objectId IN (123,133) ?
+    bool hasSecondaryKey = false;     // Using secondaryKey to restrict coverage, e.g., via
+                                      // objectId=123 or objectId IN (123,133) ?
 
     if (stmt.hasWhereClause()) {
         query::WhereClause& wc = stmt.getWhereClause();

--- a/src/qana/ScanTablePlugin.cc
+++ b/src/qana/ScanTablePlugin.cc
@@ -153,23 +153,22 @@ protojson::ScanInfo::Ptr ScanTablePlugin::_findScanTables(query::SelectStmt& stm
 #endif
         }
     }
+
     query::SelectList& sList = stmt.getSelectList();
     std::shared_ptr<query::ValueExprPtrVector> sVexpr = sList.getValueExprList();
-
     if (sVexpr) {
+        bool hasStar = false;
         query::ColumnRef::Vector cList;  // For each expr, get column refs.
-
-        typedef query::ValueExprPtrVector::const_iterator Iter;
-        for (Iter i = sVexpr->begin(), e = sVexpr->end(); i != e; ++i) {
-            (*i)->findColumnRefs(cList);
+        for (auto const& ve : *sVexpr) {
+            if (ve->isStar()) {
+                hasStar = true;  // a star reads every column
+                break;
+            }
+            ve->findColumnRefs(cList);
         }
-        // Resolve column refs, see if they include partitioned
-        // tables.
-        typedef query::ColumnRef::Vector::const_iterator ColIter;
-        for (ColIter i = cList.begin(), e = cList.end(); i != e; ++i) {
-            // FIXME: Need to resolve and see if it's a partitioned table.
-            hasSelectColumnRef = true;
-        }
+        // FIXME: Need to resolve and see if it's a partitioned table.
+        // If that happens, then the star check above also needs to be reworked.
+        hasSelectColumnRef = hasStar || !cList.empty();
     }
 
     StringPairVector scanTables;

--- a/src/qproc/testQueryAnaGeneral.cc
+++ b/src/qproc/testQueryAnaGeneral.cc
@@ -48,6 +48,8 @@
 
 // Qserv headers
 #include "ccontrol/ParseRunner.h"
+#include "css/CssAccess.h"
+#include "css/ScanTableParams.h"
 #include "mysql/MySqlConfig.h"
 #include "parser/ParseException.h"
 #include "qdisp/ChunkMeta.h"
@@ -2034,6 +2036,44 @@ BOOST_AUTO_TEST_CASE(NegatedSecondaryKeyPredicateNotUsedAsRestrictor) {
                 qsTest, "SELECT ra_Test FROM LSST.Object WHERE NOT (objectIdObjTest IN (1,2,3))");
         BOOST_CHECK_EQUAL(qs->getError(), "");
         BOOST_CHECK(qs->getSecIdxRestrictors() == nullptr);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(BareStarSelectIsClassifiedAsScan) {
+    qsTest.sqlConfig = SqlConfig(SqlConfig::MockDbTableColumns({{"LSST", {{"Object", {"objectId"}}}}}));
+    qsTest.css = lsst::qserv::css::CssAccess::createFromData(mapBuffer, /*readOnly=*/false);
+    qsTest.css->setScanTableParams("LSST", "Object", lsst::qserv::css::ScanTableParams(true, 1));
+
+    // "SELECT *" with no WHERE
+    {
+        std::shared_ptr<QuerySession> qs =
+                queryAnaHelper.buildQuerySession(qsTest, "SELECT * FROM LSST.Object");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        auto const scanInfo = qs->getScanInfo();
+        BOOST_REQUIRE(scanInfo);
+        BOOST_CHECK_EQUAL(scanInfo->infoTables.size(), 1u);
+        BOOST_CHECK_EQUAL(scanInfo->scanRating, 1);
+    }
+
+    // Column list with no WHERE
+    {
+        std::shared_ptr<QuerySession> qs =
+                queryAnaHelper.buildQuerySession(qsTest, "SELECT objectId FROM LSST.Object");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        auto const scanInfo = qs->getScanInfo();
+        BOOST_REQUIRE(scanInfo);
+        BOOST_CHECK_EQUAL(scanInfo->infoTables.size(), 1u);
+        BOOST_CHECK_EQUAL(scanInfo->scanRating, 1);
+    }
+
+    // COUNT(*) reads no specific columns and has no WHERE, so it's NOT a scan
+    {
+        std::shared_ptr<QuerySession> qs =
+                queryAnaHelper.buildQuerySession(qsTest, "SELECT COUNT(*) FROM LSST.Object");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        auto const scanInfo = qs->getScanInfo();
+        BOOST_REQUIRE(scanInfo);
+        BOOST_CHECK_EQUAL(scanInfo->infoTables.size(), 0u);
     }
 }
 


### PR DESCRIPTION
This is a low-impact bug in the current ScanTablePlugin implementation: when finding `SELECT` column references, a bare `*` does not get counted as a column ref, resulting in the query being misclassified as NOT a scan. The query then lands on the GROUP scheduler and consumes excess resources. This is not an issue in production because the upstream TAP service already fully expands incoming queries before they reach qserv. 

Resolution:
* If a query contains a `SELECT *`, properly classify it as having column refs. We can short circuit the rest of the checks.



