### PR TITLE
DM-55957: Address worker pod container startup sequencing issue

### DIFF
--- a/src/sql/MySqlConnection.cc
+++ b/src/sql/MySqlConnection.cc
@@ -25,11 +25,12 @@
 #include "sql/MySqlConnection.h"
 
 // System headers
-#include <cstdio>
 #include <cstddef>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 // LSST headers
 #include "lsst/log/Log.h"
@@ -41,13 +42,13 @@
 
 namespace {
 void populateErrorObject(lsst::qserv::mysql::MySqlConnection& m, lsst::qserv::sql::SqlErrorObject& o) {
-    MYSQL* mysql = m.getMySql();
-    if (mysql == nullptr) {
-        o.setErrNo(-999);
-        o.addErrMsg("Error connecting to mysql with config:" + m.getConfig().toString());
-    } else {
+    try {
+        MYSQL* mysql = m.getMySql();
         o.setErrNo(mysql_errno(mysql));
         o.addErrMsg(mysql_error(mysql));
+    } catch (std::logic_error const&) {
+        o.setErrNo(-999);
+        o.addErrMsg("Error connecting to mysql with config:" + m.getConfig().toString());
     }
 }
 


### PR DESCRIPTION
When the `worker-svc` container starts before its associated `mariadb` container, an sql connection failure in the worker initialization code causes a throw, and exits the container.  The worker pod then sits in not-started state until k8s reaps and restarts it after 5 minutes.

Found the exception was coming from an incomplete refactor in `MySqlConnection`.  `populateErrorObject` was written expecting `getMySql` to return null on a failed connection (which it then checks for.)  After the refactor, that null check became dead code and the function threw instead.  This PR adds a `try`/`catch` to cover that path.