### PR TITLE
DM-55571: Czar-level EXPLAIN query support

### DIFF
--- a/src/ccontrol/CMakeLists.txt
+++ b/src/ccontrol/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(ccontrol PRIVATE
     ParseRunner.cc
     QueryState.cc
     UserQueryAsyncResult.cc
+    UserQueryExplain.cc
     UserQueryFactory.cc
     UserQueryProcessList.cc
     UserQueryQueries.cc

--- a/src/ccontrol/UserQueryExplain.cc
+++ b/src/ccontrol/UserQueryExplain.cc
@@ -1,0 +1,216 @@
+// -*- LSST-C++ -*-
+/*
+ * LSST Data Management System
+ * Copyright 2026 LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Class header
+#include "ccontrol/UserQueryExplain.h"
+
+// System headers
+#include <sstream>
+
+// Third-party headers
+#include "nlohmann/json.hpp"
+
+// LSST headers
+#include "lsst/log/Log.h"
+
+// Qserv headers
+#include "cconfig/CzarConfig.h"
+#include "query/ScanTableInfo.h"
+#include "qmeta/MessageStore.h"
+#include "qproc/QuerySession.h"
+#include "query/AreaRestrictor.h"
+#include "query/QueryTemplate.h"
+#include "query/SecIdxRestrictor.h"
+#include "query/SelectStmt.h"
+#include "query/typedefs.h"
+#include "sql/SqlBulkInsert.h"
+#include "sql/SqlConnection.h"
+#include "sql/SqlConnectionFactory.h"
+#include "sql/SqlErrorObject.h"
+#include "util/Error.h"
+#include "util/IterableFormatter.h"
+
+using namespace lsst::qserv;
+using json = nlohmann::json;
+
+namespace {
+LOG_LOGGER _log = LOG_GET("lsst.qserv.ccontrol.UserQueryExplain");
+
+/// Concatenate restrictors for display
+template <typename VecPtr>
+std::string restrictorsToString(VecPtr const& restrictors) {
+    if (restrictors == nullptr || restrictors->empty()) return "none";
+    std::ostringstream os;
+    os << util::ptrPrintable(restrictors, "", "");
+    return os.str();
+}
+
+/// Convert JSON values for use in MariaDB-style EXPLAIN table
+std::string jsonValueToString(json const& value) {
+    if (value.is_string()) return value.get<std::string>();
+    if (value.is_boolean()) return value.get<bool>() ? "yes" : "no";
+    if (value.is_number()) return value.dump();
+    return value.dump(2);
+}
+
+}  // namespace
+
+namespace lsst::qserv::ccontrol {
+
+UserQueryExplain::UserQueryExplain(std::shared_ptr<qproc::QuerySession> const& qSession,
+                                   std::string const& userQueryId, std::string const& resultDb,
+                                   bool jsonFormat)
+        : _qSession(qSession),
+          _jsonFormat(jsonFormat),
+          _messageStore(std::make_shared<qmeta::MessageStore>()),
+          _resultTableName("qserv_result_explain_" + userQueryId),
+          _resultDb(resultDb) {}
+
+std::string UserQueryExplain::getError() const { return _qSession->getError(); }
+
+json UserQueryExplain::_getQueryInfo() const {
+    auto const& qs = *_qSession;
+    json qInfo = json::object();
+
+    qInfo["parsed_sql"] = qs.getStmt().getQueryTemplate().sqlFragment();
+
+    std::ostringstream irStream;
+    irStream << qs.getStmt();
+    qInfo["parsed_ir"] = irStream.str();
+
+    qInfo["needs_merge"] = qs.needsMerge();
+    auto const mergeStmt = qs.getMergeStmt();
+    qInfo["merge_sql"] = mergeStmt != nullptr ? mergeStmt->getQueryTemplate().sqlFragment() : "none";
+
+    qInfo["is_chunked"] = qs.hasChunks();
+    qInfo["chunks_matched"] = qs.isDummy() ? 0 : qs.getChunksSize();
+
+    qInfo["area_restrictors"] = restrictorsToString(qs.getAreaRestrictors());
+    qInfo["secidx_restrictors"] = restrictorsToString(qs.getSecIdxRestrictors());
+
+    qInfo["scan_interactive"] = qs.getScanInteractive();
+    auto const scanInfo = qs.getScanInfo();
+    qInfo["scan_rating"] = scanInfo->scanRating;
+    json scanTables = json::array();
+    for (auto const& tbl : scanInfo->infoTables) {
+        scanTables.push_back(json::object({{"db", tbl.db},
+                                           {"table", tbl.table},
+                                           {"rating", tbl.scanRating},
+                                           {"lock_in_memory", tbl.lockInMemory}}));
+    }
+    qInfo["scan_tables"] = scanTables;
+
+    std::ostringstream workerStream;
+    bool first = true;
+    for (auto const& stmt : qs.getStmtParallel()) {
+        if (stmt == nullptr) continue;
+        if (!first) workerStream << " /*QSEPARATOR*/; ";
+        workerStream << stmt->getQueryTemplate().sqlFragment();
+        first = false;
+    }
+    qInfo["worker_sql"] = first ? "none" : workerStream.str();
+
+    return qInfo;
+}
+
+std::string UserQueryExplain::getResultQuery() const {
+    return "SELECT * FROM " + _resultDb + "." + _resultTableName + " ORDER BY 1";
+}
+
+void UserQueryExplain::submit() {
+    try {
+        _populateResultTable();
+    } catch (std::exception const& exc) {
+        std::string const message = std::string("Internal failure, EXPLAIN failed: ") + exc.what();
+        LOGS(_log, LOG_LVL_ERROR, message);
+        _messageStore->addMessage(-1, "EXPLAIN", util::Error::INTERNAL, message, MessageSeverity::MSG_ERROR);
+        _qState = ERROR;
+    }
+}
+
+void UserQueryExplain::_populateResultTable() {
+    auto qInfo = _getQueryInfo();
+
+    auto const czarConfig = cconfig::CzarConfig::instance();
+    auto const resultDbConn = sql::SqlConnectionFactory::make(czarConfig->getMySqlResultConfig());
+    sql::SqlErrorObject errObj;
+
+    auto fail = [this](int code, std::string const& message) {
+        LOGS(_log, LOG_LVL_ERROR, message);
+        _messageStore->addMessage(-1, "EXPLAIN", code, message, MessageSeverity::MSG_ERROR);
+        _qState = ERROR;
+    };
+
+    std::string createTable;
+    std::vector<std::string> columns;
+    std::vector<std::vector<std::string>> rows;
+
+    if (_jsonFormat) {
+        // Single-column, single-row JSON document (like MariaDB EXPLAIN FORMAT=JSON).
+        createTable = "CREATE TABLE " + _resultTableName + " (`EXPLAIN` MEDIUMTEXT)";
+        columns = {"EXPLAIN"};
+        rows.push_back({qInfo.dump(2)});
+    } else {
+        // Attribute/value table, one row per entry
+        createTable = "CREATE TABLE " + _resultTableName + " (`attribute` VARCHAR(255), `value` MEDIUMTEXT)";
+        columns = {"attribute", "value"};
+        for (auto const& [key, value] : qInfo.items()) {
+            rows.push_back({key, jsonValueToString(value)});
+        }
+    }
+
+    LOGS(_log, LOG_LVL_DEBUG, "creating result table: " << createTable);
+    if (!resultDbConn->runQuery(createTable, errObj)) {
+        fail(util::Error::RESULT_CREATETABLE,
+             "Internal failure, failed to create result table: " + errObj.errMsg());
+        return;
+    }
+
+    sql::SqlBulkInsert bulkInsert(resultDbConn.get(), _resultTableName, columns);
+    for (auto const& row : rows) {
+        std::vector<std::string> values;
+        values.reserve(row.size());
+        for (auto const& value : row) {
+            values.push_back("'" + resultDbConn->escapeString(value) + "'");
+        }
+        if (!bulkInsert.addRow(values, errObj)) {
+            fail(util::Error::RESULT_SQL,
+                 "Internal failure, error updating result table: " + errObj.errMsg());
+            return;
+        }
+    }
+    if (!bulkInsert.flush(errObj)) {
+        fail(util::Error::RESULT_SQL, "Internal failure, error updating result table: " + errObj.errMsg());
+        return;
+    }
+
+    _qState = SUCCESS;
+}
+
+QueryState UserQueryExplain::join() { return _qState; }
+
+void UserQueryExplain::kill() {}
+
+void UserQueryExplain::discard() {}
+
+}  // namespace lsst::qserv::ccontrol

