### PR TITLE
DM-55892: Guides for AI coding agents

### DIFF
--- a/.claude/skills/build-qserv/SKILL.md
+++ b/.claude/skills/build-qserv/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: build-qserv
+description: Build Qserv C++/Python in its containerized build environment, run unit tests, clang-format, mypy, and build docs. Use for any compile/test/format task in the qserv repo.
+---
+
+# Building and unit-testing Qserv
+
+All compilation happens inside Docker containers driven by the host-side `./bin/qserv`
+CLI (Python 3 + `click pyyaml requests`, Docker required). Never attempt a bare-metal
+cmake build; system deps only exist in the build image. Image names derive from
+`git describe`, so a dirty tree changes tags — that is normal.
+
+## One-time setup
+
+```sh
+git submodule update --init          # extern/sphgeom, extern/log, extern/hyrise-sql-parser
+./bin/qserv env                      # show image names + env var overrides (QSERV_*)
+./bin/qserv build-user-build-image   # make the per-user build image (fast; wraps GHCR build image)
+```
+
+If the base/build images are missing locally they are pulled from GHCR
+(`ghcr.io/lsst/qserv-build-base:...`); only run `./bin/qserv build-images` if the
+Dockerfiles under `deploy/docker/` changed.
+
+## The standard build + unit test cycle
+
+```sh
+./bin/qserv build -j8 --no-build-image        # cmake (if needed) + make install + unit tests
+./bin/qserv build -j8                         # same, then also packages the qserv run image
+```
+
+Useful toggles: `--no-unit-test`, `--no-mypy`, `--cmake/--no-cmake` (force/skip cmake),
+`--clang-format CHECK|REFORMAT|OFF` (CI uses CHECK; use REFORMAT to fix formatting),
+`--dry` to print the docker commands without running.
+
+Build artifacts land in `build/` at the repo root; `rm -rf build/` is the fix for
+mysterious cmake-state errors.
+
+## Fast iteration
+
+```sh
+./bin/qserv run-build        # interactive shell in the build container, repo mounted
+# then inside:
+make -j8 install             # incremental
+make -j8 install test ARGS=-j8   # with unit tests (CTest)
+ctest -R testQueryAna -j4    # run a single test suite from the build dir
+```
+
+Unit tests are Boost.Test binaries registered with CTest (`test*.cc` in each
+`src/<module>/`). To add one, follow the `add_executable`/`add_test` pattern in the
+module's `CMakeLists.txt`.
+
+## Lint / format only
+
+```sh
+./bin/qserv build --no-make --no-mypy --clang-format REFORMAT   # just reformat C++
+ruff check python/ bin/       # if ruff available on host; config in pyproject.toml (line length 110)
+```
+
+## Docs
+
+```sh
+tox -e docs                  # sphinx via documenteer; warnings are errors
+# or: ./bin/qserv build-docs
+```
+
+Output: `build/doc/html`. Note `doc/architecture/*.md` is intentionally excluded from
+the sphinx build (see `doc/conf.py` exclude_patterns).

--- a/.claude/skills/deploy-qserv/SKILL.md
+++ b/.claude/skills/deploy-qserv/SKILL.md
@@ -13,9 +13,11 @@ hold catalog data that takes **days to weeks** to re-ingest. Before proposing an
 change, confirm it cannot cause Kubernetes or Argo CD to delete, recreate, or orphan
 those PVCs:
 
-- Renaming the chart, release, StatefulSet, or volumeClaimTemplate changes generated
-  PVC names → new empty volumes get bound and the old ones are stranded (or reclaimed,
-  depending on the StorageClass reclaim policy).
+- Renaming the chart, a StatefulSet, or a volumeClaimTemplate changes generated PVC
+  names → new empty volumes get bound and the old ones are stranded (or reclaimed,
+  depending on the StorageClass reclaim policy). STS names derive from the **chart
+  name**, not the Helm release name, so a release rename keeps PVC names — but it
+  changes the immutable selector labels and forces an STS delete/recreate.
 - Most `volumeClaimTemplates` spec fields are immutable; changes there force STS
   delete/recreate.
 - Argo CD prune/auto-sync could delete resources removed from the rendered chart. Sync
@@ -42,8 +44,10 @@ to existing PVCs.
 3. **Deployment config.** `qserv-deployments` repo (a separate git repo,
    conventionally checked out as a sibling: `../qserv-deployments/`; see its
    AGENTS.md): `deployments/usdf-qserv-{dev,int,prod}/application.yaml` pins chart
-   `targetRevision`; `values.yaml` pins image names, replica counts, storage
-   class/size, node tiers, and the external LoadBalancer. Update by PR to that repo.
+   `targetRevision`; `values.yaml` overrides node tiers, replica counts, ingest
+   enablement, and the external LoadBalancer. Image names and storage class/size come
+   from the chart's own `values.yaml`, pinned per chart release — the deployments
+   deliberately no longer override images. Update by PR to that repo.
 4. **Argo CD.** Watches `qserv-deployments` `main`. A human performs the sync in the
    Argo CD UI/CLI (manual by design). Rollout order matters: smig Jobs
    (`*-smig-job.yaml`) migrate DB schemas; StatefulSets restart pods against the

--- a/.claude/skills/deploy-qserv/SKILL.md
+++ b/.claude/skills/deploy-qserv/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: deploy-qserv
+description: Qserv release and deployment workflow — version tags, GHCR images, the Helm chart, qserv-deployments values, and Argo CD at USDF. Use for any release, chart, values, or deployment-config task. Contains the mandatory PVC safety checklist.
+---
+
+# Releasing and deploying Qserv
+
+## ⚠️ PVC safety checklist — read before ANY chart or deployment change
+
+The StatefulSets (`worker`, `czar`, `repl` in `deploy/helm/templates/*-sts.yaml`)
+create PVCs from `volumeClaimTemplates` (`worker-data-qserv-worker-N`, etc.). Those PVs
+hold catalog data that takes **days to weeks** to re-ingest. Before proposing any
+change, confirm it cannot cause Kubernetes or Argo CD to delete, recreate, or orphan
+those PVCs:
+
+- Renaming the chart, release, StatefulSet, or volumeClaimTemplate changes generated
+  PVC names → new empty volumes get bound and the old ones are stranded (or reclaimed,
+  depending on the StorageClass reclaim policy).
+- Most `volumeClaimTemplates` spec fields are immutable; changes there force STS
+  delete/recreate.
+- Argo CD prune/auto-sync could delete resources removed from the rendered chart. Sync
+  is intentionally **manual** — never suggest enabling auto-sync or running a prune
+  without explicit human sign-off naming the resources to be pruned.
+- `helm uninstall` / namespace deletion do not delete PVCs by default, but cluster
+  policy or manual cleanup afterwards can. Treat PVC deletion as unrecoverable.
+
+Flag the risk explicitly in any PR/plan that touches these files, and say what happens
+to existing PVCs.
+
+## The pipeline
+
+1. **Code → images.** Every push runs `.github/workflows/ci.yml`, which (re)builds only
+   missing images and publishes `ghcr.io/lsst/qserv:<git-describe>` plus
+   `qserv-mariadb`, `qserv-build-base`, `qserv-run-base`, ssl-proxy images. Release
+   versions come from annotated tags like `2026.8.1-rc2`; between tags the version is
+   `<tag>-<n>-g<sha>` from `git describe`. The CI job summary prints ready-to-paste
+   `values.yaml` image names.
+2. **Chart.** The chart source is `deploy/helm/` (`Chart.yaml` version is set as part
+   of the release process); the packaged chart is consumed from `ghcr.io/lsst/charts`
+   as OCI. Note: no workflow in this repo pushes the chart (verified 2026-08) — the
+   publish step happens outside this repo; ask before assuming how it runs.
+3. **Deployment config.** `qserv-deployments` repo (a separate git repo,
+   conventionally checked out as a sibling: `../qserv-deployments/`; see its
+   AGENTS.md): `deployments/usdf-qserv-{dev,int,prod}/application.yaml` pins chart
+   `targetRevision`; `values.yaml` pins image names, replica counts, storage
+   class/size, node tiers, and the external LoadBalancer. Update by PR to that repo.
+4. **Argo CD.** Watches `qserv-deployments` `main`. A human performs the sync in the
+   Argo CD UI/CLI (manual by design). Rollout order matters: smig Jobs
+   (`*-smig-job.yaml`) migrate DB schemas; StatefulSets restart pods against the
+   migrated schemas.
+
+## Topology reference (what a deployment looks like)
+
+- `qserv-czar` STS: containers `mariadb` (result tables + qmeta/css), `mysql-proxy`
+  (port 14040, SQL frontend), `czar-http` (port 4048, HTTP/REST frontend). PVC `czar-data`.
+- `qserv-worker` STS ×N: `mariadb` (chunk data), `worker-svc` (`qserv-worker-http`,
+  port 25010), `repl-worker` (`qserv-replica-worker`). PVC `worker-data`.
+- `qserv-repl` STS: `mariadb` (replication config/state DB) + `repl-controller`
+  (`qserv-replica-master-http`, port 25081). PVC `repl-data`.
+- `qserv-registry` Deployment (`qserv-replica-registry`, port 25082): service
+  discovery for workers/czars.
+- Optional `ingest` STS and `czar-external-svc` (MetalLB LoadBalancer at USDF).
+- Environment presets also exist in-repo: `deploy/helm/environments/usdf-{dev,int,prod}.yaml`
+  (the qserv-deployments values are the ones actually deployed).
+
+## Local sanity checks for chart changes
+
+```sh
+helm template deploy/helm -f ../qserv-deployments/deployments/usdf-qserv-dev/values.yaml > /tmp/rendered.yaml
+helm lint deploy/helm
+# then diff rendered output before/after your change; scrutinize anything touching
+# volumeClaimTemplates, StatefulSet names, or labels/selectors.
+```

--- a/.claude/skills/deploy-qserv/SKILL.md
+++ b/.claude/skills/deploy-qserv/SKILL.md
@@ -53,19 +53,9 @@ to existing PVCs.
    (`*-smig-job.yaml`) migrate DB schemas; StatefulSets restart pods against the
    migrated schemas.
 
-## Topology reference (what a deployment looks like)
-
-- `qserv-czar` STS: containers `mariadb` (result tables + qmeta/css), `mysql-proxy`
-  (port 14040, SQL frontend), `czar-http` (port 4048, HTTP/REST frontend). PVC `czar-data`.
-- `qserv-worker` STS ×N: `mariadb` (chunk data), `worker-svc` (`qserv-worker-http`,
-  port 25010), `repl-worker` (`qserv-replica-worker`). PVC `worker-data`.
-- `qserv-repl` STS: `mariadb` (replication config/state DB) + `repl-controller`
-  (`qserv-replica-master-http`, port 25081). PVC `repl-data`.
-- `qserv-registry` Deployment (`qserv-replica-registry`, port 25082): service
-  discovery for workers/czars.
-- Optional `ingest` STS and `czar-external-svc` (MetalLB LoadBalancer at USDF).
-- Environment presets also exist in-repo: `deploy/helm/environments/usdf-{dev,int,prod}.yaml`
-  (the qserv-deployments values are the ones actually deployed).
+Deployment topology (StatefulSets, containers, ports, PVCs, optional services) is
+documented in `doc/architecture/deployment.md` — read it there rather than
+duplicating it here.
 
 ## Local sanity checks for chart changes
 

