### PR TITLE
DM-55862: Implicit `JOIN` support 

### DIFF
--- a/data/case01/queries/1030.1_timeSeries_implicitJoin.sql
+++ b/data/case01/queries/1030.1_timeSeries_implicitJoin.sql
@@ -1,0 +1,14 @@
+-- Variant of 1030_timeSeries.sql using implicit join conditions.
+
+-- pragma noheader
+SELECT s.objectId, s.taiMidPoint, scisql_fluxToAbMag(s.psfFlux)
+FROM   Source AS s
+JOIN   Object AS o
+INNER JOIN Filter AS f
+WHERE  s.objectId = o.objectId
+  AND  s.filterId = f.filterId
+  AND  o.ra_PS BETWEEN 355 AND 360 -- noQserv
+  AND  o.decl_PS BETWEEN 0 AND 20  -- noQserv
+-- withQserv AND qserv_areaspec_box(355, 0, 360, 20)
+  AND  f.filterName = 'g'
+ORDER BY s.objectId, s.taiMidPoint ASC

--- a/data/case01/queries/1104.1_column_disambiguation_implicitJoin.sql
+++ b/data/case01/queries/1104.1_column_disambiguation_implicitJoin.sql
@@ -1,0 +1,7 @@
+-- Variant of 1104_column_disambiguation.sql using an implicit join condition.
+
+-- pragma sortresult
+SELECT Object.htmId20, Source.htmId20
+FROM Object
+JOIN Source
+WHERE Object.objectId = Source.objectId;

--- a/src/ccontrol/HyriseAdapter.cc
+++ b/src/ccontrol/HyriseAdapter.cc
@@ -617,6 +617,10 @@ std::shared_ptr<query::JoinSpec> buildJoinSpec(hsql::JoinDefinition const* join)
         // natural/cross joins have no specification
         return nullptr;
     }
+    if (join->type == hsql::kJoinInner) {
+        // Implicit join (no JOIN ... ON or USING)
+        return nullptr;
+    }
     unsupported("join without ON or USING");
 }
 

