### PR TITLE
DM-55838: Check for NOT / NOT IN when creating SI restrictor

### DIFF
--- a/src/qana/QservRestrictorPlugin.cc
+++ b/src/qana/QservRestrictorPlugin.cc
@@ -615,9 +615,11 @@ std::vector<std::shared_ptr<query::SecIdxRestrictor>> getSecIndexRestrictors(que
     for (auto&& term : andTerm->_terms) {
         auto factor = std::dynamic_pointer_cast<query::BoolFactor>(term);
         if (!factor) continue;
+        if (factor->_hasNot) continue;  // NOT (...) inverts the search; can't restrict
         for (auto factorTerm : factor->_terms) {
             std::shared_ptr<query::SecIdxRestrictor> restrictor;
             if (auto const inPredicate = std::dynamic_pointer_cast<query::InPredicate>(factorTerm)) {
+                if (inPredicate->hasNot) continue;  // NOT IN (...) also can't restrict
                 restrictor = makeSecondaryIndexRestrictor(*inPredicate, context);
             } else if (auto const compPredicate =
                                std::dynamic_pointer_cast<query::CompPredicate>(factorTerm)) {

--- a/src/qproc/testQueryAnaGeneral.cc
+++ b/src/qproc/testQueryAnaGeneral.cc
@@ -1999,6 +1999,44 @@ BOOST_AUTO_TEST_CASE(AngSepNotEqualsAlongsideValidEdgeStillFilters) {
                 actual.find("<>5") != std::string::npos || actual.find("<> 5") != std::string::npos);
 }
 
+BOOST_AUTO_TEST_CASE(NegatedSecondaryKeyPredicateNotUsedAsRestrictor) {
+    qsTest.sqlConfig = SqlConfig(
+            SqlConfig::MockDbTableColumns({{"LSST", {{"Object", {"objectIdObjTest", "ra_Test"}}}}}));
+    qsTest.css = lsst::qserv::css::CssAccess::createFromData(mapBuffer, /*readOnly=*/false);
+
+    // Equality on a director column *should* produce a restrictor (see opposite cases below).
+    {
+        std::shared_ptr<QuerySession> qs = queryAnaHelper.buildQuerySession(
+                qsTest, "SELECT ra_Test FROM LSST.Object WHERE objectIdObjTest = 42");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        BOOST_CHECK(qs->getSecIdxRestrictors() != nullptr);
+    }
+
+    // "col NOT IN (...)" is exclusionary rather than selecting specific values; should not restrict.
+    {
+        std::shared_ptr<QuerySession> qs = queryAnaHelper.buildQuerySession(
+                qsTest, "SELECT ra_Test FROM LSST.Object WHERE objectIdObjTest NOT IN (1,2,3)");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        BOOST_CHECK(qs->getSecIdxRestrictors() == nullptr);
+    }
+
+    // Same as above, but with "NOT (col = ...)"
+    {
+        std::shared_ptr<QuerySession> qs = queryAnaHelper.buildQuerySession(
+                qsTest, "SELECT ra_Test FROM LSST.Object WHERE NOT (objectIdObjTest = 42)");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        BOOST_CHECK(qs->getSecIdxRestrictors() == nullptr);
+    }
+
+    // "NOT (col IN (...))" negates the whole IN via enclosing factor; also should not restrict.
+    {
+        std::shared_ptr<QuerySession> qs = queryAnaHelper.buildQuerySession(
+                qsTest, "SELECT ra_Test FROM LSST.Object WHERE NOT (objectIdObjTest IN (1,2,3))");
+        BOOST_CHECK_EQUAL(qs->getError(), "");
+        BOOST_CHECK(qs->getSecIdxRestrictors() == nullptr);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(DirectorChildSpatialJoin) {
     std::string stmt =
             "select count(*) from LSST.Object o, LSST.Source s "

--- a/src/query/BoolFactor.h
+++ b/src/query/BoolFactor.h
@@ -95,7 +95,7 @@ public:
 
     // FIXME these members should be private, or at least protected. Jira issue DM-17306
     std::vector<std::shared_ptr<BoolFactorTerm>> _terms;
-    bool _hasNot;
+    bool _hasNot = false;
 
 protected:
     /// Serialize this instance to os for debug output.


### PR DESCRIPTION
When we are creating secondary index restrictors, handle negated predicates by checking for NOT / NOT IN. This prevents the query from being optimistically restricted too narrowly and missing matching rows.