--- a/.claude/skills/itest/SKILL.md
+++ b/.claude/skills/itest/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: itest
+description: Run Qserv integration tests — launch the docker-compose test cluster, run query-correctness suites (itest), HTTP frontend tests, and ingest tests, then tear down. Use when verifying end-to-end behavior.
+---
+
+# Qserv integration tests
+
+Integration tests run real queries against a small docker-compose Qserv cluster
+(2 workers, czar with both frontends, replication controller/registry, MariaDB
+instances — see `deploy/compose/docker-compose.yml`) and compare results against a
+plain reference MySQL loaded with the same data. Datasets and expected outputs live in
+`data/case01..case04`, `data/test101`; the runner is
+`python/lsst/qserv/admin/cli/_integration_test.py` driven through the in-container
+`entrypoint` CLI.
+
+Requires: docker + docker-compose, the qserv and mariadb images (built by
+`/build-qserv` or pulled from GHCR; pass `--qserv-image`/`--mariadb-image` or set
+`QSERV_IMAGE`/`QSERV_MARIADB_IMAGE` to use specific ones).
+
+## Workflow
+
+```sh
+./bin/qserv up                 # start the compose cluster (give it ~1-3 min to settle)
+docker ps -a                   # sanity check: all containers up, none restarting
+
+./bin/qserv itest              # classic path: load test datasets, run per-case queries,
+                               #   compare qserv vs reference MySQL results
+./bin/qserv itest-http --reload --load-http   # same suites through the HTTP frontend
+./bin/qserv itest-http-ingest  # user-table ingest via the HTTP frontend
+
+./bin/qserv itest-rm           # remove integration-test data volumes
+./bin/qserv down -v            # stop cluster and remove its volumes
+```
+
+- `itest` accepts `--case caseNN` (repeatable) to run a subset, `--tests-yaml` for an
+  alternate test config (default `etc/integration_tests.yaml`), and
+  `--reload`/`--load`/`--unload` for dataset management — see `./bin/qserv itest --help`.
+- Test queries are `data/caseNN/queries/*.sql`; a failing comparison prints the
+  difference between qserv and reference outputs. Add new cases by extending a case's
+  `queries/` + expected data rather than inventing a new harness.
+- On failure, container logs are the first stop:
+  `docker logs $USER-czar-proxy-1`, `$USER-czar-http-1`, `$USER-worker-svc-{0,1}-1`,
+  `$USER-repl-controller-1` (names are prefixed with `$USER`, suffixed `-1` by compose).
+- CI runs exactly this sequence (`.github/workflows/ci.yml`), so a green local run is a
+  good predictor.
+
+Compose state is per-user (project name includes `$USER`), so parallel checkouts don't
+collide, but only one cluster per user at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,10 @@ fastest way to orient before touching unfamiliar subsystems.
   Qserv on Kubernetes. Never propose or perform chart changes, StatefulSet
   renames/deletions, `helm uninstall`, Argo CD sync/prune operations, or namespace
   deletions that could collaterally delete or orphan these PVCs without explicitly
-  flagging the risk and getting human confirmation. Note that renaming the chart or a
-  StatefulSet changes the generated PVC names, which strands or recreates volumes
-  (STS names derive from the chart name, so a Helm release rename keeps PVC names —
-  but it changes immutable selector labels and still forces an STS delete/recreate).
-  Argo CD sync is intentionally **manual** for this reason.
+  flagging the risk and getting human confirmation. Renames are dangerous even when
+  nothing is deleted: chart/StatefulSet renames change the generated PVC names, and
+  even a release rename forces an STS recreate. Argo CD sync is intentionally
+  **manual** for this reason. Mechanics in `doc/architecture/deployment.md`.
 - **Trust the code over `doc/`:** Most of `doc/` is severely dated. The exceptions,
   which are current and trustworthy, are the user-guide sections *Asynchronous Query
   API* (`doc/user/async.rst`), *HTTP Frontend* (`doc/user/http-frontend*.rst`), and
@@ -84,10 +83,9 @@ git submodule update --init                 # once, after clone
   container runs them (`ARGS=-jN` parallelizes). A single suite can be run from the
   build dir, e.g. `ctest -R testCss`.
 - Formatting is enforced: clang-format via `src/.clang-format` (Google-based, 110 cols,
-  4-space indent, includes NOT sorted) —
-  `qserv build` fails in CI with `--clang-format CHECK`; use `--clang-format REFORMAT`
-  locally. Python: ruff (line length 110, py312) and strict-ish mypy — configs in
-  `pyproject.toml`.
+  4-space indent, includes NOT sorted); CI runs `--clang-format CHECK`, use
+  `--clang-format REFORMAT` locally. Python: ruff (line length 110, py312) and
+  strict-ish mypy — configs in `pyproject.toml`.
 - Docs build: `tox -e docs` (sphinx/documenteer, warnings are errors).
 
 ## Conventions
@@ -109,11 +107,9 @@ git submodule update --init                 # once, after clone
 
 ## Deployments (context, not something to do casually)
 
-USDF deployments (dev/int/prod) are Argo CD Applications defined in the
-`qserv-deployments` repo; each points at the published Helm chart
-(`ghcr.io/lsst/charts/qserv`) plus a per-deployment `values.yaml`. Release flow: push a
-tag like `2026.8.1-rc2` → CI publishes images `ghcr.io/lsst/qserv*:<git-describe>` →
-chart is published to `ghcr.io/lsst/charts` → bump `targetRevision`/image names in
-`qserv-deployments` → human syncs in Argo CD (sync is deliberately manual). See
-`doc/architecture/deployment.md` before touching any of this, and re-read the PVC
-caution above.
+USDF deployments (dev/int/prod) are Argo CD Applications in the `qserv-deployments`
+repo, each pinning a published chart version (`ghcr.io/lsst/charts/qserv`, which
+carries matching image tags) plus per-deployment values. Release flow: push a tag like
+`2026.8.1-rc2` → CI publishes images → chart published to `ghcr.io/lsst/charts` →
+bump `targetRevision` in qserv-deployments → human syncs in Argo CD (deliberately
+manual). See `doc/architecture/deployment.md` first, and re-read the PVC caution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,11 @@ fastest way to orient before touching unfamiliar subsystems.
   Qserv on Kubernetes. Never propose or perform chart changes, StatefulSet
   renames/deletions, `helm uninstall`, Argo CD sync/prune operations, or namespace
   deletions that could collaterally delete or orphan these PVCs without explicitly
-  flagging the risk and getting human confirmation. Note that renaming a release,
-  chart, or StatefulSet changes the generated PVC names, which strands or recreates
-  volumes. Argo CD sync is intentionally **manual** for this reason.
+  flagging the risk and getting human confirmation. Note that renaming the chart or a
+  StatefulSet changes the generated PVC names, which strands or recreates volumes
+  (STS names derive from the chart name, so a Helm release rename keeps PVC names —
+  but it changes immutable selector labels and still forces an STS delete/recreate).
+  Argo CD sync is intentionally **manual** for this reason.
 - **Trust the code over `doc/`:** Most of `doc/` is severely dated. The exceptions,
   which are current and trustworthy, are the user-guide sections *Asynchronous Query
   API* (`doc/user/async.rst`), *HTTP Frontend* (`doc/user/http-frontend*.rst`), and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# Qserv — guide for AI coding agents