--- a/src/ccontrol/HyriseAdapter.cc
+++ b/src/ccontrol/HyriseAdapter.cc
@@ -774,7 +774,12 @@ std::shared_ptr<query::SelectStmt> HyriseAdapter::makeSelectStmt(std::string con
     hsql::SQLParser::parse(sql, &result);
 
     if (!result.isValid() || result.size() == 0) {
-        throw parser::ParseException("Failed to instantiate query: \"" + sql + '"');
+        if (result.errorMsg() != nullptr) {
+            throw parser::ParseException(std::string(result.errorMsg()) + " (line " +
+                                         std::to_string(result.errorLine()) + ", column " +
+                                         std::to_string(result.errorColumn()) + ") in query: \"" + sql + '"');
+        }
+        throw parser::ParseException("no statements found in query: \"" + sql + '"');
     }
 
     if (result.size() > 1) {

--- a/src/ccontrol/testCControl.cc
+++ b/src/ccontrol/testCControl.cc
@@ -71,9 +71,12 @@ static const std::vector<ParseErrorQueryInfo> PARSE_ERROR_QUERIES = {
         // "UNION JOIN" is not expected to parse.
         ParseErrorQueryInfo(
                 "SELECT s1.foo, s2.foo AS s2_foo FROM Source s1 UNION JOIN Source s2 WHERE s1.bar = s2.bar;",
-                "ParseException:Failed to instantiate query: \"SELECT s1.foo, s2.foo AS s2_foo FROM Source "
-                "s1 UNION "
-                "JOIN Source s2 WHERE s1.bar = s2.bar;\""),
+                PARSER_EXPECTED(
+                        "ParseException:syntax error, unexpected JOIN, expecting SELECT or '(' (line 0, "
+                        "column 53) in query: \"SELECT s1.foo, s2.foo AS s2_foo FROM Source s1 UNION JOIN "
+                        "Source s2 WHERE s1.bar = s2.bar;\"",
+                        "ParseException:Failed to instantiate query: \"SELECT s1.foo, s2.foo AS s2_foo FROM "
+                        "Source s1 UNION JOIN Source s2 WHERE s1.bar = s2.bar;\"")),
 
         // The qserv manual says:
         // "Expressions/functions in ORDER BY clauses are not allowed
@@ -89,17 +92,29 @@ static const std::vector<ParseErrorQueryInfo> PARSE_ERROR_QUERIES = {
                         "ParseException:Error parsing query, near \"ABS(iE1_SG)\", qserv does not "
                         "support functions in ORDER BY.")),
 
-        ParseErrorQueryInfo("SELECT foo from Filter f limit 5 garbage query !#$%!#$",
-                            "ParseException:Failed to instantiate query: \"SELECT foo from Filter f limit 5 "
-                            "garbage query !#$%!#$\""),
+        ParseErrorQueryInfo(
+                "SELECT foo from Filter f limit 5 garbage query !#$%!#$",
+                PARSER_EXPECTED("ParseException:syntax error, unexpected IDENTIFIER, expecting end of "
+                                "file (line 0, column 33) in query: \"SELECT foo from Filter f limit 5 "
+                                "garbage query !#$%!#$\"",
+                                "ParseException:Failed to instantiate query: \"SELECT foo from Filter f "
+                                "limit 5 garbage query !#$%!#$\"")),
 
-        ParseErrorQueryInfo("SELECT foo from Filter f limit 5 garbage query !#$%!#$",
-                            "ParseException:Failed to instantiate query: \"SELECT foo from Filter f limit 5 "
-                            "garbage query !#$%!#$\""),
+        ParseErrorQueryInfo(
+                "SELECT foo from Filter f limit 5 garbage query !#$%!#$",
+                PARSER_EXPECTED("ParseException:syntax error, unexpected IDENTIFIER, expecting end of "
+                                "file (line 0, column 33) in query: \"SELECT foo from Filter f limit 5 "
+                                "garbage query !#$%!#$\"",
+                                "ParseException:Failed to instantiate query: \"SELECT foo from Filter f "
+                                "limit 5 garbage query !#$%!#$\"")),
 
-        ParseErrorQueryInfo("SELECT foo from Filter f limit 5; garbage query !#$%!#$",
-                            "ParseException:Failed to instantiate query: \"SELECT foo from Filter f limit 5; "
-                            "garbage query !#$%!#$\""),
+        ParseErrorQueryInfo(
+                "SELECT foo from Filter f limit 5; garbage query !#$%!#$",
+                PARSER_EXPECTED("ParseException:syntax error, unexpected IDENTIFIER, expecting end of "
+                                "file (line 0, column 34) in query: \"SELECT foo from Filter f limit 5; "
+                                "garbage query !#$%!#$\"",
+                                "ParseException:Failed to instantiate query: \"SELECT foo from Filter f "
+                                "limit 5; garbage query !#$%!#$\"")),
 
         ParseErrorQueryInfo(
                 "SELECT count(*) AS n, AVG(ra_PS), AVG(decl_PS), _chunkId FROM Object GROUP BY _chunkId;",
@@ -134,8 +149,12 @@ static const std::vector<ParseErrorQueryInfo> PARSE_ERROR_QUERIES = {
                 "LECT sce.filterName,sce.field "
                 "FROM LSST.Science_Ccd_Exposure AS sce "
                 "WHERE sce.field=535 AND sce.camcol LIKE '%' ",
-                "ParseException:Failed to instantiate query: \"LECT sce.filterName,sce.field "
-                "FROM LSST.Science_Ccd_Exposure AS sce WHERE sce.field=535 AND sce.camcol LIKE '%' \""),
+                PARSER_EXPECTED(
+                        "ParseException:syntax error, unexpected IDENTIFIER, expecting SELECT or '(' (line "
+                        "0, column 0) in query: \"LECT sce.filterName,sce.field FROM "
+                        "LSST.Science_Ccd_Exposure AS sce WHERE sce.field=535 AND sce.camcol LIKE '%' \"",
+                        "ParseException:Failed to instantiate query: \"LECT sce.filterName,sce.field FROM "
+                        "LSST.Science_Ccd_Exposure AS sce WHERE sce.field=535 AND sce.camcol LIKE '%' \"")),
 
         // per testQueryAnaGeneral: CASE in column spec is illegal.
         ParseErrorQueryInfo(

--- a/src/ccontrol/testHyriseGeneratedIR.cc
+++ b/src/ccontrol/testHyriseGeneratedIR.cc
@@ -2382,6 +2382,44 @@ BOOST_DATA_TEST_CASE(hyrise_test, HYRISE_TEST_QUERIES, queryInfo) {
     BOOST_REQUIRE_EQUAL(serializedQuery, expectedSerializedQuery);
 }
 
+static std::vector<std::string> const IMPLICIT_JOIN_QUERIES = {
+        "SELECT * FROM Object o JOIN Source s WHERE o.objectId = s.objectId",
+        "SELECT * FROM Object o INNER JOIN Source s WHERE o.objectId = s.objectId",
+};
+
+BOOST_DATA_TEST_CASE(implicit_join, IMPLICIT_JOIN_QUERIES, sql) {
+    auto selectStatement = ccontrol::ParseRunner::makeSelectStmt(sql);
+    BOOST_REQUIRE(selectStatement != nullptr);
+    auto const& tables = selectStatement->getFromList().getTableRefList();
+    BOOST_REQUIRE_EQUAL(tables.size(), 1);
+    auto const& joins = tables.front()->getJoins();
+    BOOST_REQUIRE_EQUAL(joins.size(), 1);
+    BOOST_CHECK(joins.front()->getJoinType() == query::JoinRef::DEFAULT);
+    BOOST_CHECK(!joins.front()->isNatural());
+    BOOST_CHECK(joins.front()->getSpec() == nullptr);
+    BOOST_CHECK_EQUAL(selectStatement->getQueryTemplate().sqlFragment(),
+                      "SELECT * FROM `Object` AS `o` JOIN `Source` AS `s` WHERE "
+                      "`o`.`objectId`=`s`.`objectId`");
+}
+
+BOOST_AUTO_TEST_CASE(rsp_implicit_join) {
+    auto selectStatement = ccontrol::ParseRunner::makeSelectStmt(
+            "SELECT ut1.objid AS ut1_objid, ut1.ra AS ut1_ra, ut1.dec AS ut1_dec, "
+            "objectId, coord_ra, coord_dec, u_cModelMag, g_cModelMag, r_cModelMag, "
+            "i_cModelMag, z_cModelMag, y_cModelMag "
+            "FROM dp1.Object JOIN TAP_UPLOAD.ut1 AS ut1 "
+            "WHERE CONTAINS(POINT('ICRS', coord_ra, coord_dec), "
+            "CIRCLE('ICRS', ut1.ra, ut1.dec, 0.00027))=1");
+    BOOST_REQUIRE(selectStatement != nullptr);
+    auto const& tables = selectStatement->getFromList().getTableRefList();
+    BOOST_REQUIRE_EQUAL(tables.size(), 1);
+    auto const& joins = tables.front()->getJoins();
+    BOOST_REQUIRE_EQUAL(joins.size(), 1);
+    BOOST_CHECK(joins.front()->getJoinType() == query::JoinRef::DEFAULT);
+    BOOST_CHECK(!joins.front()->isNatural());
+    BOOST_CHECK(joins.front()->getSpec() == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(float_literal_text_preserved) {
     auto selectStatement = ccontrol::ParseRunner::makeSelectStmt(
             "SELECT objectId FROM Object WHERE ra_PS = 0.12345678901234567890123456789");

--- a/src/qproc/testQueryAnaGeneral.cc
+++ b/src/qproc/testQueryAnaGeneral.cc
@@ -1605,6 +1605,37 @@ BOOST_AUTO_TEST_SUITE_END()
 
 /// table JOIN table syntax
 BOOST_FIXTURE_TEST_SUITE(JoinSyntax, QueryAnaFixture)
+BOOST_AUTO_TEST_CASE(ImplicitJoin) {
+    std::vector<std::pair<std::string, std::string>> const joinForms = {
+            {"JOIN", "JOIN"},
+            {"INNER JOIN", PARSER_EXPECTED("JOIN", "INNER JOIN")},
+    };
+    qsTest.sqlConfig = SqlConfig(SqlConfig::MockDbTableColumns(
+            {{"LSST",
+              {{"Object", {"foo", "objectIdObjTest"}}, {"Source", {"ra", "decl", "objectIdSourceTest"}}}}}));
+
+    for (auto const& [inputJoin, expectedJoin] : joinForms) {
+        BOOST_TEST_CONTEXT("join form: " << inputJoin) {
+            std::string const stmt = "SELECT s.ra, s.decl, o.foo FROM Source s " + inputJoin +
+                                     " Object o WHERE s.objectIdSourceTest = o.objectIdObjTest "
+                                     "AND o.objectIdObjTest = 430209694171136;";
+            std::string const expected =
+                    "SELECT `s`.`ra` AS `s.ra`,`s`.`decl` AS `s.decl`,`o`.`foo` AS `o.foo` "
+                    "FROM `LSST`.`Source_100` AS `s` " +
+                    expectedJoin +
+                    " `LSST`.`Object_100` AS `o` "
+                    "WHERE `s`.`objectIdSourceTest`=`o`.`objectIdObjTest` "
+                    "AND `o`.`objectIdObjTest`=430209694171136";
+
+            auto queries = queryAnaHelper.getInternalQueries(qsTest, stmt);
+            BOOST_REQUIRE_EQUAL(queries.size(), 3);
+            BOOST_CHECK_EQUAL(queries[0], expected);
+            BOOST_CHECK(queries[1].empty());
+            BOOST_CHECK(queries[2].empty());
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(NoSpec) {
     std::string stmt =
             "SELECT s1.foo, s2.foo AS s2_foo "

--- a/src/qproc/testQueryAnaGeneral.cc
+++ b/src/qproc/testQueryAnaGeneral.cc
@@ -1439,14 +1439,22 @@ BOOST_AUTO_TEST_CASE(dm681) {
 
     stmt = "SELECT foo from Filter f limit 5 garbage query !#$%!#$";
     stmt2 = "SELECT foo from Filter f limit 5; garbage query !#$%!#$";
-    char const expectedErr[] =
+    char const expectedErr[] = PARSER_EXPECTED(
+            "ParseException:syntax error, unexpected IDENTIFIER, expecting end of file (line 0, column 33) "
+            "in query: \"SELECT foo from Filter f limit 5 garbage query !#$%!#$\"",
             "ParseException:Failed to instantiate query: \"SELECT foo from Filter f limit 5 garbage query "
-            "!#$%!#$\"";
+            "!#$%!#$\"");
+    char const expectedErr2[] = PARSER_EXPECTED(
+            "ParseException:syntax error, unexpected IDENTIFIER, expecting end of file (line 0, column 34) "
+            "in query: \"SELECT foo from Filter f limit 5; garbage query !#$%!#$\"",
+            "ParseException:Failed to instantiate query: \"SELECT foo from Filter f limit 5; garbage query "
+            "!#$%!#$\"");
+
     std::shared_ptr<QuerySession> qs;
     qs = queryAnaHelper.buildQuerySession(qsTest, stmt);
     BOOST_CHECK_EQUAL(qs->getError(), expectedErr);
-    qs = queryAnaHelper.buildQuerySession(qsTest, stmt);
-    BOOST_CHECK_EQUAL(qs->getError(), expectedErr);
+    qs = queryAnaHelper.buildQuerySession(qsTest, stmt2);
+    BOOST_CHECK_EQUAL(qs->getError(), expectedErr2);
 }
 
 BOOST_AUTO_TEST_CASE(FuncExprPred) {
@@ -1538,9 +1546,14 @@ BOOST_AUTO_TEST_CASE(Garbled) {
             "FROM LSST.Science_Ccd_Exposure AS sce "
             "WHERE sce.field=535 AND sce.camcol LIKE '%' ";
     std::shared_ptr<QuerySession> qs = queryAnaHelper.buildQuerySession(qsTest, stmt);
-    BOOST_CHECK_EQUAL(qs->getError(),
-                      "ParseException:Failed to instantiate query: \"LECT sce.filterName,sce.field "
-                      "FROM LSST.Science_Ccd_Exposure AS sce WHERE sce.field=535 AND sce.camcol LIKE '%' \"");
+    BOOST_CHECK_EQUAL(
+            qs->getError(),
+            PARSER_EXPECTED(
+                    "ParseException:syntax error, unexpected IDENTIFIER, expecting SELECT or '(' (line 0, "
+                    "column 0) in query: \"LECT sce.filterName,sce.field FROM LSST.Science_Ccd_Exposure AS "
+                    "sce WHERE sce.field=535 AND sce.camcol LIKE '%' \"",
+                    "ParseException:Failed to instantiate query: \"LECT sce.filterName,sce.field FROM "
+                    "LSST.Science_Ccd_Exposure AS sce WHERE sce.field=535 AND sce.camcol LIKE '%' \""));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The [Hyrise parser](https://github.com/lsst/hyrise-sql-parser/tree/qserv-compat) (link to our compatibility branch -- the main change is there) Bison grammar does not support implicit joins like the following:

```
SELECT * FROM customers c, orders o WHERE c.id = o.customer_id;
```
and instead requires the more modern form:
```
SELECT * FROM customers c JOIN orders o ON c.id = o.customer_id;
```
So a query without `JOIN … ON`  or `JOIN … USING` will fail to parse. 

This PR points at an updated hyrise submodule that supports this `JOIN` syntax and updates the Hyrise adapter to incorporate the change. New unit and integration tests were added to catch this discrepancy in the future.

**NOTE**: the other type of implicit join, or "comma join" that implies a cartesian product (e.g., `SELECT *
FROM students, courses;`) was and still is supported by the parser.