--- a/src/ccontrol/UserQueryExplain.h
+++ b/src/ccontrol/UserQueryExplain.h
@@ -1,0 +1,106 @@
+// -*- LSST-C++ -*-
+/*
+ * LSST Data Management System
+ * Copyright 2026 LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_QSERV_CCONTROL_USERQUERYEXPLAIN_H
+#define LSST_QSERV_CCONTROL_USERQUERYEXPLAIN_H
+
+// System headers
+#include <memory>
+#include <string>
+
+// Third-party headers
+#include "nlohmann/json_fwd.hpp"
+
+// Qserv headers
+#include "ccontrol/UserQuery.h"
+#include "global/intTypes.h"
+
+// Forward decl
+namespace lsst::qserv::qproc {
+class QuerySession;
+}  // namespace lsst::qserv::qproc
+
+namespace lsst::qserv::ccontrol {
+
+/// UserQueryExplain : implementation of UserQuery for `EXPLAIN [FORMAT=JSON] <select>`.
+///
+/// The supplied QuerySession should have already had analysis run previously. This query type places analysis
+/// info into a result table (either tabular or JSON format).
+class UserQueryExplain : public UserQuery {
+public:
+    /**
+     *  @param qSession   Already-analyzed QuerySession for the inner SELECT query.
+     *  @param userQueryId Unique string identifying query
+     *  @param resultDb   Name of the database that will contain results.
+     *  @param jsonFormat If true, output a single-column JSON document
+     */
+    UserQueryExplain(std::shared_ptr<qproc::QuerySession> const& qSession, std::string const& userQueryId,
+                     std::string const& resultDb, bool jsonFormat);
+
+    UserQueryExplain(UserQueryExplain const&) = delete;
+    UserQueryExplain& operator=(UserQueryExplain const&) = delete;
+
+    /// @return a non-empty string describing the current error state
+    std::string getError() const override;
+
+    /// Populate the EXPLAIN result table.
+    void submit() override;
+
+    /// Wait until the query has completed execution (everything happens in submit()).
+    QueryState join() override;
+
+    /// No-op, does not run async
+    void kill() override;
+
+    /// No-op, no resources to release
+    void discard() override;
+
+    // Delegate objects
+    std::shared_ptr<qmeta::MessageStore> getMessageStore() override { return _messageStore; }
+
+    /// @return Name of the result table for this query.
+    std::string getResultTableName() const override { return _resultTableName; }
+
+    /// @return Result location for this query.
+    std::string getResultLocation() const override { return "table:" + getResultTableName(); }
+
+    std::string getResultQuery() const override;
+
+private:
+    /// Gather query analysis info as JSON, one attribute per key.
+    nlohmann::json _getQueryInfo() const;
+
+    /// Create and populate the result table. May throw; callers must not let that escape submit().
+    void _populateResultTable();
+
+    std::shared_ptr<qproc::QuerySession> _qSession;
+    bool const _jsonFormat;
+    QueryState _qState = UNKNOWN;
+    std::shared_ptr<qmeta::MessageStore> _messageStore;
+    std::string _resultTableName;
+    std::string _resultDb;
+};
+
+}  // namespace lsst::qserv::ccontrol
+
+#endif  // LSST_QSERV_CCONTROL_USERQUERYEXPLAIN_H