+
+Qserv is a petascale, shared-nothing, distributed SQL database (MPP) built to host the
+astronomical catalogs of Rubin Observatory's LSST survey. A **czar** frontend parses and
+analyzes each incoming SQL query, rewrites it into per-chunk queries, and dispatches them
+over HTTP to **workers** that each hold a shard ("chunks") of the data in a colocated
+MariaDB; the czar then collects per-worker result files and merges/aggregates them into a
+result table. A separate **replication/ingest system** (controller + registry + per-worker
+daemons) manages data placement, replication, and catalog ingest.
+
+Read `doc/architecture/README.md` for the system overview and a map of the deeper
+architecture docs (query lifecycle, worker internals, replication/ingest, metadata
+stores, deployment, build/test). These docs are current as of 2026-08 and are the
+fastest way to orient before touching unfamiliar subsystems.
+
+## Critical cautions
+
+- **PVC safety (operations/deployment work):** The Helm chart's StatefulSets create PVCs
+  via `volumeClaimTemplates` (`worker-data`, `czar-data`, `repl-data`). The persistent
+  volumes behind them hold catalog data that takes **days to weeks** to re-ingest.
+  Inadvertent release of these PVCs is the single largest operational risk of running
+  Qserv on Kubernetes. Never propose or perform chart changes, StatefulSet
+  renames/deletions, `helm uninstall`, Argo CD sync/prune operations, or namespace
+  deletions that could collaterally delete or orphan these PVCs without explicitly
+  flagging the risk and getting human confirmation. Note that renaming a release,
+  chart, or StatefulSet changes the generated PVC names, which strands or recreates
+  volumes. Argo CD sync is intentionally **manual** for this reason.
+- **Trust the code over `doc/`:** Most of `doc/` is severely dated. The exceptions,
+  which are current and trustworthy, are the user-guide sections *Asynchronous Query
+  API* (`doc/user/async.rst`), *HTTP Frontend* (`doc/user/http-frontend*.rst`), and
+  *Ingesting Catalogs* (`doc/ingest/`). Everything else: verify against the code.
+  Updating stale docs alongside code changes is encouraged.
+- **XRootD is gone:** older docs/comments reference XRootD/SSI for czar–worker
+  communication. That was removed (2025/2026); all czar↔worker traffic is now HTTP +
+  JSON (`src/protojson/`) with results pulled as files over HTTP.
+- **`qana/RelationGraph.h`** contains a long, authoritative comment on how Qserv decides
+  whether a query is evaluable (join admissibility, overlap, query rewriting). Read it
+  before touching query analysis (`src/qana/`, `src/qproc/`).
+
+## Repository map
+
+| Path | Contents |
+| --- | --- |
+| `src/` | C++ sources, one directory per module (see below) |
+| `python/lsst/qserv/` | Python tooling: `admin/` (CLI, in-container entrypoint), `schema/` (smig migrations), `testing/` (kraken load tester) |
+| `bin/` | Host-side CLIs: `qserv` (build/test driver), `entrypoint` (in-container), `qserv-smig`, `qserv-kraken` |
+| `deploy/` | `docker/` (image Dockerfiles), `compose/` (dev/CI test cluster), `helm/` (the Qserv chart) |
+| `doc/` | Sphinx docs (published to qserv.lsst.io; mostly dated — see cautions). `doc/architecture/` holds current agent/developer architecture notes (markdown, not published) |
+| `data/` | Integration-test datasets and reference query results (`case01`…, `test101`) |
+| `extern/` | Git submodules: `sphgeom`, `log`, `hyrise-sql-parser` — run `git submodule update --init` after clone |
+| `../qserv-deployments/` | Separate repo (github.com/lsst/qserv-deployments), conventionally checked out as a sibling of this one: Argo CD Applications + per-deployment Helm values. It has its own AGENTS.md |
+
+C++ module prefixes: modules starting with `w` are worker-side (`wbase`, `wcomms`,
+`wconfig`, `wcontrol`, `wdb`, `wmain`, `wpublish`, `wsched`); czar-side query processing
+is `ccontrol` (user query orchestration), `parser`/`query` (SQL → IR), `qana` (analysis
+plugins), `qproc` (chunking/templates), `qdisp` (dispatch/UberJobs), `rproc` (result
+merge), `czar` (service + HTTP frontend). Shared: `css` (global table metadata), `qmeta`
+(query metadata), `cconfig`/`global`/`util`/`http`/`qhttp`/`mysql`/`sql`/`protojson`.
+`replica/` is the replication/ingest control plane (largest module). `partition/` is the
+offline data partitioner (`sph-partition` etc.). `www/` is the web dashboard.
+
+## Build, test, lint
+
+Everything builds **inside containers** via the host-side `./bin/qserv` CLI (needs
+Python 3 with `click`, `pyyaml`, `requests`, plus Docker). There is no supported
+bare-metal build. Image names are derived from `git describe` (see `qserv env`).
+
+```sh
+git submodule update --init                 # once, after clone
+./bin/qserv build-images                    # build base/build images (slow, rarely needed — CI reuses GHCR)
+./bin/qserv build-user-build-image          # personalized build image (once per user)
+./bin/qserv build -j8                       # cmake+make+unit tests+clang-format, then package qserv image
+./bin/qserv build -j8 --no-build-image      # compile + unit tests only, skip image packaging
+./bin/qserv run-build                       # shell inside build container; then: make -j8 install test
+./bin/qserv up / down [-v]                  # start/stop docker-compose test cluster
+./bin/qserv itest                           # integration tests (query correctness vs reference MySQL)
+./bin/qserv itest-http / itest-http-ingest  # HTTP frontend / user-table ingest integration tests
+./bin/qserv itest-rm                        # remove integration test volumes
+```
+
+- C++ unit tests are Boost.Test binaries wired into CTest; `make test` inside the build
+  container runs them (`ARGS=-jN` parallelizes). A single suite can be run from the
+  build dir, e.g. `ctest -R testCss`.
+- Formatting is enforced: clang-format via `src/.clang-format` (Google-based, 110 cols,
+  4-space indent, includes NOT sorted) —
+  `qserv build` fails in CI with `--clang-format CHECK`; use `--clang-format REFORMAT`
+  locally. Python: ruff (line length 110, py312) and strict-ish mypy — configs in
+  `pyproject.toml`.
+- Docs build: `tox -e docs` (sphinx/documenteer, warnings are errors).
+
+## Conventions
+
+- Branches: `tickets/DM-NNNNN` matching a Rubin Jira ticket
+  (https://rubinobs.atlassian.net/browse/DM-NNNNN). CI (`rebase_checker`) rejects PRs
+  that merge `main` into the ticket branch — rebase instead.
+- Commit subjects: short, imperative. PRs merge into `main`.
+- C++20 (`set(CMAKE_CXX_STANDARD 20)`): follow surrounding style. LSST-ish naming: private members
+  `_underscorePrefixed`, classes `UpperCamel`, methods `lowerCamel`. Logging via
+  `LOGS(_log, LOG_LVL_*, ...)` (lsst/log). Doxygen-style `///` comments on public APIs.
+- Every C++ file gets the GPL header block; keep module-local `#include` grouping
+  (system / third-party / LSST / Qserv) as in existing files.
+- Config values flow through `cconfig::CzarConfig` / `wconfig::WorkerConfig`
+  (`util::ConfigValMap`) — add new tunables there, not ad-hoc.
+- Schema changes to the czar/worker/replication MySQL databases require a smig
+  migration: add `migrate-N-to-N+1.sql` under `python/lsst/qserv/schema/migrations/{czar,worker,repl}/`
+  and bump the expected version in the matching code.
+
+## Deployments (context, not something to do casually)
+
+USDF deployments (dev/int/prod) are Argo CD Applications defined in the
+`qserv-deployments` repo; each points at the published Helm chart
+(`ghcr.io/lsst/charts/qserv`) plus a per-deployment `values.yaml`. Release flow: push a
+tag like `2026.8.1-rc2` → CI publishes images `ghcr.io/lsst/qserv*:<git-describe>` →
+chart is published to `ghcr.io/lsst/charts` → bump `targetRevision`/image names in
+`qserv-deployments` → human syncs in Argo CD (sync is deliberately manual). See
+`doc/architecture/deployment.md` before touching any of this, and re-read the PVC
+caution above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,9 @@
 
 # Claude Code specifics
 
-- Project skills live in `.claude/skills/`: `build-qserv` (containerized build/unit-test
-  loop), `itest` (integration test cluster + suites), `deploy-qserv` (release → images →
-  chart → qserv-deployments → Argo CD, with the PVC safety checklist). Prefer invoking
-  the relevant skill over reconstructing those workflows from scratch.
+- Prefer the project skills (`build-qserv`, `itest`, `deploy-qserv`) over
+  reconstructing those workflows from scratch; `deploy-qserv` carries the mandatory
+  PVC safety checklist.
 - When exploring large subsystems (`src/replica/` especially), delegate broad reads to
   subagents to protect context; the architecture docs in `doc/architecture/` usually
   answer structural questions without a code sweep.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+@AGENTS.md
+
+# Claude Code specifics
+
+- Project skills live in `.claude/skills/`: `build-qserv` (containerized build/unit-test
+  loop), `itest` (integration test cluster + suites), `deploy-qserv` (release → images →
+  chart → qserv-deployments → Argo CD, with the PVC safety checklist). Prefer invoking
+  the relevant skill over reconstructing those workflows from scratch.
+- When exploring large subsystems (`src/replica/` especially), delegate broad reads to
+  subagents to protect context; the architecture docs in `doc/architecture/` usually
+  answer structural questions without a code sweep.

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -1,0 +1,115 @@
+# Qserv architecture notes
+
+*Developer/agent-oriented architecture documentation, written 2026-08 from direct code
+inspection. These files are deliberately **not** part of the published Sphinx guide
+(see `exclude_patterns` in `doc/conf.py`); unlike much of the rest of `doc/`, they are
+current — but the code always wins. Please update them alongside code changes.*
+
+| Doc | Covers |
+| --- | --- |
+| [query-lifecycle.md](query-lifecycle.md) | SQL in → merged results out: frontends, parsing, IR, analysis plugins, chunking, dispatch, merging, async queries |
+| [worker.md](worker.md) | Worker internals: task building, shared-scan scheduling, subchunk handling, result files, worker↔czar status protocol |
+| [replication-ingest.md](replication-ingest.md) | The replication/ingest control plane: controller, registry, replica workers, ingest transactions, director index |
+| [metadata-and-state.md](metadata-and-state.md) | Who stores what: CSS, QMeta, worker inventory, replication DB, director index, smig migrations |
+| [deployment.md](deployment.md) | Images, compose, Helm chart, qserv-deployments/Argo CD, **the PVC hazard** |
+| [build-and-test.md](build-and-test.md) | Containerized build, test layers, CI, release versioning |
+
+## What Qserv is
+
+Qserv is a shared-nothing MPP SQL database for Rubin Observatory's LSST catalogs.
+The design bet: astronomical catalogs are read-mostly, spatially partitionable, and
+queried either by small regions/objects (interactive) or by full-sky scans (batch).
+So: partition every large table spherically into **chunks** (and chunks into
+**subchunks**, materialized on demand), replicate chunks across workers each backed by
+a plain MariaDB, rewrite each user query into per-chunk queries that are answerable
+using only worker-local data, run them in parallel with heavy **shared scan**
+optimization, and merge/aggregate the partial results on a frontend ("**czar**") node.
+Plain MariaDB does all actual SQL execution; Qserv's own code is the distributed query
+planner, dispatcher, scheduler, result merger, and data-management control plane around
+it.
+
+## Component map
+
+```
+                       SQL (mysql protocol)          REST/JSON
+  users ──────────────► mysql-proxy + Lua ─┐   ┌─── qserv-czar-http (:4048)
+                              (:14040)     │   │      sync + async + user-table ingest
+                                           ▼   ▼
+                                     ┌──── CZAR ────┐        czar MariaDB:
+                                     │ parse → IR   │◄─────  qservCssData (CSS metadata)
+                                     │ qana plugins │        qservMeta (QMeta + director index)
+                                     │ chunk spec   │        result tables
+                                     │ UberJob disp │
+                                     └──┬───────▲───┘
+                    UberJobs (HTTP/JSON)│       │ result files (HTTP pull)
+                        ┌───────────────┼───────┼──────────────┐
+                        ▼                                      ▼
+              ┌── WORKER pod ×N ──────────┐          ┌── WORKER pod ×N ──┐
+              │ qserv-worker-http (:25010)│          │        ...        │
+              │   tasks → BlendScheduler  │          └───────────────────┘
+              │   → chunk queries against │
+              │ worker MariaDB (chunk DBs,│
+              │   qservw_worker inventory)│
+              │ qserv-replica-worker      │
+              └───────────▲───────────────┘
+                          │ replication/ingest control (+ ingest data pushes)
+        ┌─────────────────┴──────────────────┐
+        │ REPLICATION CONTROLLER (:25081)    │◄── repl MariaDB: qservReplica
+        │   replication, ingest REST API,    │    (config, replicas, transactions)
+        │   chunk-map publish → qservMeta,   │
+        │   health monitor, web dashboard    │
+        └─────────────────▲──────────────────┘
+                          │ heartbeats/contact info (also from workers & czar)
+                REGISTRY (:25082) — service discovery
+```
+
+## The 30-second query lifecycle
+
+1. A frontend receives SQL (or an HTTP query request) and hands it to
+   `ccontrol::UserQueryFactory`, which classifies it (SELECT, COUNT(*) shortcut,
+   async SUBMIT, admin statements…) and for real SELECTs builds a
+   `ccontrol::UserQuerySelect`.
+2. The statement is parsed (Hyrise parser by default) into the `query::` IR, then
+   `qproc::QuerySession` runs the `qana::` plugin sequence: table metadata lookup
+   (CSS), join admissibility via `qana::RelationGraph` (**read the long comment in
+   `src/qana/RelationGraph.h`**), spatial/secondary-index restrictor extraction,
+   aggregation split into parallel (worker) + merge (czar) statements.
+3. Chunk numbers are chosen (area restrictors → sphgeom region → chunks; objectId
+   restrictors → director-index lookup; else all chunks minus empty ones), giving one
+   job per chunk. Jobs are grouped per target worker into **UberJobs** using the
+   chunk→worker map (from the replication system via QMeta), and POSTed to workers.
+4. Each worker turns an UberJob into per-chunk `wbase::Task`s, schedules them
+   (interactive queries on the group scheduler; scans on chunk-ordered shared-scan
+   schedulers), materializes subchunk/overlap in-memory tables when needed, runs the
+   SQL against local MariaDB, and streams rows into a CSV result file. It then tells
+   the czar the file is ready.
+5. The czar pulls each result file over HTTP and `rproc::InfileMerger` loads it into
+   the query's result table (applying the merge/aggregation statement when needed).
+   When all jobs finish, the client gets the result — the proxy path runs a final
+   "result query" against the result table; the HTTP path returns/streams it directly.
+   QMeta tracks status/progress throughout; async queries return a QueryId
+   immediately and results are fetched later.
+
+## Module ownership cheat-sheet
+
+Czar side: `ccontrol` (orchestration) → `parser`/`query` (SQL→IR) → `qana` (analysis
+plugins) → `qproc` (chunking, templates) → `qdisp` (Executive/UberJobs) → `rproc`
+(merge). `czar` = service wiring + HTTP frontend + chunk-map/registry clients.
+Worker side: `wmain` (startup), `wcomms` (REST), `wbase` (tasks/result channels),
+`wsched` (schedulers), `wdb` (execution, subchunks), `wcontrol` (Foreman, limits),
+`wconfig`, `wpublish` (inventory, stats). Control plane: `replica` (+ `registry`
+within it). Shared: `css`, `qmeta`, `cconfig`, `global`, `util`, `http` (client),
+`qhttp` (server), `mysql`/`sql` (DB access), `protojson` (czar↔worker messages),
+`proxy` (mysql-proxy glue), `partition` (offline partitioner), `www` (dashboard).
+
+## History you'll trip over
+
+- **XRootD/SSI is gone** (removed 2025–2026, tags `2026.8.1-xrd-*` mark the last
+  XRootD-era line). Any doc/comment mentioning xrootd, SSI, or `xrdsvc` is historical.
+  Czar↔worker transport is HTTP/JSON (`protojson`) with file-based result delivery.
+- **The ANTLR parser is being replaced by Hyrise** (`extern/hyrise-sql-parser`,
+  `ccontrol/HyriseAdapter`); ANTLR remains as a build-time option and for comparison
+  tests.
+- The **wmgr**, **qserv-ingest**, and other older admin layers referenced in `doc/`
+  predate the current replication-system ingest API; trust `doc/ingest/` (current) and
+  the code.

--- a/doc/architecture/build-and-test.md
+++ b/doc/architecture/build-and-test.md
@@ -59,10 +59,10 @@ Python tooling under `/usr/local/python`, entered via `entrypoint`.
   compose-based integration suite (all three itest flavors) with container logs dumped
   on failure. Publishes images to GHCR (`packages: write`).
 - `docs.yaml` — builds Sphinx docs via `tox -e docs` (documenteer; **warnings are
-  errors**) and uploads to LSST-the-Docs (qserv.lsst.io) for tagged releases and
-  `tickets/*` PRs. Note: `doc/architecture/*.md` is excluded from the Sphinx build via
-  `exclude_patterns` in `doc/conf.py` — if you add *published* docs, wire them into a
-  toctree and expect `-W` strictness.
+  errors**) and uploads to LSST-the-Docs (qserv.lsst.io) on pushes to `main`,
+  published releases, and PRs from `tickets/*` branches. Note: `doc/architecture/*.md`
+  is excluded from the Sphinx build via `exclude_patterns` in `doc/conf.py` — if you
+  add *published* docs, wire them into a toctree and expect `-W` strictness.
 - `rebase_checker.yaml` — fails PRs whose ticket branch has `main` merged in; rebase
   ticket branches instead of merging main into them.
 

--- a/doc/architecture/build-and-test.md
+++ b/doc/architecture/build-and-test.md
@@ -1,0 +1,73 @@
+# Build system, tests, and CI
+
+*Current as of 2026-08, derived from code inspection. Trust the code over this doc if
+they diverge; update this doc when you change the code.*
+
+## Build system
+
+CMake at the root builds `src/` (one static-ish library + test binaries per module
+directory, wired together into the final executables) plus the vendored submodules in
+`extern/` (`sphgeom` spatial library, `log`, `hyrise-sql-parser`). The
+`QSERV_USE_HYRISE_SQL_PARSER` option (default `ON`) selects the Hyrise-based SQL parser
+for SELECT statements over the legacy ANTLR4 one.
+
+You never run cmake on the host. The `./bin/qserv` CLI
+(`python/lsst/qserv/admin/qservCli/`) wraps every step in Docker:
+
+- `qserv env` — shows the image names (derived from `git describe`) and the `QSERV_*`
+  env vars that override them (`QSERV_IMAGE`, `QSERV_BUILD_IMAGE`, ...).
+- `qserv build` — runs clang-format (CHECK/REFORMAT/OFF), cmake (if `build/` absent),
+  `make install`, unit tests (`make test`, i.e. CTest), mypy; then optionally packages
+  the run image. `-jN` parallelizes both make and ctest.
+- `qserv run-build` — drops you into the build container for incremental `make`.
+- `qserv build-images` / `build-user-build-image` / `build-mariadb-image` /
+  `build-run-base-image` / `build-ssl-proxy-image` — the image hierarchy; base images
+  are content-addressed by their Dockerfiles, so CI only rebuilds them when
+  `deploy/docker/*` changes.
+
+Binaries produced (installed into the run image): `qserv-czar-http`, `mysql-proxy` glue
+(`czarProxy` lib + Lua), `qserv-worker-http`, `qserv-replica-master-http`,
+`qserv-replica-registry`, `qserv-replica-worker`, various `qserv-replica-*` admin
+tools, the partitioner tools (`sph-partition`, `sph-partition-matches`, ...), and the
+Python tooling under `/usr/local/python`, entered via `entrypoint`.
+
+## Test layers
+
+1. **C++ unit tests** — Boost.Test `test*.cc` files in each `src/<module>/`,
+   registered with CTest; run by `make test` inside the build container or
+   `ctest -R <name>` in `build/`. Notable suites: `qproc/testQueryAna*` (query
+   analysis golden tests), `ccontrol/testAntlr4GeneratedIR` / `testHyriseGeneratedIR` /
+   `testParserCorpus` (parser → IR corpus tests, with a `.sql` stress corpus in
+   `ccontrol/testdata/`), `wsched/testSchedulers`. A few suites need a live MySQL and
+   are excluded from CTest (e.g. `qmeta/testQMeta` — its `add_test` is commented out).
+2. **Python unit tests** — under `python/lsst/qserv/*/tests`; mypy+ruff gate style
+   (`pyproject.toml`).
+3. **Integration tests** — real compose cluster + dataset cases in `data/caseNN/`
+   comparing Qserv results against a reference MariaDB running the same queries
+   unpartitioned. Three suites: `itest` (SQL via proxy), `itest-http` (HTTP frontend),
+   `itest-http-ingest` (user-table ingest). Config: `etc/integration_tests.yaml`;
+   runner: `python/lsst/qserv/admin/cli/_integration_test.py`. See the `itest` skill /
+   `doc/architecture/deployment.md` for the workflow.
+4. **Load testing** — `bin/qserv-kraken` (`python/lsst/qserv/testing/`) replays query
+   mixes against a deployment (not part of CI).
+
+## CI (`.github/workflows/`)
+
+- `ci.yml` — on every push: recompute image names from `git describe`; rebuild base /
+  mariadb / ssl-proxy images only if missing from GHCR; build the qserv image
+  (clang-format CHECK enforced, unit tests run inside the build); then run the full
+  compose-based integration suite (all three itest flavors) with container logs dumped
+  on failure. Publishes images to GHCR (`packages: write`).
+- `docs.yaml` — builds Sphinx docs via `tox -e docs` (documenteer; **warnings are
+  errors**) and uploads to LSST-the-Docs (qserv.lsst.io) for tagged releases and
+  `tickets/*` PRs. Note: `doc/architecture/*.md` is excluded from the Sphinx build via
+  `exclude_patterns` in `doc/conf.py` — if you add *published* docs, wire them into a
+  toctree and expect `-W` strictness.
+- `rebase_checker.yaml` — fails PRs whose ticket branch has `main` merged in; rebase
+  ticket branches instead of merging main into them.
+
+## Release versioning
+
+Annotated tags `YYYY.M.P[-rcN]` (e.g. `2026.8.1-rc2`) define releases; everything else
+is tagged `<last-tag>-<n>-g<sha>` via `git describe` (`--dirty` locally). The CI job
+summary prints the exact image names for pasting into deployment `values.yaml`.

--- a/doc/architecture/deployment.md
+++ b/doc/architecture/deployment.md
@@ -10,8 +10,13 @@ The Helm chart's StatefulSets create PVCs via `volumeClaimTemplates` — `worker
 catalog data that takes **days to weeks** to re-ingest. Releasing those PVCs by
 accident — through a rename that changes generated PVC names, an Argo CD prune, an STS
 recreate, or storage-class reclaim — is the largest operational risk of running Qserv
-on Kubernetes. Argo CD sync is **intentionally manual** as a guard. Treat every change
-to `deploy/helm/templates/*-sts.yaml`, release/chart names, labels/selectors, or
+on Kubernetes. Argo CD sync is **intentionally manual** as a guard. Note that the
+chart builds StatefulSet names from the **chart name** (`qserv-worker` → PVC
+`worker-data-qserv-worker-N`), not the Helm release name — so a release rename keeps
+PVC names, but it changes the immutable selector labels and forces an STS
+delete/recreate, while a chart or StatefulSet rename does change PVC names. Treat
+every change to
+`deploy/helm/templates/*-sts.yaml`, release/chart names, labels/selectors, or
 qserv-deployments as PVC-affecting until proven otherwise, and say so in the PR.
 
 ## Images
@@ -57,7 +62,8 @@ The same topology appears in docker-compose (dev/CI) and Kubernetes (production)
 
 `deploy/compose/docker-compose.yml`, driven by `./bin/qserv up|down`. Two workers,
 one czar (proxy + http), repl controller/registry + their MariaDBs. Container names are
-`$USER-<service>-1`. This is what integration tests (`./bin/qserv itest*`) run against.
+`$USER-<service>-1`. Note the proxy listens on **4040** here (deployments use 14040).
+This is what integration tests (`./bin/qserv itest*`) run against.
 Note the compose file passes fixed test passwords/keys (`CHANGEME`, `replauthkey`) —
 fine locally, never a pattern to copy elsewhere.
 
@@ -92,9 +98,13 @@ AGENTS.md with the deployment-change workflow. Layout:
   from `ghcr.io/lsst/charts` (`chart: qserv`, pinned `targetRevision`, e.g.
   `2026.8.1-rc2-23-g750048b57`) and this git repo for `values.yaml` (multi-source
   `$values` ref).
-- `values.yaml` — deployment overrides: image names, worker replica count (70 in dev
-  as of 2026-08), storage class `rubin-qserv-storage` + sizes, node tiers, external
-  LoadBalancer IP/allowed ranges.
+- `values.yaml` — deployment overrides: node tiers, worker replica count (70 in dev,
+  35 in int and prod as of 2026-08), ingest enablement, external LoadBalancer
+  IP/allowed ranges. Image names and storage (class `rubin-qserv-storage`, sizes such
+  as 10 Ti per worker) are **not** set here — they come from the chart's own
+  `values.yaml`, pinned per chart release. (The deployment values used to override
+  image names; that was deliberately removed — see qserv-deployments commit "Remove
+  image values".)
 
 Argo CD watches `main` of qserv-deployments and reconciles — but **sync is manual**: a
 human reviews the diff in Argo CD and syncs. Deploying a new Qserv version means: tag

--- a/doc/architecture/deployment.md
+++ b/doc/architecture/deployment.md
@@ -1,0 +1,115 @@
+# Deployment: containers, compose, Helm, Argo CD
+
+*Current as of 2026-08, derived from code inspection. Trust the code over this doc if
+they diverge; update this doc when you change the code.*
+
+## ⚠️ The one thing you must not break
+
+The Helm chart's StatefulSets create PVCs via `volumeClaimTemplates` — `worker-data`
+(chunk data, per worker), `czar-data`, `repl-data`. The volumes behind them hold
+catalog data that takes **days to weeks** to re-ingest. Releasing those PVCs by
+accident — through a rename that changes generated PVC names, an Argo CD prune, an STS
+recreate, or storage-class reclaim — is the largest operational risk of running Qserv
+on Kubernetes. Argo CD sync is **intentionally manual** as a guard. Treat every change
+to `deploy/helm/templates/*-sts.yaml`, release/chart names, labels/selectors, or
+qserv-deployments as PVC-affecting until proven otherwise, and say so in the PR.
+
+## Images
+
+Five images, built by `.github/workflows/ci.yml` via `./bin/qserv` and published to
+GHCR, all tagged from `git describe` (release tags look like `2026.8.1-rc2`):
+
+| Image | Dockerfile | Role |
+| --- | --- | --- |
+| `ghcr.io/lsst/qserv` | `deploy/docker/run/Dockerfile` | The application image: all C++ binaries + Python tooling, entered via `entrypoint` |
+| `ghcr.io/lsst/qserv-mariadb` | `deploy/docker/mariadb/Dockerfile` | MariaDB with Qserv extras (scisql UDFs) |
+| `ghcr.io/lsst/qserv-build-base` | `deploy/docker/base/Dockerfile` (target `qserv-build-base`) | Build toolchain (also used as `ingestHelper` image) |
+| `ghcr.io/lsst/qserv-run-base` | `deploy/docker/base/Dockerfile` (target `qserv-run-base`) | Runtime base for the qserv image |
+| ssl-proxy | `deploy/docker/ssl-proxy/Dockerfile` | TLS terminator for the mysql-proxy frontend |
+
+The container `entrypoint` (`bin/entrypoint` → `python/lsst/qserv/admin/cli/entrypoint.py`)
+is how every service starts: `entrypoint czar-http | proxy | worker-svc | worker-repl |
+replication-controller | replication-registry | smig-update | ...`. It renders config
+templates from `src/admin/templates/`, waits for/migrates schemas, then execs the C++
+binary.
+
+## Process/service topology
+
+The same topology appears in docker-compose (dev/CI) and Kubernetes (production):
+
+- **Czar** — three colocated processes: MariaDB (`qservMeta`, `qservCssData`,
+  `qservStatusData`, `qservResult` result tables);
+  `mysql-proxy` (port 14040) embedding Lua glue (`src/proxy/mysqlProxy.lua`) that calls
+  into czar code for the SQL frontend; `qserv-czar-http` (port 4048) — the HTTP/JSON
+  frontend (sync/async queries, user-table ingest). Both frontends run the full czar
+  query machinery in-process.
+- **Worker ×N** — three colocated processes: MariaDB (chunk data, `qservw_worker`);
+  `qserv-worker-http` (port 25010, the query-serving worker daemon);
+  `qserv-replica-worker` (replication/ingest agent).
+- **Replication controller** — `qserv-replica-master-http` (port 25081) + its MariaDB
+  (`qservReplica`). Singleton.
+- **Registry** — `qserv-replica-registry` (port 25082), stateless service discovery:
+  workers/czars self-register; czar and controller poll it.
+- **Dashboard** — the web UI in `www/` is served by the replication controller's HTTP
+  server.
+
+## docker-compose (dev/CI)
+
+`deploy/compose/docker-compose.yml`, driven by `./bin/qserv up|down`. Two workers,
+one czar (proxy + http), repl controller/registry + their MariaDBs. Container names are
+`$USER-<service>-1`. This is what integration tests (`./bin/qserv itest*`) run against.
+Note the compose file passes fixed test passwords/keys (`CHANGEME`, `replauthkey`) —
+fine locally, never a pattern to copy elsewhere.
+
+## Helm chart (production shape)
+
+Chart source: `deploy/helm/` (`Chart.yaml`, `values.yaml`, `templates/`). Rendered
+resources:
+
+- `czar-sts.yaml`, `worker-sts.yaml`, `repl-sts.yaml` — StatefulSets described above,
+  each with a data PVC from `volumeClaimTemplates`; worker STS supports node-tier
+  affinity (`qserv.lsst.io/tier` label) and host anti-affinity.
+- `registry-deploy.yaml` — stateless registry Deployment.
+- `ingest-sts.yaml` (optional, `ingest.enable`) — ingest helper.
+- `*-smig-job.yaml` — schema-migration Jobs run per upgrade (czar, worker, repl).
+- `*-cm.yaml` / secrets — config files and passwords/auth keys mounted into pods.
+- `czar-external-svc.yaml` (optional) — LoadBalancer exposing the SQL/HTTP frontends
+  outside the cluster (MetalLB at USDF).
+- `mode: full | db-only` in values — `db-only` runs just the MariaDBs (used
+  operationally for maintenance; see `qserv.enable` helper in `_helpers.tpl`).
+
+`deploy/helm/environments/usdf-{dev,int,prod}.yaml` are in-repo presets, but the values
+actually deployed live in **qserv-deployments** (below).
+
+## qserv-deployments + Argo CD (USDF gitops)
+
+Repo: `github.com/lsst/qserv-deployments` — a **separate git repo**, conventionally
+checked out as a sibling of this one (`../qserv-deployments/`); it carries its own
+AGENTS.md with the deployment-change workflow. Layout:
+`deployments/usdf-qserv-{dev,int,prod}/`, each with:
+
+- `application.yaml` — an Argo CD `Application` with two sources: the packaged chart
+  from `ghcr.io/lsst/charts` (`chart: qserv`, pinned `targetRevision`, e.g.
+  `2026.8.1-rc2-23-g750048b57`) and this git repo for `values.yaml` (multi-source
+  `$values` ref).
+- `values.yaml` — deployment overrides: image names, worker replica count (70 in dev
+  as of 2026-08), storage class `rubin-qserv-storage` + sizes, node tiers, external
+  LoadBalancer IP/allowed ranges.
+
+Argo CD watches `main` of qserv-deployments and reconciles — but **sync is manual**: a
+human reviews the diff in Argo CD and syncs. Deploying a new Qserv version means: tag
+qserv → CI publishes images → chart published to `ghcr.io/lsst/charts` (this publish
+step is *not* in this repo's workflows as of 2026-08 — verify how before relying on
+it) → PR to qserv-deployments bumping `targetRevision` and image names → merge → manual
+sync. Smig jobs handle schema upgrades during rollout.
+
+## Ports quick reference
+
+| Port | Service |
+| --- | --- |
+| 14040 | czar mysql-proxy (SQL frontend) |
+| 4048 | czar HTTP frontend (REST) |
+| 25010 | worker qserv-worker-http |
+| 25081 | replication controller REST + dashboard |
+| 25082 | registry |
+| 3306 | each colocated MariaDB |

--- a/doc/architecture/deployment.md
+++ b/doc/architecture/deployment.md
@@ -15,9 +15,9 @@ chart builds StatefulSet names from the **chart name** (`qserv-worker` → PVC
 `worker-data-qserv-worker-N`), not the Helm release name — so a release rename keeps
 PVC names, but it changes the immutable selector labels and forces an STS
 delete/recreate, while a chart or StatefulSet rename does change PVC names. Treat
-every change to
-`deploy/helm/templates/*-sts.yaml`, release/chart names, labels/selectors, or
-qserv-deployments as PVC-affecting until proven otherwise, and say so in the PR.
+every change to `deploy/helm/templates/*-sts.yaml`, release/chart names,
+labels/selectors, or qserv-deployments as PVC-affecting until proven otherwise, and
+say so in the PR.
 
 ## Images
 
@@ -102,9 +102,8 @@ AGENTS.md with the deployment-change workflow. Layout:
   35 in int and prod as of 2026-08), ingest enablement, external LoadBalancer
   IP/allowed ranges. Image names and storage (class `rubin-qserv-storage`, sizes such
   as 10 Ti per worker) are **not** set here — they come from the chart's own