--- a/src/ccontrol/UserQueryFactory.cc
+++ b/src/ccontrol/UserQueryFactory.cc
@@ -41,6 +41,7 @@
 #include "ccontrol/ConfigMap.h"
 #include "ccontrol/ParseRunner.h"
 #include "ccontrol/UserQueryAsyncResult.h"
+#include "ccontrol/UserQueryExplain.h"
 #include "ccontrol/UserQueryInvalid.h"
 #include "ccontrol/UserQueryProcessList.h"
 #include "ccontrol/UserQueryQueries.h"
@@ -184,6 +185,63 @@ std::shared_ptr<UserQuery> _makeUserQueryQueries(query::SelectStmt::Ptr& stmt,
 }
 
 /**
+ * @brief Make a UserQueryExplain (or UserQueryInvalid) from given parameters.
+ *
+ * Runs czar-side analysis (parse, plugins, restrictor and chunk coverage) on the provided SELECT without
+ * actually dispatching any work.
+ *
+ * @param innerQuery The SELECT statement to analyze
+ * @param jsonFormat True if JSON format was requested.
+ * @param sharedResources Resources used by UserQueryFactory to create UserQueries.
+ * @param defaultDb Default database name, may be empty.
+ * @param userQueryId Unique string identifying the query.
+ * @param resultDb Name of the database that will contain results.
+ * @return std::shared_ptr<UserQuery>, will be a UserQueryExplain or UserQueryInvalid.
+ */
+std::shared_ptr<UserQuery> _makeUserQueryExplain(std::string const& innerQuery, bool jsonFormat,
+                                                 userQuerySharedResourcesPtr& sharedResources,
+                                                 std::string const& defaultDb, std::string const& userQueryId,
+                                                 std::string const& resultDb) {
+    LOGS(_log, LOG_LVL_DEBUG,
+         "make UserQueryExplain: jsonFormat=" << (jsonFormat ? 'y' : 'n') << " query=" << innerQuery);
+
+    if (!UserQueryType::isSelect(innerQuery)) {
+        return std::make_shared<UserQueryInvalid>("EXPLAIN not supported for: " + innerQuery);
+    }
+    query::SelectStmt::Ptr stmt;
+    try {
+        stmt = ParseRunner::makeSelectStmt(innerQuery);
+    } catch (parser::ParseException& e) {
+        return std::make_shared<UserQueryInvalid>(std::string("ParseException:") + e.what());
+    }
+
+    auto qs = std::make_shared<qproc::QuerySession>(sharedResources->css, sharedResources->databaseModels,
+                                                    defaultDb, sharedResources->interactiveChunkLimit);
+    try {
+        qs->analyzeQuery(innerQuery, stmt);
+    } catch (...) {
+        return std::make_shared<UserQueryInvalid>(
+                "Unknown failure occurred setting up QuerySession for EXPLAIN (query is invalid).");
+    }
+
+    if (!qs->getError().empty()) {
+        return std::make_shared<UserQueryInvalid>("Invalid query: " + qs->getError());
+    }
+
+    try {
+        // Compute chunk coverage
+        qs->setupChunking(sharedResources->secondaryIndex);
+
+        // Analysis before submission
+        qs->finalize();
+    } catch (std::exception const& exc) {
+        return std::make_shared<UserQueryInvalid>(std::string("EXPLAIN analysis failed: ") + exc.what());
+    }
+
+    return std::make_shared<UserQueryExplain>(qs, userQueryId, resultDb, jsonFormat);
+}
+
+/**
  * @brief Determine if the qmeta database has a metadata table with chunks & row
  *        counts that represents the table in the FROM statement for a SELECT
  *        COUNT(*) query.
@@ -296,6 +354,13 @@ UserQuery::Ptr UserQueryFactory::newUserQuery(std::string const& aQuery, std::st
     std::string dbName, tableName;
     bool full = false;
     QueryId userJobId = 0;
+
+    std::string explainStripped;
+    bool explainInJson = false;
+    if (UserQueryType::isExplain(query, explainStripped, explainInJson)) {
+        return _makeUserQueryExplain(explainStripped, explainInJson, _userQuerySharedResources, defaultDb,
+                                     userQueryId, resultDb);
+    }
 
     if (UserQueryType::isSelect(query)) {
         // Processing regular select query

--- a/src/ccontrol/UserQuerySelect.cc
+++ b/src/ccontrol/UserQuerySelect.cc
@@ -101,7 +101,6 @@
 #include "rproc/InfileMerger.h"
 #include "sql/Schema.h"
 #include "util/Bug.h"
-#include "util/IterableFormatter.h"
 #include "util/QdispPool.h"
 
 using namespace std;
@@ -695,48 +694,7 @@ void UserQuerySelect::_expandSelectStarInMergeStatment(shared_ptr<query::SelectS
 
 void UserQuerySelect::saveResultQuery() { _queryMetadata->saveResultQuery(_queryId, getResultQuery()); }
 
-void UserQuerySelect::_setupChunking() {
-    LOGS(_log, LOG_LVL_TRACE, "Setup chunking");
-    std::shared_ptr<qproc::IndexMap> im;
-    std::shared_ptr<IntSet const> eSet = _qSession->getEmptyChunks();
-    {
-        eSet = _qSession->getEmptyChunks();
-        if (!eSet) {
-            eSet = make_shared<IntSet>();
-            LOGS(_log, LOG_LVL_WARN, "Missing empty chunks info for dominantDbs");
-        }
-    }
-    // FIXME add operator<< for QuerySession
-    LOGS(_log, LOG_LVL_TRACE, "_qSession: " << _qSession);
-    if (_qSession->hasChunks()) {
-        auto areaRestrictors = _qSession->getAreaRestrictors();
-        auto secIdxRestrictors = _qSession->getSecIdxRestrictors();
-        css::StripingParams partStriping = _qSession->getDbStriping();
-        auto const im = std::make_shared<qproc::IndexMap>(partStriping, _secondaryIndex);
-        qproc::ChunkSpecVector csv;
-        if (areaRestrictors != nullptr || secIdxRestrictors != nullptr) {
-            csv = im->getChunks(areaRestrictors, secIdxRestrictors);
-        } else {  // Unrestricted: full-sky
-            csv = im->getAllChunks();
-        }
-        LOGS(_log, LOG_LVL_TRACE, "Chunk specs: " << util::printable(csv));
-
-        // Filter out empty chunks
-        std::shared_ptr<IntSet const> eSet = _qSession->getEmptyChunks();
-        if (!eSet) {
-            eSet = std::make_shared<IntSet const>();
-            LOGS(_log, LOG_LVL_WARN, "Missing empty chunks info for dominantDbs");
-        }
-        for (qproc::ChunkSpecVector::const_iterator i = csv.begin(), e = csv.end(); i != e; ++i) {
-            if (eSet->count(i->chunkId) == 0) {  // chunk not in empty?
-                _qSession->addChunk(*i);
-            }
-        }
-    } else {
-        LOGS(_log, LOG_LVL_TRACE, "No chunks added, QuerySession will add dummy chunk");
-    }
-    _qSession->setScanInteractive();
-}
+void UserQuerySelect::_setupChunking() { _qSession->setupChunking(_secondaryIndex); }
 
 void UserQuerySelect::qMetaRegister(string const& resultLocation, string const& msgTableName) {
     qmeta::QInfo::QType qType = _async ? qmeta::QInfo::ASYNC : qmeta::QInfo::SYNC;

--- a/src/ccontrol/UserQueryType.cc
+++ b/src/ccontrol/UserQueryType.cc
@@ -30,7 +30,6 @@
 #include "boost/algorithm/string/case_conv.hpp"
 
 // LSST headers
-#include "lsst/log/Log.h"
 #include "query/FromList.h"
 #include "query/SelectStmt.h"
 #include "query/SelectList.h"
@@ -38,8 +37,6 @@
 #include "query/ValueExpr.h"
 
 namespace {
-
-LOG_LOGGER _log = LOG_GET("lsst.qserv.ccontrol.UserQueryType");
 
 // regex for SELECT *
 // Note that parens around whole string are not part of the regex but raw string literal
@@ -100,13 +97,10 @@ namespace lsst::qserv::ccontrol {
 
 /// Returns true if query is regular SELECT (not isSelectResult())
 bool UserQueryType::isSelect(std::string const& query) {
-    LOGS(_log, LOG_LVL_TRACE, "isSelect: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _selectRe);
     if (match) {
-        LOGS(_log, LOG_LVL_TRACE, "isSelect: match");
         if (boost::regex_match(query, sm, _selectResultRe)) {
-            LOGS(_log, LOG_LVL_TRACE, "isSelect: match select result");
             match = false;
         }
     }
@@ -115,12 +109,10 @@ bool UserQueryType::isSelect(std::string const& query) {
 
 /// Returns true if query is SHOW [FULL] PROCESSLIST
 bool UserQueryType::isShowProcessList(std::string const& query, bool& full) {
-    LOGS(_log, LOG_LVL_TRACE, "isShowProcessList: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _showProcessListRe);
     if (match) {
         full = sm.length(1) != 0;
-        LOGS(_log, LOG_LVL_TRACE, "isShowProcessList: full: " << (full ? 'y' : 'n'));
     }
     return match;
 }
@@ -138,64 +130,51 @@ bool UserQueryType::isQueriesTable(std::string const& dbName, std::string const&
 
 /// Returns true if query is SUBMIT ...
 bool UserQueryType::isSubmit(std::string const& query, std::string& stripped) {
-    LOGS(_log, LOG_LVL_TRACE, "isSubmit: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _submitRe);
     if (match) {
         stripped = sm.str(1);
-        LOGS(_log, LOG_LVL_TRACE, "isSubmit: match: " << stripped);
     }
     return match;
 }
 
 /// Returns true if query is SELECT * FROM QSERV_RESULT(...)
 bool UserQueryType::isSelectResult(std::string const& query, QueryId& queryId) {
-    LOGS(_log, LOG_LVL_TRACE, "isSelectResult: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _selectResultRe);
     if (match) {
         queryId = std::stoull(sm.str(1));
-        LOGS(_log, LOG_LVL_TRACE, "isSelectResult: queryId: " << queryId);
     }
     return match;
 }
 
 // Returns true if query is KILL [QUERY|CONNECTION] NNN
 bool UserQueryType::isKill(std::string const& query, int& threadId) {
-    LOGS(_log, LOG_LVL_TRACE, "isKill: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _killRe);
     if (match) {
         threadId = std::stoi(sm.str(1));
-        LOGS(_log, LOG_LVL_TRACE, "isKill: threadId: " << threadId);
     }
     return match;
 }
 
 // Returns true if query is CANCEL NNN
 bool UserQueryType::isCancel(std::string const& query, QueryId& queryId) {
-    LOGS(_log, LOG_LVL_TRACE, "isCancel: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _cancelRe);
     if (match) {
         queryId = std::stoull(sm.str(1));
-        LOGS(_log, LOG_LVL_TRACE, "isCancel: queryId: " << queryId);
     }
     return match;
 }
 
-bool UserQueryType::isCall(std::string const& query) {
-    LOGS(_log, LOG_LVL_TRACE, "isCall: " << query);
-    return boost::regex_match(query, _callRe);
-}
+bool UserQueryType::isCall(std::string const& query) { return boost::regex_match(query, _callRe); }
 
 bool UserQueryType::isResultDelete(std::string const& query, std::string& queryId) {
-    LOGS(_log, LOG_LVL_TRACE, "isResultDelete: " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _resultDeleteRe);
     if (match) {
         queryId = sm.str(1);
-        LOGS(_log, LOG_LVL_TRACE, "isResultDelete: queryId: " << queryId);
     }
     return match;
 }
@@ -220,23 +199,16 @@ bool UserQueryType::isSimpleCountStar(std::shared_ptr<query::SelectStmt> const& 
 
 /// Returns true if query is SET
 bool UserQueryType::isSet(std::string const& query) {
-    LOGS(_log, LOG_LVL_TRACE, "isSet: " << query);
     boost::smatch sm;
-    bool match = boost::regex_match(query, sm, _setRe);
-    if (match) {
-        LOGS(_log, LOG_LVL_TRACE, "isSet: match");
-    }
-    return match;
+    return boost::regex_match(query, sm, _setRe);
 }
 
 bool UserQueryType::isSetGlobal(std::string const& query, std::string& varName, std::string& varValue) {
-    LOGS(_log, LOG_LVL_TRACE, "isSetGlobal (extract): " << query);
     boost::smatch sm;
     bool match = boost::regex_match(query, sm, _setGlobalRe);
     if (match) {
         varName = sm.str(1);
         varValue = sm.str(2);
-        LOGS(_log, LOG_LVL_TRACE, "isSetGlobal: " << varName << "=" << varValue);
     }
     return match;
 }

--- a/src/ccontrol/UserQueryType.cc
+++ b/src/ccontrol/UserQueryType.cc
@@ -55,6 +55,11 @@ boost::regex _showProcessListRe(R"(^show\s+(full\s+)?processlist$)",
 boost::regex _submitRe(R"(^submit\s+(.+)$)",
                        boost::regex::ECMAScript | boost::regex::icase | boost::regex::optimize);
 
+// regex for EXPLAIN [FORMAT=JSON|TRADITIONAL] ...
+// group 1 (optional) is the requested output format, group 2 is the stripped query
+boost::regex _explainRe(R"(^explain\s+(?:format\s*=\s*(json|traditional)\s+)?(.+)$)",
+                        boost::regex::ECMAScript | boost::regex::icase | boost::regex::optimize);
+
 // regex for SELECT * FROM QSERV_RESULT(12345)
 // group 1 is the query ID number
 // Note that parens around whole string are not part of the regex but raw string literal
@@ -134,6 +139,17 @@ bool UserQueryType::isSubmit(std::string const& query, std::string& stripped) {
     bool match = boost::regex_match(query, sm, _submitRe);
     if (match) {
         stripped = sm.str(1);
+    }
+    return match;
+}
+
+/// Returns true if query is EXPLAIN [FORMAT=JSON|TRADITIONAL] ...
+bool UserQueryType::isExplain(std::string const& query, std::string& stripped, bool& jsonFormat) {
+    boost::smatch sm;
+    bool match = boost::regex_match(query, sm, _explainRe);
+    if (match) {
+        jsonFormat = boost::to_lower_copy(sm.str(1)) == "json";
+        stripped = sm.str(2);
     }
     return match;
 }

--- a/src/ccontrol/UserQueryType.h
+++ b/src/ccontrol/UserQueryType.h
@@ -79,6 +79,12 @@ public:
     static bool isSubmit(std::string const& query, std::string& stripped);
 
     /**
+     *  Returns true if query is EXPLAIN [FORMAT=JSON|TRADITIONAL] <query>, returns query without "EXPLAIN" in
+     * `stripped` string and whether or not JSON format was requested in `jsonFormat`.
+     */
+    static bool isExplain(std::string const& query, std::string& stripped, bool& jsonFormat);
+
+    /**
      *  Returns true if query is SELECT * FROM QSERV_RESULT(...), returns
      *  query ID in `queryId` argument.
      */