-  `values.yaml`, pinned per chart release. (The deployment values used to override
-  image names; that was deliberately removed — see qserv-deployments commit "Remove
-  image values".)
+  `values.yaml`, pinned per chart release (image overrides were deliberately removed;
+  see qserv-deployments commit "Remove image values").
 
 Argo CD watches `main` of qserv-deployments and reconciles — but **sync is manual**: a
 human reviews the diff in Argo CD and syncs. Deploying a new Qserv version means: tag

--- a/doc/architecture/metadata-and-state.md
+++ b/doc/architecture/metadata-and-state.md
@@ -1,0 +1,86 @@
+# Metadata and state stores
+
+*Current as of 2026-08, derived from code inspection. Trust the code over this doc if
+they diverge; update this doc when you change the code.*
+
+Qserv keeps its bookkeeping in a handful of MySQL/MariaDB databases spread across
+three MariaDB roles (czar, per-worker, replication), plus one in-memory registry
+service. Knowing which store owns which fact is the fastest way to orient when
+debugging.
+
+## The databases
+
+| Database | Lives on | Owner code | Contents |
+| --- | --- | --- | --- |
+| `qservCssData` | czar MariaDB | `src/css/` | CSS — the "Central State System": global catalog metadata. Databases/tables known to Qserv, table types (director/child/match/RefMatch), partitioning params (stripes, overlap), scan ratings, empty-chunk lists. Stored as a key-value tree in a MySQL table (`KvInterfaceImplMySql`) |
+| `qservMeta` | czar MariaDB | `src/qmeta/` | QMeta — per-query metadata: `QInfo` (query text, status, timing, result location), `QTable`, `QMessages`, `QCzar`, the chunk map published by the replication system (`chunkMap` + `chunkMapStatus` tables), director-index tables (`<db>__<table>`), row-counter tables (`<db>__<table>__rows`), and user-table ingest bookkeeping |
+| `qservStatusData` | czar MariaDB | `src/qmeta/QProgress*` | Transient query progress (`QProgress`, `QProgressHistory`) — split from `qservMeta` so high-rate updates don't touch the durable store |
+| `qservResult` | czar MariaDB | `src/rproc/`, `src/czar/MessageTable` | Result tables (`result_<queryId>`, plus `_m` merge tables during aggregation) and transient `message_<n>` / `result_async_<n>` tables used by the proxy protocol |
+| `qservw_worker` | each worker MariaDB | `src/wpublish/ChunkInventory` | Worker-local inventory: which databases/chunks this worker serves (`Dbs`/`Chunks` tables), worker identity/UUID |
+| `qservReplica` | repl MariaDB | `src/replica/config/` | Replication system config + state: worker registry, database families, databases/tables being ingested, replica disposition, ingest transactions and contributions, controller event log |
+
+Chunk *data* itself lives in per-catalog databases on each worker MariaDB (chunk tables
+named `Table_<chunkId>`, overlap tables `TableFullOverlap_<chunkId>`, plus transient
+`Subchunks_<db>_<chunk>` MEMORY databases built on demand).
+
+## Who writes what
+
+- **CSS is written by the replication/ingest system** (e.g.
+  `src/replica/contr/HttpIngestModule.cc` writes `qservCssData` directly when a
+  database is published) and **read by the czar** at query-analysis time
+  (`css::CssAccess`, used by `qproc::QuerySession` to get table types, partitioning
+  params, and empty chunks).
+- **The chunk map** (`chunkMap`/`chunkMapStatus` in `qservMeta`) is atomically
+  rewritten by the replication controller (`replica::ChunkMap::update()`) and read by
+  the czar's `czar::CzarFamilyMap` / `czar::CzarChunkMap`, which turn it into the
+  chunk→worker assignment used to build UberJobs. So: replication decides placement;
+  the czar consumes it via QMeta.
+- **Worker contact info** flows through the **Registry** service
+  (`src/replica/registry/`, deployed as `qserv-registry`): workers and czars POST their
+  identity/host/port there periodically; the czar polls it
+  (`czar::CzarRegistry::waitForWorkerContactMap`) to learn how to reach workers, and the
+  replication controller uses it for health monitoring. The registry is soft state —
+  it repopulates from heartbeats after a restart.
+- **QMeta** is written by the czar throughout the query lifecycle (registration,
+  status transitions, progress, final stats, result-query text for the proxy to run).
+
+## Database families
+
+Partitioned databases belong to a *family* (defined in the replication system's config)
+that shares identical partitioning parameters (num stripes/sub-stripes, overlap). All
+tables joined in one query must be partition-compatible, which in practice means their
+databases are in the same family; chunk placement/replication is managed per-family so
+joins can always be satisfied worker-locally (see `src/qana/RelationGraph.h` for why).
+**Caveat:** on the czar side "family" is currently a stub — `czar::CzarFamilyMap`
+treats each database as its own family (`getFamilyNameFromDbName` returns the db name;
+TODO DM-53239), because the published chunk map carries no family column yet.
+
+## The director index (a.k.a. secondary index)
+
+For point lookups (`WHERE objectId = ...` / `IN (...)` on a director table's primary
+key), the czar avoids querying every chunk by consulting the *director index*: a table
+`<db>__<DirectorTable>` in the `qservMeta` database on the czar MariaDB, mapping
+objectId → (chunk, subchunk). It is built by the replication system during ingest
+(`src/replica/contr/HttpDirectorIndexModule.cc`) and queried at analysis time via
+`qproc::SecondaryIndex` restrictors. See `doc/admin/director-index.rst`.
+
+## Schema migration (smig)
+
+Each database's schema is versioned; migration scripts live in
+`python/lsst/qserv/schema/migrations/{czar,worker,repl}/migrate-N-to-M.sql` (czar →
+`qservMeta` + CSS, worker → `qservw_worker`, repl → `qservReplica`). The `smig`
+machinery (`python/lsst/qserv/schema/`, CLI `bin/qserv-smig`, entrypoint command
+`smig-update`) applies them. In Kubernetes, per-component smig Jobs
+(`deploy/helm/templates/*-smig-job.yaml`) run migrations on upgrade; services block at
+startup until the schema version matches expectations (`--schema-upgrade-wait`).
+**Any schema change to these databases needs a migration script plus a bump of the
+expected version constant in the owning module.**
+
+## Configuration files vs databases
+
+Czar and worker process configuration is file-based (INI-style read into
+`cconfig::CzarConfig` / `wconfig::WorkerConfig` via `util::ConfigValMap`; templates
+rendered by the container `entrypoint` from `src/admin/templates/`). The replication
+system is different: its configuration lives *in* `qservReplica`
+(`replica::Configuration`), bootstrapped from a JSON/SQL seed and edited through the
+controller's REST API or `qserv-replica-config` tooling.

--- a/doc/architecture/query-lifecycle.md
+++ b/doc/architecture/query-lifecycle.md
@@ -7,8 +7,10 @@ they diverge; update this doc when you change the code.*
 
 Two czar processes run the same `czar::Czar` core, differing only in name/transport;
 both also run a control HTTP server (`czar::HttpSvc`, `replication.http_port`) that
-**workers call back to** (`/queryjob-ready`, `/queryjob-error`, `/workerczarcomissue`,
-`/querystatus` replies, `/event` from the replication system).
+**workers call back to** (`/queryjob-ready`, `/queryjob-error`, `/workerczarcomissue`)
+and that the replication system notifies via `/event`. (The worker's answers to the
+czar's `/querystatus` polls ride the HTTP response to the czar's POST — they do not
+come through this server.)
 
 **mysql-proxy path** (`src/proxy/`): `mysql-proxy` runs `mysqlProxy.lua`, which calls
 into czar code via the `czarProxy` Lua extension. The Lua classifies each statement

--- a/doc/architecture/query-lifecycle.md
+++ b/doc/architecture/query-lifecycle.md
@@ -1,0 +1,189 @@
+# Query lifecycle: SQL in → merged results out
+
+*Current as of 2026-08, derived from code inspection. Trust the code over this doc if
+they diverge; update this doc when you change the code.*
+
+## Frontends
+
+Two czar processes run the same `czar::Czar` core, differing only in name/transport;
+both also run a control HTTP server (`czar::HttpSvc`, `replication.http_port`) that
+**workers call back to** (`/queryjob-ready`, `/queryjob-error`, `/workerczarcomissue`,
+`/querystatus` replies, `/event` from the replication system).
+
+**mysql-proxy path** (`src/proxy/`): `mysql-proxy` runs `mysqlProxy.lua`, which calls
+into czar code via the `czarProxy` Lua extension. The Lua classifies each statement
+(local passthrough, disallowed, KILL/CANCEL, or send-to-qserv) and calls
+`Czar::submitQuery`. Synchronization is a neat trick: the czar pre-creates an
+`ENGINE=MEMORY` *message table* (`message_<n>` in the result db) and holds a
+`LOCK TABLES ... WRITE` on it; the proxy immediately issues a SELECT against that
+table, which blocks until the czar's finalizer thread (submit → join → unlock) releases
+the lock. The proxy then checks the message rows for errors, streams the czar-provided
+*result query* (`SELECT ... FROM <resultdb>.result_<qid> [ORDER BY ...]`) straight to
+the client, and drops both tables (except for `SELECT * FROM qserv_result(<id>)`,
+which must not drop the async result table).
+
+**HTTP frontend** (`czar/HttpCzarSvc`, TLS-only, port 4048): `POST /query` (sync),
+`POST /query-async` (literally prefixes the SQL with `SUBMIT ` and reuses the same
+path), `GET /query-async/status/:qid`, `GET /query-async/result/:qid`,
+`DELETE /query-async/:qid` (cancel) and `.../result/:qid` (delete result), plus
+user-table ingest (`/ingest/csv`, `/ingest/data`, ...). Results are returned as JSON
+`{schema, rows}` with configurable binary-column encoding (hex/b64/array). See
+`doc/user/http-frontend*.rst` (current).
+
+**Async SQL API** (`doc/user/async.rst`, current): `SUBMIT <select>` returns a row
+`jobId | resultLocation` immediately; progress via `information_schema.processlist` /
+`.queries`; results via `SELECT * FROM qserv_result(<id>)`; cleanup via
+`CALL qserv_result_delete(<id>)`; cancel via `CANCEL <id>`. Unclaimed async results
+are GC'd after `resultdb.oldestAsyncResultKeptSeconds` (default 1 h).
+
+## Classification: `ccontrol::UserQueryFactory`
+
+Order matters (`UserQueryFactory::newUserQuery`): strip `SUBMIT` (→ async) → if
+SELECT: parse; `information_schema.PROCESSLIST`/`QUERIES` → process-list query types;
+**COUNT(\*) shortcut** — a bare `SELECT COUNT(*) FROM t` (no WHERE/ORDER/GROUP/HAVING/
+JOIN) with row-counter data available in `qservMeta.<db>__<table>__rows` becomes
+`UserQuerySelectCountStar`, which never touches workers (toggle:
+`SET GLOBAL QSERV_ROW_COUNTER_OPTIMIZATION=0|1`); otherwise the full
+`UserQuerySelect` pipeline. Non-SELECT: `SELECT * FROM qserv_result(N)` →
+`UserQueryAsyncResult`; `SHOW PROCESSLIST`; `CALL qserv_result_delete(N)`;
+`SET GLOBAL` (recognized vars: `QSERV_ROW_COUNTER_OPTIMIZATION`,
+`QSERV_DEBUG_CZAR_NO_MERGE`); anything else → `UserQueryInvalid`.
+
+## Parsing → IR
+
+Build-time choice (`QSERV_USE_HYRISE_SQL_PARSER`, default ON): the Hyrise parser
+(`extern/hyrise-sql-parser` + `ccontrol/HyriseAdapter`, ~800 lines of conversion) or
+the legacy ANTLR4 grammar (`parser/*.g4` + `ccontrol/ParseListener`). Both produce the
+same IR: `query::SelectStmt` owning SelectList, FromList (TableRef/JoinRef), WhereClause
+(BoolTerm tree + a *restrictor side-channel* where `qserv_areaspec_box|circle|ellipse|
+poly` hints are lifted), OrderBy/GroupBy/Having, DISTINCT, LIMIT. `query::ValueExpr` /
+`ValueFactor` model expressions; `query::QueryTemplate` renders IR to SQL text with
+alias-mode control and substitutable entries (how chunk numbers get patched in later).
+`CASE` is rejected; area restrictors may not appear under OR/NOT.
+
+## Analysis: `qproc::QuerySession` + `qana` plugins
+
+`analyzeQuery` runs the plugin sequence (hardcoded order in
+`QuerySession::_preparePlugins`):
+
+1. **DuplSelectExprPlugin** — reject duplicate select-list names (result table is a
+   real MySQL table).
+2. **WherePlugin** — simplify/normalize the boolean tree.
+3. **AggregatePlugin** — split each select item into *parallel* (worker) and *merge*
+   (czar) forms: `COUNT→COUNT/SUM`, `SUM/MIN/MAX→same-over-alias`,
+   `AVG→SUM(SUM)/SUM(COUNT)`. Sets `needsMerge` (and all-chunks-required) for
+   aggregates/DISTINCT.
+4. **TablePlugin** — resolve default dbs, assign table/value aliases, compute dominant
+   dbs, canonicalize column refs (ORDER BY items **must** match a select-list entry —
+   source of a well-known user error), then per parallel statement build
+   `qana::RelationGraph` and `rewrite()` — join admissibility, overlap analysis, and
+   fan-out into up to 2^N statements with chunk/subchunk/overlap table-name patterns
+   (**read the long comment in `src/qana/RelationGraph.h`**). Also snapshots the
+   *preflight* statement used to derive the result-table schema.
+5. **MatchTablePlugin** — for single match-table queries, add the duplicate-row
+   filter (`dir1 IS NULL OR flag <> 2`).
+6. **QservRestrictorPlugin** — turn `qserv_areaspec_*` hints into real
+   `scisql_s2PtIn*` predicates on each chunked table, or *infer* one area restrictor
+   from an existing `scisql_s2PtIn*(...)=1` / `scisql_angSep(...) < r` predicate on
+   partitioning columns; collect director-index restrictors from `=`/`IN` predicates
+   on director-key columns.
+7. **PostPlugin** — LIMIT/ORDER BY: strip per-chunk LIMIT when GROUP BY present;
+   LIMIT+chunks forces a merge; without LIMIT, ORDER BY is removed from parallel and
+   merge statements entirely (ordering happens only in the final *result query*).
+8. **ScanTablePlugin** — classify as shared scan (any column refs in SELECT or WHERE
+   → all partitioned FROM tables are scan tables; rating = max CSS `scanRating`);
+   `applyFinal` de-classifies queries under `tuning.interactiveChunkLimit` (default
+   10 chunks) as interactive.
+
+The split: parallel statements (HAVING removed) run on workers; `_stmtMerge`
+(select-list only, retargeted at the merge table) runs on the czar iff `needsMerge`;
+the **result query** (built from aliases + the *original* ORDER BY, persisted in
+`QInfo.resultQuery`) is what the frontend runs against the final result table.
+
+## Chunk selection
+
+`UserQuerySelect::_setupChunking`: area restrictors → sphgeom regions →
+`IndexMap`/`sphgeom::Chunker` intersection; director-index restrictors →
+`SELECT chunkId, subChunkId FROM qservMeta.<db>__<table> WHERE ...`; both present →
+intersection (AND only); neither → all chunks. Then subtract the CSS empty-chunk set.
+A chunk-less query gets the dummy chunk (1234567890). >interactiveChunkLimit chunks →
+not interactive.
+
+## Dispatch (`qdisp/`)
+
+`UserQuerySelect::submit()` creates one `JobDescription` per chunk (chunk tag left
+unsubstituted — workers do that), then `buildAndSendUberJobs()` groups unassigned
+chunks **in numerical order** (keeps worker shared scans aligned) by their *primary
+scan worker* — assigned by `czar::CzarChunkMap::organize()` (chunks sorted by size,
+greedily placed on the least-loaded replica-holding worker; placement data ultimately
+from the replication system via `qservMeta.chunkMap`). Up to `uberjob.maxChunks`
+(default 10000) jobs per UberJob; each UberJob is POSTed as JSON to the worker's
+`/queryjob` (`protojson::UberJobMsg` — with query-template and db-table interning to
+keep messages small; includes rowlimit, maxtablesizemb, scan info, czar contact info).
+
+Failure handling: transmit failure → jobs unassigned and reassigned next cycle;
+worker "unknown table" errors → mark that worker avoided for those jobs (cleared when
+a newer family map arrives) and reassign; worker restart/death (from registry
+liveness + `w-startup-time`) → kill incomplete UberJobs and reassign — *unless* the
+result file merge already started, in which case reassignment would corrupt results
+and is refused. Per-job attempt cap `tuning.jobMaxAttempts` (default 150) → query
+squashed.
+
+**LIMIT squash:** for `LIMIT` without ORDER BY/GROUP BY/aggregates, once merged rows
+reach the limit the executive squashes remaining jobs as "superfluous", tells workers
+to drop results, and treats the query as successfully complete. Workers also stop
+early (rowlimit is in the UberJob message).
+
+**Cancellation:** `KILL`/`CANCEL`/HTTP DELETE → `Executive::squash` → cancel all
+jobs + `endUserQueryOnWorkers` (workers drop tasks and delete files via the status
+protocol).
+
+## Result path (czar side)
+
+Worker POSTs `/queryjob-ready` with `{fileUrl, rowCount, fileSize}`. The czar queues a
+file-collect command (priority pool), GETs the file (libcurl, shared connection pool
+of `resultdb.maxhttpconnections`), buffers it through `mysql::CsvMemDisk` (in-memory
+up to a process-wide `resultdb.maxTransferMemMB` budget, spilling to
+`resultdb.transferDir`), and merges via `rproc::InfileMerger`:
+`LOAD DATA LOCAL INFILE` (virtual file via `mysql::LocalInfile` handler,
+`FIELDS ENCLOSED BY '\''` — the worker writes quoted-TSV) into the merge table
+(`result_<qid>_m` when aggregating, else directly `result_<qid>`, ENGINE=MyISAM,
+schema derived by running the preflight statement). On success the czar DELETEs the
+file from the worker. When all jobs finish, `finalize()` runs the merge statement
+(`CREATE TABLE result_<qid> AS <merge select>` + drop `_m`) if needed. A failed merge
+that already wrote bytes marks the result **contaminated** (query fails; no silent
+partial results). Result-size cap `resultdb.maxtablesize_mb` (default ~5 GB) is
+enforced both per worker response and on the accumulated total (`FAILED_LR` status).
+
+## Bookkeeping (qmeta)
+
+`QInfo` row per query (type, status EXECUTING→COMPLETED/FAILED/FAILED_LR/ABORTED,
+query text, parallel/merge templates, result location, result query, timestamps);
+`QTable` (tables touched); `QProgress` + history (chunk completion, throttled
+updates); `QMessages` (per-job/error messages, capped per source); `QCzar` (czar
+registry; czar restart aborts its stale EXECUTING queries at startup and can notify
+workers to cancel pre-restart query ids). The proxy's transient message/result tables
+live in `resultdb` (`qservResult`), not qmeta.
+
+## Config quick reference (`cconfig::CzarConfig`)
+
+`uberjob.maxChunks` 10000 · `tuning.interactiveChunkLimit` 10 ·
+`tuning.jobMaxAttempts` 150 · `resultdb.maxtablesize_mb` 5001 ·
+`resultdb.maxTransferMemMB` 10000 · `resultdb.oldestResultKeptDays` 30 ·
+`resultdb.oldestAsyncResultKeptSeconds` 3600 · `qdisppool.*` (dispatch pool shape) ·
+`activeworker.*` (worker liveness: 300 s questionable / 600 s dead) ·
+`familymap.maxUpdateWaitSecs` 120 · `css.database` qservCssData · `qmeta.db` qservMeta
+· `qstatus.db` qservStatusData · `resultdb.db` qservResult.
+
+## Gotchas
+
+- The ANTLR path still compiles and behaves differently for non-SELECT statements;
+  don't assume Hyrise-only semantics when touching `UserQueryFactory`.
+- ORDER BY without LIMIT never reaches workers or the merge — only the final result
+  query orders. `copyMerge()` deliberately drops ORDER BY.
+- The COUNT(\*) shortcut silently depends on row counters having been deployed at
+  ingest time; without them the full scan path runs.
+- `ScanTablePlugin` has a disabled (`#if 0`) branch that would de-classify
+  director-index point lookups as scans — such queries are currently still rated as
+  scans until `applyFinal`'s chunk-count check rescues small ones.
+- Czar-side "family" == database today (DM-53239 stub); see replication-ingest.md.

--- a/doc/architecture/replication-ingest.md
+++ b/doc/architecture/replication-ingest.md
@@ -1,0 +1,182 @@
+# The replication/ingest control plane (`src/replica/`)
+
+*Current as of 2026-08, derived from code inspection. Trust the code over this doc if
+they diverge; update this doc when you change the code. `doc/ingest/` is the current,
+trustworthy user-facing documentation for the ingest API — this doc covers the
+internals.*
+
+The replication system is a control plane separate from the query path: a singleton
+**Replication Controller** (`qserv-replica-master-http`), a stateless **Registry**
+(`qserv-replica-registry`), and a **replica-worker daemon** (`qserv-replica-worker`)
+colocated with every qserv worker. Shared state lives in the `qservReplica` MySQL DB.
+It owns data placement, replication level, catalog ingest, the director index, row
+counters, and the publish step that makes catalogs visible to the czar.
+
+## Module layout (`src/replica/`)
+
+`apps/` (CLI/daemon application classes) · `config/` (the Configuration service backed
+by `qservReplica`) · `contr/` (Controller, its long-running tasks, and the REST API
+modules) · `ingest/` (worker-side ingest services) · `jobs/` (cluster-wide composite
+operations) · `requests/` (single-worker operations + the Messenger transport) ·
+`mysql/` (its own MySQL client layer + `QueryGenerator`) · `proto/` (protobuf wire
+schema) · `qserv/` (controller→qserv-worker/czar management requests, HTTP) ·
+`registry/` (the Registry service + client) · `services/` (`ServiceProvider`
+singletons, `DatabaseServices` persistence, `ChunkMap` publisher) · `worker/` (the
+replica-worker daemon) · `tools/` (binary entry points) · `util/`, `tests/`.
+
+## Controller
+
+`MasterControllerHttpApp` runs three things:
+
+- **ReplicationTask** — the linear replication loop, each cycle:
+  `FindAllJob` (rescan replicas on all workers) → `FixUpJob` (repair/colocation) →
+  `ReplicateJob` (raise chunks to the family replication level) → `RebalanceJob` →
+  optional `PurgeJob` (drop excess), each followed by a `QservSyncJob` that pushes the
+  "good replica" view into qserv workers' `ChunkInventory` (`POST /replicas` on the
+  worker management port). With `--qserv-chunk-map-update` it also republishes the
+  chunk map (below).
+- **HealthMonitorTask** — probes both the qserv service and the replication service on
+  every worker; a worker becomes an eviction candidate only when *both* are silent
+  past the timeout, and only one worker may be evicted at a time (a second concurrent
+  failure demands human intervention). Eviction = stop ReplicationTask, run
+  `DeleteWorkerJob` (redistribute its chunks), restart.
+- **The REST API** (`contr/HttpProcessor` + `Http*Module` classes) on
+  `controller.http-server-port` (25081): `/replication/*` (config, workers, levels,
+  jobs, requests, qserv monitoring), `/ingest/*` (databases, tables, transactions,
+  chunk allocation, director index, table stats), `/export/*`. It also serves the
+  `www/` dashboard as static content.
+
+A tracker thread reconciles Registry heartbeats into the Configuration,
+auto-registering new workers/czars if configured.
+
+### Jobs → requests → transport
+
+Controller *jobs* (`jobs/`) fan out into per-worker *requests* (`requests/`).
+**Current controller↔replica-worker transport is protobuf over persistent TCP**
+(`proto/protocol.proto`, 4-byte length-prefixed frames, multiplexed per-worker by
+`requests/Messenger`). A parallel **HTTP backend** on the replica worker
+(`worker/WorkerHttpSvc`, `/worker/*` routes) is implemented and served but **nothing
+calls it yet** — the controller-side migration hasn't happened (easy to misread the
+tree as HTTP-only). By contrast, controller→*qserv* management traffic (`qserv/`
+request classes) is already fully HTTP against the qserv workers'/czars' management
+ports.
+
+## Registry (`registry/`)
+
+A small qhttp service (port 25082) holding a purely **in-memory** JSON map — no
+persistence, **no TTL/expiry**; consumers judge staleness via `update-time-ms`.
+Registrants (all on ~1 s heartbeat loops): replica workers (`POST /worker`), qserv
+workers (`POST /qserv-worker` — name is the UUID from `qservw_worker.Id`, plus
+management-port and result-file data-port), czars (`POST /czar` — note a *denied*
+czar registration calls `abort()`), and the controller (`POST /controller`).
+Consumers: the controller (worker/czar discovery + health) and each czar
+(`czar::CzarRegistry` polls `GET /services` every 15 s to build its worker contact
+map).
+
+## Configuration and database families (`config/`)
+
+`replica::Configuration` is backed by `qservReplica` (schema version asserted at load;
+`--schema-upgrade-wait` supports rolling smig upgrades). Durable tables hold general
+params, worker enable/read-only flags (`config_worker` — host/ports come from the
+Registry at runtime, *not* the DB), families, databases, tables, and table schemas.
+
+A **database family** (`config_database_family`) = databases sharing identical
+partitioning (`num_stripes`, `num_sub_stripes`, `overlap`) plus a
+`min_replication_level`; same-numbered chunks are spatially identical across the
+family and are kept colocated so joins work worker-locally. Families are created
+implicitly when a database is registered with a new parameter combination. Effective
+replication level = `min(family level, controller.max-repl-level, #eligible workers)`.
+Changed via `PUT /replication/level`.
+
+## Ingest workflow (internals)
+
+Matches `doc/ingest/api/concepts/overview.rst`. Key mechanics:
+
+1. **Register database/tables** (`POST /ingest/database`, `/ingest/table`): stores
+   metadata + schema in `qservReplica`; database starts unpublished.
+2. **Transactions** ("super-transactions", `POST /ingest/trans`): every ingested row
+   is tagged with a `qserv_trans_id` column and each transaction gets its own MySQL
+   partition in every affected table, making abort cheap (`AbortTransactionJob` drops
+   the partition cluster-wide). Explicit transitional states
+   (`IS_STARTING/STARTED/IS_ABORTING/...`) in the `transaction` table.
+3. **Chunk allocation** (`POST /ingest/chunk`): the controller picks the worker —
+   reusing an existing replica's worker, else preferring workers already holding that
+   chunk number for *any* database in the family (colocation), else least-loaded —
+   and returns that worker's loader endpoints. The workflow then **pushes
+   contribution data directly to workers**, bypassing the controller.
+4. **Contributions**: worker-side `IngestHttpSvc` (`POST /ingest/csv|data|file|
+   file-async`, sync and async by-reference modes; the async loader is a per-database
+   queued thread pool with per-database concurrency limits). `IngestFileSvc` stages
+   CSV (prepending the transaction id field) and runs `LOAD DATA INFILE`. Every
+   contribution is a row in `transaction_contrib` with full status/error/retry
+   bookkeeping — the `retry_allowed` flag tells workflows whether an in-transaction
+   retry is safe or the transaction must be aborted. (A legacy protobuf push protocol
+   and `qserv-replica-file INGEST` client also exist.)
+5. **Commit/abort transactions**, then **publish** (`PUT /ingest/database/:db`):
+   consolidate the director index, optionally scan/deploy row counters, create
+   missing chunk tables, **drop the per-transaction MySQL partitions**, then
+   `_publishDatabaseInMaster`: create the database/prototype tables in the czar's
+   MariaDB, register everything **in CSS** (striping params from the family, match
+   tables, scan params), and rebuild the CSS **empty-chunk list** (all chunks the
+   sphgeom Chunker allows minus chunks actually ingested). Finally flip
+   `is_published`, reconfigure workers, qserv-sync, and notify czars.
+
+Czar-facing notifications are `POST /event` with a `DataManagementEvent`
+(`DATABASE_PUBLISHED`, `CHUNK_MAP_REBUILT`, ...) → czar `EventService` → empty-chunks
+cache invalidation and family-map re-read.
+
+## Director index and row counters
+
+- **Director index**: `qservMeta.<db>__<DirectorTable>` mapping director key →
+  (chunkId, subChunkId). Built incrementally during ingest (per-transaction
+  partitions, consolidated at publish; vetoable via `auto_build_secondary_index=0`)
+  or bulk-rebuilt via `POST /ingest/index/secondary` → `DirectorIndexJob`, which
+  harvests per-(worker, chunk) extracts (`SELECT ... INTO OUTFILE`, streamed back)
+  and `LOAD DATA LOCAL INFILE`s them into the index table.
+- **Row counters** (`POST /ingest/table-stats`): per-chunk row counts persisted in
+  `qservReplica.stats_table_rows` and optionally *deployed* to
+  `qservMeta.<db>__<table>__rows` — which is exactly what the czar's
+  `SELECT COUNT(*)` optimization reads.
+
+## Chunk map: how placement reaches the czar
+
+`replica::ChunkMap::update()` reads COMPLETE replicas from `DatabaseServices`, and
+atomically rewrites the `chunkMap` + `chunkMapStatus` tables in the czar's
+**qservMeta** DB (full delete + bulk insert in one transaction). Triggered by the
+replication loop (with `--qserv-chunk-map-update`) and on ingest events, followed by
+`CHUNK_MAP_REBUILT` events to all registered czars. The czar reads it back through
+`qmeta::QMeta::getChunkMap()` into `czar::CzarFamilyMap`/`CzarChunkMap`, which greedily
+assigns each chunk a primary scan worker (largest chunks first, least-loaded
+replica-holder wins). **Caveat:** czar-side "family" is currently a stub — one
+pseudo-family per database (`CzarFamilyMap::getFamilyNameFromDbName` returns the db
+name, TODO DM-53239) — so the czar does not yet see real family grouping.
+
+## Replica-worker daemon (`worker/`)
+
+Reads its identity from the colocated qserv worker's `qservw_worker.Id`, then runs
+**six services in one process**: protobuf/TCP replica-management (`worker.svc-port`),
+HTTP replica-management (served, unused — see above), the file server (`fs-port`,
+serves replica files to *other* workers during replication), legacy binary ingest
+(`loader-port`), HTTP ingest (`http-loader-port`), and the exporter
+(`exporter-port`). Plus the Registry heartbeat.
+
+It does **not** talk to the qserv worker's REST API — the *controller* does that
+(`QservSyncJob` → `POST /replicas` etc. against `wcomms/HttpReplicaMgtModule`) to keep
+`ChunkInventory` in sync with what the replication system considers good replicas.
+
+## Binaries
+
+`qserv-replica-master-http` (controller), `qserv-replica-worker`,
+`qserv-replica-registry`, `qserv-replica-config[-test]`, `qserv-replica-controller-cmd`,
+`qserv-replica-worker-notify`, `qserv-replica-calc-cs`, and multi-verb tools
+`qserv-replica-job` (REPLICATE, PURGE, REBALANCE, FIXUP, SYNC, INDEX, DELETE-WORKER,
+...), `qserv-replica-file` (INGEST client, file server, S3), `qserv-replica-test`.
+
+## Known gaps / in-flight work
+
+- HTTP worker backend served but unconsumed (protobuf path still authoritative).
+- Czar family stub (DM-53239) — `chunkMap` carries no family column yet.
+- `Czar::_monitor()` currently forces a family-map re-read every cycle (`|| true`
+  with a TODO) despite the event-driven path existing.
+- `ChunkMap::update()` rewrites the whole table each time; no incremental path.
+- Registry entries never expire; explicit DELETE only.

--- a/doc/architecture/worker.md
+++ b/doc/architecture/worker.md
@@ -1,0 +1,151 @@
+# Worker internals (`src/w*`)
+
+*Current as of 2026-08, derived from code inspection. Trust the code over this doc if
+they diverge; update this doc when you change the code.*
+
+The worker is one process, `qserv-worker-http` (`src/wmain/`), colocated with a MariaDB
+holding chunk tables and with the `qserv-replica-worker` agent. It exposes **two** HTTP
+servers:
+
+1. The REST API (`wcomms::HttpSvc`) on the configured `replication.http_port` (25010 in
+   deployments) — used by *both* czars (`/queryjob`, `/querystatus`) and the
+   replication system (`/replica*`, `/inventory`) plus monitoring endpoints.
+2. A **separate result-file server** owned by `wcontrol::Foreman`
+   (`src/wcontrol/Foreman.cc` — `qhttp::Server::create(_io_service, 0)`, i.e. an
+   **OS-assigned port**) that serves the results directory as static content and
+   accepts `DELETE /:file`. The worker advertises both ports to the registry
+   (`management-port` vs `data-port`).
+
+## Startup (`src/wmain/WorkerMain.cc`)
+
+Order: config (`wconfig::WorkerConfig`) → schedulers (GroupScheduler + Scan
+fast/med/slow + snail, blended by `wsched::BlendScheduler`) → `wpublish::QueriesAndChunks`
+global stats/booting threads → `wcontrol::SqlConnMgr` → `ChunkInventory` (retries
+`SELECT db FROM qservw_worker.Dbs` forever, 1 s loop — this doubles as the MariaDB
+readiness gate) → `Foreman` → results-dir GC (deletes *all* result files on restart) →
+`wcomms::HttpSvc` → a registry heartbeat thread POSTing worker name (the UUID from
+`qservw_worker.Id`, not the config name), FQDN, and both ports every ~1 s.
+
+Scan schedulers partition tasks by scan rating (`protojson::ScanInfo::Rating`:
+FASTEST=0..SLOWEST=100): fast [0,10], med [11,20], slow [21,30], snail [31,100].
+
+## From UberJob to Tasks (`wcomms/`, `wbase/`)
+
+`POST /queryjob` (`wcomms/HttpWorkerCzarModule.cc`) parses `protojson::UberJobMsg`,
+registers the query with `QueriesAndChunks` (rejecting UberJobs for already-cancelled
+queries or already-dead UberJob ids), and creates `wbase::UberJobData` — which owns the
+single `FileChannelShared` output channel, the czar contact info, row limit, and
+`maxTableSizeBytes` (arrives **in the message**, not from worker config). Actual task
+building is deferred to a scheduler command; the HTTP handler returns immediately, and
+later failures are reported asynchronously to the czar.
+
+Task fan-out (`wbase/Task.cc`, `createTasksFromUberJobMsg`): UberJob → one job per
+chunk → fragments → sub-query templates → subchunks. One `Task` per (template ×
+subchunk); chunk-only fragments get a single task with `subchunkId = -1`. Query
+templates are interned per-query in `wbase::UserQueryInfo` and expanded at run time by
+substituting the `%CC%`/`%SS%` placeholder tags with chunk/subchunk numbers. All tasks
+of an UberJob share one result file. Task states:
+`CREATED → QUEUED → STARTED → EXECUTING_QUERY → READING_DATA → FINISHED`.
+
+## Scheduling (`wsched/`)
+
+`BlendScheduler::queCmd` routes a whole UberJob's tasks by the **first** task:
+interactive or no scan tables → GroupScheduler (effectively a FIFO for point queries);
+otherwise the ScanScheduler whose rating window matches; queries already "booted" go to
+the snail scheduler. Key mechanics:
+
+- **Shared scans:** each ScanScheduler wraps a `ChunkTasksQueue` — a map keyed by
+  chunkId with a rotating "active chunk" cursor. Tasks arriving for the active chunk
+  wait in a pending set so a chunk can't be monopolized; new chunks only open while
+  the scheduler is under its `maxactivechunks` limit; within a chunk, tasks for the
+  slowest tables run first. UberJobs are built chunk-ordered czar-side so workers'
+  scans stay aligned.
+- **Thread reservation:** each sub-scheduler reserves `inFlight + 1` threads up to its
+  configured reserve, so no scheduler is starved; pool floor is 11 threads.
+- **Booting** (`wpublish/QueriesAndChunks::examineAll`, every ~2 min): tasks running
+  longer than their scheduler's `scanmaxminutes` allowance are "booted" — the thread
+  *leaves the pool* (task keeps running as untracked load, pool spawns a replacement)
+  — and queries exceeding `maxtasksbootedperuserquery` are moved wholesale to the
+  snail scheduler. There is currently **no escalation past snail** (TODO in
+  `BlendScheduler.cc`: should ask the czar to cancel). The per-chunk timing model that
+  was meant to drive booting is currently bypassed (`useTimeStatisticsForBoot` is
+  hard-coded false).
+
+## Execution (`wdb/`)
+
+`wdb::QueryRunner::runQuery` per task: admission through `wcontrol::SqlConnMgr`
+(separate budgets for interactive vs scan connections — **note** the config names
+`maxsqlconn`/`reservedinteractivesqlconn` map inversely to the internal scan/shared
+limits and the defaults appear to violate the constructor's own validation; check the
+deployed config, there's a TODO to fix this) → fresh MySQL connection **always as user
+`qsmaster`** (`Task::defaultUser`; the configured `mysql.username` is only used for
+inventory/subchunk management connections) → acquire `ChunkResource` → run the
+(unbuffered) query → stream rows into the shared result file.
+
+**Subchunks:** `wdb::ChunkResource`/`SQLBackend` refcount and materialize subchunk and
+overlap tables on demand as `ENGINE = MEMORY` tables:
+`Subchunks_<db>_<chunk>.<tbl>_<chunk>_<sub> AS SELECT ... WHERE subChunkId = <sub>`
+(`src/wbase/Base.cc`), dropped when the refcount hits zero — currently per *task*, not
+per chunk, so near-neighbor queries can rebuild the same subchunk tables repeatedly
+(TODO in `QueryRunner.cc`). A global "memory lock" table
+(`q_memoryLockDb.memoryLockTbl`) is truncated and claimed at startup: the newest
+worker steals it and a worker that loses it `exit(EXIT_FAILURE)`s on next touch — two
+workers must never share one MariaDB.
+
+## Result files (`wbase/FileChannelShared`)
+
+- Named `<czarId>-<queryId>-<uberJobId>.csv` in `results.dirname`
+  (`util::ResultFileName`), but the content is **quoted TSV**: tab-separated,
+  single-quote-enclosed fields, `\N` for NULL — matching the czar's
+  `LOAD DATA ... FIELDS ENCLOSED BY '\''` loader.
+- `maxTableSizeBytes` is enforced after each task's rows are appended (an oversized
+  task overshoots on disk before failing) → `WORKER_RESULT_TOO_LARGE` error to czar.
+- LIMIT queries: once the file holds enough rows (`rowLimitComplete`), the first task
+  to notice latches it, remaining tasks self-cancel, and the file ships early.
+- When the last task finishes, the worker POSTs `UberJobReadyMsg` to the czar's
+  `/queryjob-ready` (`{fileUrl, rowCount, fileSize, ...}`); errors go to
+  `/queryjob-error`. Delivery failures are parked in `WorkerCzarComIssue` for retry if
+  the czar still looks alive.
+- Deletion paths: czar DELETEs after successful merge; worker deletes on error/cancel,
+  on czar-restart notice, on `/querystatus` done-lists, and deletes *everything* on
+  its own restart. All GC serializes on one static mutex also taken by the `/status`
+  monitoring endpoints (a monitoring poll briefly blocks new result channels).
+
+## Worker↔czar status protocol (`protojson/`, `wcontrol/WCzarInfoMap`, czar-side `czar/ActiveWorker`)
+
+Czars POST `WorkerQueryStatusData` to every worker's `/querystatus` on a steady cycle
+(even when empty — it doubles as a czar heartbeat): lists of finished queries
+(keep-files vs delete-files), dead UberJobs, and czar-restart markers. The worker
+applies them (cancels tasks — including for query ids it has never seen, which is how
+future UberJobs of cancelled queries get rejected — deletes files) and echoes the
+lists back so the czar can prune its maps, plus its `w-startup-time` so the czar
+detects worker restarts (→ kills incomplete UberJobs and reassigns). Conversely a
+worker that hears nothing from a czar for `czar.DeadTimeSec` (180 s) kills all that
+czar's queries; a czar that the registry says is stale transitions
+ALIVE→QUESTIONABLE→DEAD czar-side and its workers' incomplete UberJobs are reassigned.
+
+## Chunk inventory (`wpublish/ChunkInventory`)
+
+Tables `Dbs`, `Chunks`, `Id` (UUID) in `qservw_worker`. Maintained push-style by the
+replication system through `/replica*` / `PUT /inventory` (rebuild regenerates
+`Chunks` from `information_schema`). Note: the query path never checks the inventory —
+a task for a chunk the worker lacks just fails in MySQL. The "replica in use"
+protection is currently vacuous: `wcontrol::ResourceMonitor` is never incremented
+(TODO DM-53240); live per-chunk usage is instead tracked by `QueriesAndChunks` and
+exposed at `/chunkusecounts`.
+
+## Gotchas worth knowing before editing
+
+- `qserv-worker-http.cc` `#include`s `WorkerMain.cc` (the .cc!) — ODR trap.
+- `BlendScheduler`'s steady-state scheduler polling order is group, **slow, fast,
+  med**, snail (construction order), contradicting its own class doc; the configured
+  `priority_*` values only apply when `results.prioritize_by_inflight = true`
+  (default false).
+- Lock ordering: never take `BlendScheduler::_schedMtx` before
+  `util::CommandQueue::_mx`; sub-schedulers reuse the base-class queue mutex.
+- Dead code that looks live: `Foreman::_workerCommandPool` (threads with no work),
+  `wbase::SendChannel` (legacy), `ResourceMonitor` counts, `ChunkInventory::has()`,
+  `useFlexibleLock` plumbing in wsched.
+- `replication.num_http_threads` is unused on the worker; `czar.ComNumHttpThreads`
+  (default 40) sizes the REST service, and `results.num_http_threads` (default **1**)
+  sizes the result-file server.