--- a/src/ccontrol/testUserQueryType.cc
+++ b/src/ccontrol/testUserQueryType.cc
@@ -83,4 +83,28 @@ BOOST_AUTO_TEST_CASE(testSetQueryType) {
             false);
 }
 
+BOOST_AUTO_TEST_CASE(testExplainQueryType) {
+    std::string stripped;
+    bool jsonFormat = true;  // start non-default to confirm it is written
+
+    // EXPLAIN <select>.
+    BOOST_CHECK_EQUAL(
+            ccontrol::UserQueryType::isExplain("EXPLAIN SELECT * FROM LSST.Object", stripped, jsonFormat),
+            true);
+    BOOST_CHECK_EQUAL(stripped, "SELECT * FROM LSST.Object");
+    BOOST_CHECK_EQUAL(jsonFormat, false);
+
+    // EXPLAIN FORMAT=JSON <select>.
+    BOOST_CHECK_EQUAL(
+            ccontrol::UserQueryType::isExplain("EXPLAIN FORMAT=JSON SELECT a FROM b", stripped, jsonFormat),
+            true);
+    BOOST_CHECK_EQUAL(stripped, "SELECT a FROM b");
+    BOOST_CHECK_EQUAL(jsonFormat, true);
+
+    // Non-matches
+    BOOST_CHECK_EQUAL(ccontrol::UserQueryType::isExplain("SELECT * FROM Obj", stripped, jsonFormat), false);
+    BOOST_CHECK_EQUAL(ccontrol::UserQueryType::isExplain("EXPLAINX SELECT 1", stripped, jsonFormat), false);
+    BOOST_CHECK_EQUAL(ccontrol::UserQueryType::isExplain("EXPLAIN", stripped, jsonFormat), false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/proxy/mysqlProxy.lua
+++ b/src/proxy/mysqlProxy.lua
@@ -204,8 +204,7 @@ function queryType()
     end
 
     local isNotSupported = function(qU)
-        if string.find(qU, "^EXPLAIN ") or
-           string.find(qU, "^GRANT ") or
+        if string.find(qU, "^GRANT ") or
            (string.find(qU, "^FLUSH ") and not string.find(qU, "^FLUSH QSERV")) then
             err.set(ERR_NOT_SUPPORTED,
                     "Sorry, this type of queries is not supported in DC3b.")

--- a/src/proxy/test.sh
+++ b/src/proxy/test.sh
@@ -33,11 +33,14 @@ mysql --port=4040 --protocol=TCP proxyTest -e "desc Obj"
 mysql --port=4040 --protocol=TCP proxyTest -e "rollback"
 mysql --port=4040 --protocol=TCP proxyTest -e "commit"
 
+# EXPLAIN
+mysql --port=4040 --protocol=TCP proxyTest -e "explain select * from Obj"
+mysql --port=4040 --protocol=TCP proxyTest -e "explain format=json select * from Obj"
+
 # these all should fail
 mysql --port=4040 --protocol=TCP proxyTest -e "insert into Obj values(1, 2)"
 mysql --port=4040 --protocol=TCP -e "create database xyz"
 mysql --port=4040 --protocol=TCP proxyTest -e "create table tt (i int)"
-mysql --port=4040 --protocol=TCP proxyTest -e "explain select * from Obj"
 
 
 mysql -e "DROP DATABASE proxyTest"

--- a/src/qproc/QuerySession.cc
+++ b/src/qproc/QuerySession.cc
@@ -65,7 +65,9 @@
 #include "qana/TablePlugin.h"
 #include "qana/WherePlugin.h"
 #include "qproc/DatabaseModels.h"
+#include "qproc/IndexMap.h"
 #include "qproc/QueryProcessingBug.h"
+#include "qproc/SecondaryIndex.h"
 #include "query/AreaRestrictor.h"
 #include "query/QueryContext.h"
 #include "query/SecIdxRestrictor.h"
@@ -200,6 +202,40 @@ void QuerySession::setScanInteractive() {
     if (_context->chunkCount > _interactiveChunkLimit) {
         _scanInteractive = false;
     }
+}
+
+void QuerySession::setupChunking(std::shared_ptr<SecondaryIndex> const& secondaryIndex) {
+    if (hasChunks()) {
+        auto areaRestrictors = getAreaRestrictors();
+        auto secIdxRestrictors = getSecIdxRestrictors();
+        css::StripingParams partStriping = getDbStriping();
+        auto const im = std::make_shared<IndexMap>(partStriping, secondaryIndex);
+        ChunkSpecVector csv;
+        if (areaRestrictors != nullptr || secIdxRestrictors != nullptr) {
+            csv = im->getChunks(areaRestrictors, secIdxRestrictors);
+        } else {  // Unrestricted: full-sky
+            csv = im->getAllChunks();
+        }
+        LOGS(_log, LOG_LVL_TRACE, "Chunk specs: " << util::printable(csv));
+
+        // Filter out empty chunks
+        std::shared_ptr<IntSet const> eSet = getEmptyChunks();
+        if (!eSet) {
+            eSet = std::make_shared<IntSet const>();
+            LOGS(_log, LOG_LVL_WARN, "Missing empty chunks info for dominantDbs");
+        }
+        for (ChunkSpecVector::const_iterator i = csv.begin(), e = csv.end(); i != e; ++i) {
+            if (eSet->count(i->chunkId) == 0) {  // chunk not in empty?
+                addChunk(*i);
+            }
+        }
+    } else {
+        LOGS(_log, LOG_LVL_TRACE, "No chunks added, QuerySession will add dummy chunk");
+    }
+
+    // Must run after the chunks above have been added: it compares the resulting chunk count against
+    // _interactiveChunkLimit, so running it any earlier always sees a count of zero.
+    setScanInteractive();
 }
 
 void QuerySession::setDummy() {

--- a/src/qproc/QuerySession.h
+++ b/src/qproc/QuerySession.h
@@ -111,6 +111,9 @@ public:
     void addChunk(ChunkSpec const& cs);
     void setDummy();
 
+    /// @return true if this query runs against the dummy chunk rather than real chunk coverage.
+    bool isDummy() const { return _isDummy; }
+
     /**
      * @brief Compute this query's chunk coverage.
      *

--- a/src/qproc/QuerySession.h
+++ b/src/qproc/QuerySession.h
@@ -59,6 +59,9 @@ namespace query {
 class SelectStmt;
 class QueryContext;
 }  // namespace query
+namespace qproc {
+class SecondaryIndex;
+}  // namespace qproc
 }  // namespace lsst::qserv
 
 namespace lsst::qserv::qproc {
@@ -107,6 +110,14 @@ public:
 
     void addChunk(ChunkSpec const& cs);
     void setDummy();
+
+    /**
+     * @brief Compute this query's chunk coverage.
+     *
+     * Uses the secondary index + restrictors to determine the set of chunks the query touches (empty chunks
+     * are filtered out). analyzeQuery() must be called first.
+     */
+    void setupChunking(std::shared_ptr<SecondaryIndex> const& secondaryIndex);
 
     query::SelectStmt const& getStmt() const { return *_stmt; }
 


### PR DESCRIPTION
This adds support for `EXPLAIN <query>` that runs at the czar to analyze queries before they execute. This could be particularly useful in situations where a user wants to understand how their query is being scheduled, how complex it is, or how much time it may take to execute.

Currently, the following information is reported:
* Parsed SQL Representation
* Qserv IR
* Booleans (Y/N): needs_merge, chunked, scan_interactive
* Chunks matched (0 if pruned + isDummy)
* Restrictors applied
* Merge SQL (if any)
* Scan rating
* Scan table info
* Worker SQL

JSON support is also available via `EXPLAIN FORMAT=JSON <query>`

Known limitations:
* Ideally, it should be possible to issue `EXPLAIN` queries to workers and collect all of the results into a single comprehensive report. If this incurs too much additional latency, we could support both "shallow" and "deep" variants, or something like `EXPLAIN FULL <query>`. There is no standardized spec for `EXPLAIN` behavior so we have some flexibility here.
* The current implementation is not aware of queries that can execute entirely on the czar, such as `SELECT COUNT(*)`. One possible workaround is directly executing `SELECT` queries to their fullest extent and capturing the information there instead of registering a new query type.
* ~This PR will currently not merge cleanly on the `xrd` branch, undergoing investigation...~ . Partially resolved by adding a new query-only `ScanTableInfo` to separate concerns between the query/frontend and backend layers. The rest of the minor tweaks went to a separate PR.

Testing:
```
EXPLAIN FORMAT=JSON
  SELECT filterId,
         COUNT(*) AS detections,
         AVG(psfFlux) AS meanPsfFlux
  FROM Source
  GROUP BY filterId
  ORDER BY detections DESC
  LIMIT 6 \G
```
Gives us:
```
*************************** 1. row ***************************
EXPLAIN: {
  "area_restrictors": "none",
  "chunks_matched": 14,
  "is_chunked": true,
  "merge_sql": "SELECT `filterId` AS `filterId`,SUM(`QS1_COUNT`) AS `detections`,(SUM(`QS3_SUM`)/SUM(`QS2_COUNT`)) AS `meanPsfFlux` FROM `qcase01`.`Source` AS `qcase01.Source` GROUP BY `filterId` ORDER BY `detections` DESC LIMIT 6",
  "needs_merge": true,
  "parsed_ir": "SelectStmt(SelectList(ValueExpr(\"filterId\", FactorOp(ValueFactor(ColumnRef(\"TableRef(\"qcase01\", \"Source\", \"qcase01.Source\")\", \"filterId\")), query::ValueExpr::NONE)), ValueExpr(\"detections\", FactorOp(ValueFactor(query::ValueFactor::AGGFUNC, FuncExpr(\"COUNT\", ValueExpr(\"\", FactorOp(ValueFactor(STAR), query::ValueExpr::NONE)))), query::ValueExpr::NONE)), ValueExpr(\"meanPsfFlux\", FactorOp(ValueFactor(query::ValueFactor::AGGFUNC, FuncExpr(\"AVG\", ValueExpr(\"\", FactorOp(ValueFactor(ColumnRef(\"TableRef(\"qcase01\", \"Source\", \"qcase01.Source\")\", \"psfFlux\")), query::ValueExpr::NONE)))), query::ValueExpr::NONE))), FromList(TableRef(\"qcase01\", \"Source\", \"qcase01.Source\")), nullptr, OrderByClause(OrderByTerm(ValueExpr(\"detections\", FactorOp(ValueFactor(query::ValueFactor::AGGFUNC, FuncExpr(\"COUNT\", ValueExpr(\"\", FactorOp(ValueFactor(STAR), query::ValueExpr::NONE)))), query::ValueExpr::NONE)), query::OrderByTerm::DESC, \"\")), GroupByClause(GroupByTerm(ValueExpr(\"filterId\", FactorOp(ValueFactor(ColumnRef(\"TableRef(\"qcase01\", \"Source\", \"qcase01.Source\")\", \"filterId\")), query::ValueExpr::NONE)), \"\")), nullptr, 0, 6)",
  "parsed_sql": "SELECT `qcase01.Source`.`filterId` AS `filterId`,COUNT(*) AS `detections`,AVG(`qcase01.Source`.`psfFlux`) AS `meanPsfFlux` FROM `qcase01`.`Source` AS `qcase01.Source` GROUP BY `filterId` ORDER BY `detections` DESC LIMIT 6",
  "scan_interactive": false,
  "scan_rating": 1,
  "scan_tables": [
    {
      "db": "qcase01",
      "lock_in_memory": true,
      "rating": 1,
      "table": "Source"
    }
  ],
  "secidx_restrictors": "none",
  "worker_sql": "SELECT `qcase01.Source`.`filterId` AS `filterId`,COUNT(*) AS `QS1_COUNT`,COUNT(`qcase01.Source`.`psfFlux`) AS `QS2_COUNT`,SUM(`qcase01.Source`.`psfFlux`) AS `QS3_SUM` FROM `qcase01`.`Source_%C\u0007C%` AS `qcase01.Source` GROUP BY `filterId` ORDER BY COUNT(*) DESC"
}
1 row in set (0.02 sec)
```