--- a/doc/architecture/worker.md
+++ b/doc/architecture/worker.md
@@ -22,7 +22,8 @@ Order: config (`wconfig::WorkerConfig`) → schedulers (GroupScheduler + Scan
 fast/med/slow + snail, blended by `wsched::BlendScheduler`) → `wpublish::QueriesAndChunks`
 global stats/booting threads → `wcontrol::SqlConnMgr` → `ChunkInventory` (retries
 `SELECT db FROM qservw_worker.Dbs` forever, 1 s loop — this doubles as the MariaDB
-readiness gate) → `Foreman` → results-dir GC (deletes *all* result files on restart) →
+readiness gate) → `Foreman` → results-dir GC (deletes *all* result files on restart;
+`results.clean_up_on_start`, default true) →
 `wcomms::HttpSvc` → a registry heartbeat thread POSTing worker name (the UUID from
 `qservw_worker.Id`, not the config name), FQDN, and both ports every ~1 s.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,9 @@ from documenteer.conf.guide import *
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["misc", "CMakeLists.txt"]
+# "architecture" holds developer/agent-oriented markdown notes that are not part
+# of the published guide (see architecture/README.md).
+exclude_patterns = ["misc", "CMakeLists.txt", "architecture"]
 
 # Add any URL patterns to ignore (e.g. for private sites, or sites that
 # are frequently down).


### PR DESCRIPTION
Okay folks, here are adds to the repo to provide context to AI coding agents, which should facilitate more efficient, accurate, and consistent usage.

I sought advice from Merlin (a Rubin human, not agent, if you have not met him :-)), who works with coding agents extensively on summit systems, re. how to most effectively derive these.  As they exist in this PR, these are pretty much entirely written by Claude itself, having introspected our codebase.  I will include my original prompt material, as well as additional prompts/directions from Merlin, on the associated Jira ticket if you are curious to see how these were generated in detail.

I found these pretty fun to read -- it's quite delightful to see how well and thoroughly the agents can summarize the code, it's design, and usage.  Now it's up to us to correct inaccuracies and or omissions.  Please post your edit suggestions on the PR, and I will fold them in before we merge.

Please remember that these materials are for consumption by the coding agents, not other humans.  They will work best if kept brief.  The intent is to (re)load the agents with design and implementation awareness, and "save it the effort" ($$) of rereading and reanalyzing the entire code base, ab initio, on each session.  The truly small details can be gleaned by the agents with more focused code reads after having loaded this context.

I recommend starting with `AGENTS.md`.  As part of the prompt material, I cautioned Claude that much of what was to be found under `doc/` was severely dated (except the parts Igor has been working on recently). In response to one of Merlin's prompts, it wrote its own, up to date, brief architecture summary there (see doc/architecture/ on this PR).  As is, Claude wrote that principally for its own consumption, and arranged for it _not_ to be published in the official docs.  Parts of it are pretty good, though, and we might do well to crib from some of it...

This also ran over `main`, and made observations like "XRootD is gone now..." etc.  So some of this will need to be adjusted during backport if Igor would like to have versions tailored for use on the `xrd` branch.  (Igor, we can go another round for that if you wish, asking it to have an initial pass at tailoring what is here specifically for the `xrd` branch and seeing what we get.)