### PR TITLE
DM-55991: Streamline CI integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
           --mariadb-image ${{ needs.image-names.outputs.mariadb-image }}
 
       - name: Check Qserv containers
-        run: sleep 180 && docker ps -a
+        run: docker ps -a
 
       - name: Run integration tests
         run: |

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -88,14 +88,13 @@ services:
             - type: volume
               source: volume_worker_0_mariadb_run
               target: /var/run/mysqld  # This is where the mariadb container puts the socket file
-        network_mode: "service:worker-svc-0"
 
     worker-svc-0:
         << : *worker-svc
         command: >
           entrypoint worker-svc
-          --db-uri mysql://qsmaster:CHANGEME@127.0.0.1:3306
-          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306
+          --db-uri mysql://qsmaster:CHANGEME@worker-mariadb-0:3306
+          --db-admin-uri mysql://root:CHANGEME@worker-mariadb-0:3306
           --repl-instance-id qserv_proj
           --repl-auth-key replauthkey
           --repl-admin-auth-key=repladminauthkey
@@ -114,10 +113,6 @@ services:
               source: volume_worker_0_mariadb_run
               target: /qserv/mariadb/run  # This matches the ?socket=... location in --db-uri and --db-admin-uri
             - << : *log-volume
-        networks:
-            default:
-                aliases:
-                    - worker-mariadb-0
 
     repl-worker-0:
         << : *repl-worker
@@ -161,14 +156,13 @@ services:
             - type: volume
               source: volume_worker_1_mariadb_run
               target: /var/run/mysqld  # This is where the mariadb container puts the socket file
-        network_mode: "service:worker-svc-1"
 
     worker-svc-1:
         << : *worker-svc
         command: >
           entrypoint --log-level DEBUG worker-svc
-          --db-uri mysql://qsmaster:CHANGEME@127.0.0.1:3306?socket={{db_socket}}
-          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306?socket={{db_socket}}
+          --db-uri mysql://qsmaster:CHANGEME@worker-mariadb-1:3306?socket={{db_socket}}
+          --db-admin-uri mysql://root:CHANGEME@worker-mariadb-1:3306?socket={{db_socket}}
           --repl-instance-id qserv_proj
           --repl-auth-key replauthkey
           --repl-admin-auth-key=repladminauthkey
@@ -188,10 +182,6 @@ services:
               source: volume_worker_1_mariadb_run
               target: /qserv/mariadb/run  # This matches the ?socket=... location in --db-uri and --db-admin-uri
             - << : *log-volume
-        networks:
-            default:
-                aliases:
-                    - worker-mariadb-1
 
     repl-worker-1:
         << : *repl-worker
@@ -223,7 +213,6 @@ services:
         image: "${QSERV_MARIADB_IMAGE:?err}"
         init: true
         command: --port 3306
-        network_mode: "service:czar-proxy"
         environment:
             MYSQL_ROOT_PASSWORD: CHANGEME
         volumes:
@@ -242,14 +231,19 @@ services:
             - type: volume
               source: volume_czar_mariadb_run
               target: /var/run/mysqld
+        networks:
+            default:
+                aliases:
+                    - czar-proxy
 
     czar-proxy:
         image: "${QSERV_IMAGE:?err}"
         init: true
+        network_mode: "service:czar-mariadb"
         command: >
           entrypoint --log-level DEBUG proxy
-          --db-uri mysql://qsmaster:CHANGEME@127.0.0.1:3306?socket={{db_socket}}
-          --db-admin-uri mysql://root:CHANGEME@127.0.0.1:3306?socket={{db_socket}}
+          --db-uri mysql://qsmaster:CHANGEME@czar-mariadb:3306?socket={{db_socket}}
+          --db-admin-uri mysql://root:CHANGEME@czar-mariadb:3306?socket={{db_socket}}
           --targs db_socket=/qserv/mariadb/run/mysqld.sock
           --log-cfg-file=/config-etc/log/log-czar-proxy.cfg
           --repl-instance-id qserv_proj
@@ -274,10 +268,6 @@ services:
               source: volume_czar_transfer
               target: /tmp
             - << : *log-volume
-        networks:
-            default:
-                aliases:
-                    - czar-mariadb
 
     czar-http:
         image: "${QSERV_IMAGE:?err}"
@@ -313,7 +303,7 @@ services:
               target: /home/qserv
             - << : *log-volume
         ports:
-            - "0.0.0.0:${QSERV_HTTP_FRONTEND_PORT:-4048}:4048"
+            - "127.0.0.1:${QSERV_HTTP_FRONTEND_PORT:-4048}:4048"
 
     repl-mariadb:
         image: "${QSERV_MARIADB_IMAGE:?err}"
@@ -350,8 +340,6 @@ services:
           --qserv-sync-force
           --qserv-chunk-map-update
           --debug
-        ports:
-            - "0.0.0.0:${QSERV_DASHBOARD_PORT:-25081}:25081"
         volumes:
             - type: volume
               source: volume_repl_mariadb_data
@@ -363,6 +351,8 @@ services:
               source: ../../src/www
               target: /usr/local/qserv/www
             - << : *log-volume
+        ports:
+            - "127.0.0.1:${QSERV_DASHBOARD_PORT:-25081}:25081"
 
     repl-registry:
         image: "${QSERV_IMAGE:?err}"

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -414,3 +414,16 @@ services:
           --debug
         volumes:
             - << : *log-volume
+
+    cluster-ready:
+        image: "${QSERV_IMAGE:?err}"
+        init: true
+        command: sleep infinity
+        depends_on:
+            repl-registry:
+                condition: service_started
+        healthcheck:
+            test: ["CMD-SHELL", "curl -sf 'http://repl-registry:25082/services?instance_id=qserv_proj' | python3 -c \"import sys,json; d=json.load(sys.stdin)['services']; exit(0 if len(d['workers'])>=2 and len(d['czars'])>=1 else 1)\""]
+            start_period: 120s
+            interval: 5s
+            timeout: 5s

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -5,6 +5,11 @@ x-worker-mariadb:
     command: --port 3306
     environment:
         MYSQL_ROOT_PASSWORD: CHANGEME
+    healthcheck:
+        test: ["CMD", "healthcheck.sh", "--defaults-extra-file=/qserv/data/mysql/.my-healthcheck.cnf", "--connect", "--innodb_initialized"]
+        start_period: 30s
+        interval: 5s
+        timeout: 3s
 
 x-worker-mariadb-cnf-volume:
     &worker-mariadb-cnf-volume
@@ -215,6 +220,11 @@ services:
         command: --port 3306
         environment:
             MYSQL_ROOT_PASSWORD: CHANGEME
+        healthcheck:
+            test: ["CMD", "healthcheck.sh", "--defaults-extra-file=/qserv/data/mysql/.my-healthcheck.cnf", "--connect", "--innodb_initialized"]
+            start_period: 30s
+            interval: 5s
+            timeout: 3s
         volumes:
             - type: volume
               source: volume_czar_mariadb_data
@@ -311,6 +321,11 @@ services:
         command: --port 3306
         environment:
             MYSQL_ROOT_PASSWORD: CHANGEME
+        healthcheck:
+            test: ["CMD", "healthcheck.sh", "--defaults-extra-file=/qserv/data/mysql/.my-healthcheck.cnf", "--connect", "--innodb_initialized"]
+            start_period: 30s
+            interval: 5s
+            timeout: 3s
         volumes:
             - type: volume
               source: volume_repl_mariadb_data

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -22,17 +22,11 @@ x-worker-svc:
     &worker-svc
     image: "${QSERV_IMAGE:?err}"
     init: true
-    expose:
-        - "3306" # for the worker db, which shares this container's network stack.
+
 x-repl-worker:
     &repl-worker
     image: "${QSERV_IMAGE:?err}"
     init: true
-    expose:
-        - "25000"
-        - "25001"
-        - "25003"
-        - "25004"
 
 volumes:
 
@@ -280,9 +274,6 @@ services:
               source: volume_czar_transfer
               target: /tmp
             - << : *log-volume
-        expose:
-            - "3306" # for czar-mariadb
-            - "4040"
         networks:
             default:
                 aliases:
@@ -321,8 +312,6 @@ services:
               source: volume_czar_home
               target: /home/qserv
             - << : *log-volume
-        expose:
-            - "4048"
         ports:
             - "0.0.0.0:${QSERV_HTTP_FRONTEND_PORT:-4048}:4048"
 
@@ -330,8 +319,6 @@ services:
         image: "${QSERV_MARIADB_IMAGE:?err}"
         init: true
         command: --port 3306
-        expose:
-            - "3306"
         environment:
             MYSQL_ROOT_PASSWORD: CHANGEME
         volumes:
@@ -363,8 +350,6 @@ services:
           --qserv-sync-force
           --qserv-chunk-map-update
           --debug
-        expose:
-            - "25081"
         ports:
             - "0.0.0.0:${QSERV_DASHBOARD_PORT:-25081}:25081"
         volumes:
@@ -392,7 +377,5 @@ services:
           --auth-key=replauthkey
           --admin-auth-key=repladminauthkey
           --debug
-        expose:
-            - "25082"
         volumes:
             - << : *log-volume

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -5,16 +5,19 @@ x-worker-mariadb:
     command: --port 3306
     environment:
         MYSQL_ROOT_PASSWORD: CHANGEME
+
 x-worker-mariadb-cnf-volume:
     &worker-mariadb-cnf-volume
     - type: bind
       source: ../../src/admin/templates/mariadb/etc/my.cnf
       target: /etc/mysql/my.cnf
+
 x-log-volume:
     &log-volume
     - type: bind
       source: ./log/
       target: /config-etc/log/
+
 x-worker-svc:
     &worker-svc
     image: "${QSERV_IMAGE:?err}"
@@ -32,6 +35,7 @@ x-repl-worker:
         - "25004"
 
 volumes:
+
     volume_czar_xrootd:
     volume_czar_home:
     volume_czar_cfg:
@@ -64,6 +68,7 @@ volumes:
     volume_repl_worker_1_cfg:
 
 networks:
+
     default:
         ipam:
             driver: default
@@ -71,6 +76,7 @@ networks:
                 - subnet: 192.168.3.0/24
 
 services:
+
     # worker 0 uses and validates ip+port to connect to the worker-mariadb
     worker-mariadb-0:
         << : *worker-mariadb
@@ -118,6 +124,7 @@ services:
             default:
                 aliases:
                     - worker-mariadb-0
+
     repl-worker-0:
         << : *repl-worker
         command: >
@@ -191,6 +198,7 @@ services:
             default:
                 aliases:
                     - worker-mariadb-1
+
     repl-worker-1:
         << : *repl-worker
         # qserv-replica-worker app does not support socket file yet.
@@ -271,7 +279,6 @@ services:
             - type: volume
               source: volume_czar_transfer
               target: /tmp
-
             - << : *log-volume
         expose:
             - "3306" # for czar-mariadb
@@ -280,8 +287,7 @@ services:
             default:
                 aliases:
                     - czar-mariadb
-        # ports:
-        #     - "127.0.0.1:4040:4040"
+
     czar-http:
         image: "${QSERV_IMAGE:?err}"
         init: true
@@ -319,6 +325,7 @@ services:
             - "4048"
         ports:
             - "0.0.0.0:${QSERV_HTTP_FRONTEND_PORT:-4048}:4048"
+
     repl-mariadb:
         image: "${QSERV_MARIADB_IMAGE:?err}"
         init: true
@@ -337,6 +344,7 @@ services:
             - type: volume
               source: volume_repl_mariadb_lib
               target: /var/lib/mysql
+
     repl-controller:
         image: "${QSERV_IMAGE:?err}"
         init: true
@@ -370,6 +378,7 @@ services:
               source: ../../src/www
               target: /usr/local/qserv/www
             - << : *log-volume
+
     repl-registry:
         image: "${QSERV_IMAGE:?err}"
         init: true

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -261,6 +261,8 @@ services:
             default:
                 aliases:
                     - czar-proxy
+        ports:
+            - "127.0.0.1:${QSERV_MYSQL_FRONTEND_PORT:-4040}:4040"
 
     czar-proxy:
         image: "${QSERV_IMAGE:?err}"

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -96,6 +96,9 @@ services:
 
     worker-svc-0:
         << : *worker-svc
+        depends_on:
+            worker-mariadb-0:
+                condition: service_healthy
         command: >
           entrypoint worker-svc
           --db-uri mysql://qsmaster:CHANGEME@worker-mariadb-0:3306
@@ -121,6 +124,11 @@ services:
 
     repl-worker-0:
         << : *repl-worker
+        depends_on:
+            worker-mariadb-0:
+                condition: service_healthy
+            repl-mariadb:
+                condition: service_healthy
         command: >
           entrypoint worker-repl
           --db-admin-uri mysql://root:CHANGEME@worker-mariadb-0:3306/qservw_worker
@@ -164,6 +172,9 @@ services:
 
     worker-svc-1:
         << : *worker-svc
+        depends_on:
+            worker-mariadb-1:
+                condition: service_healthy
         command: >
           entrypoint --log-level DEBUG worker-svc
           --db-uri mysql://qsmaster:CHANGEME@worker-mariadb-1:3306?socket={{db_socket}}
@@ -191,6 +202,11 @@ services:
     repl-worker-1:
         << : *repl-worker
         # qserv-replica-worker app does not support socket file yet.
+        depends_on:
+            worker-mariadb-1:
+                condition: service_healthy
+            repl-mariadb:
+                condition: service_healthy
         command: >
           entrypoint worker-repl
           --db-admin-uri mysql://root:CHANGEME@worker-mariadb-1:3306/qservw_worker
@@ -250,6 +266,9 @@ services:
         image: "${QSERV_IMAGE:?err}"
         init: true
         network_mode: "service:czar-mariadb"
+        depends_on:
+            czar-mariadb:
+                condition: service_healthy
         command: >
           entrypoint --log-level DEBUG proxy
           --db-uri mysql://qsmaster:CHANGEME@czar-mariadb:3306?socket={{db_socket}}
@@ -282,6 +301,9 @@ services:
     czar-http:
         image: "${QSERV_IMAGE:?err}"
         init: true
+        depends_on:
+            czar-mariadb:
+                condition: service_healthy
         command: >
           entrypoint --log-level DEBUG czar-http
           --db-uri mysql://qsmaster:CHANGEME@czar-mariadb:3306/
@@ -340,6 +362,11 @@ services:
     repl-controller:
         image: "${QSERV_IMAGE:?err}"
         init: true
+        depends_on:
+            repl-mariadb:
+                condition: service_healthy
+            czar-mariadb:
+                condition: service_healthy
         command: >
           entrypoint --log-level DEBUG replication-controller
           --db-uri mysql://qsreplica:CHANGEME@repl-mariadb:3306/qservReplica
@@ -372,6 +399,9 @@ services:
     repl-registry:
         image: "${QSERV_IMAGE:?err}"
         init: true
+        depends_on:
+            repl-mariadb:
+                condition: service_healthy
         command: >
           entrypoint --log-level DEBUG replication-registry
           --db-uri mysql://qsreplica:CHANGEME@repl-mariadb:3306/qservReplica

--- a/python/lsst/qserv/admin/qservCli/launch.py
+++ b/python/lsst/qserv/admin/qservCli/launch.py
@@ -37,6 +37,7 @@ from .opt import (
     env_dashboard_port,
     env_http_frontend_port,
     env_mariadb_image,
+    env_mysql_frontend_port,
     env_qserv_image,
 )
 
@@ -1638,6 +1639,7 @@ def up(
     mariadb_image: str,
     dashboard_port: int | None,
     http_frontend_port: int | None,
+    mysql_frontend_port: int | None,
 ) -> None:
     """Send docker compose up and down commands.
 
@@ -1657,6 +1659,8 @@ def up(
         The host port to use for the qserv dashboard.
     http_frontend_port : `int` or `None`
         The host port to use for the qserv HTTP frontend.
+    mysql_frontend_port : `int` or `None`
+        The host port to use for the qserv MySQL frontend.
     """
     args = ["docker", "compose", "-f", yaml_file]
     if project:
@@ -1670,6 +1674,8 @@ def up(
         env_override[env_dashboard_port.env_var] = str(dashboard_port)
     if http_frontend_port:
         env_override[env_http_frontend_port.env_var] = str(http_frontend_port)
+    if mysql_frontend_port:
+        env_override[env_mysql_frontend_port.env_var] = str(mysql_frontend_port)
     if dry:
         env_str = " ".join([f"{k}={v}" for k, v in env_override.items()])
         print(f"{env_str} {' '.join(args)}")

--- a/python/lsst/qserv/admin/qservCli/launch.py
+++ b/python/lsst/qserv/admin/qservCli/launch.py
@@ -871,6 +871,14 @@ def itest_ref(
         f"src={itest_volumes.db_lib},dst=/var/lib/mysql,type=volume",
         "-e",
         "MYSQL_ROOT_PASSWORD=CHANGEME",
+        "--health-cmd",
+        "healthcheck.sh --defaults-extra-file=/qserv/data/mysql/.my-healthcheck.cnf --connect --innodb_initialized",
+        "--health-start-period",
+        "30s",
+        "--health-interval",
+        "5s",
+        "--health-timeout",
+        "3s",
     ]
     add_network_option(args, project)
     args.extend(
@@ -885,6 +893,49 @@ def itest_ref(
         return
     _log.debug(f"Running {' '.join(args)}")
     subproc.run(args)
+    _wait_for_container_healthy(container_name)
+
+
+def _wait_for_container_healthy(container_name: str, timeout: int = 120, interval: int = 2) -> None:
+    """Poll Docker until a container's healthcheck reports healthy.
+
+    Parameters
+    ----------
+    container_name : `str`
+        The name of the container to monitor.
+    timeout : `int`
+        Maximum seconds to wait before raising.
+    interval : `int`
+        Seconds between polls.
+    """
+    _log.info(f"Waiting for container {container_name} to become healthy (timeout {timeout}s)...")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                container_name,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"docker inspect failed for {container_name}: {result.stderr.strip()}")
+        status = result.stdout.strip()
+        if status == "none":
+            raise RuntimeError(f"Container {container_name} has no healthcheck configured")
+        if status == "healthy":
+            elapsed = timeout - (deadline - time.time())
+            _log.info(f"Container {container_name} is healthy (after {elapsed:.0f}s).")
+            return
+        if status == "unhealthy":
+            raise RuntimeError(f"Container {container_name} became unhealthy")
+        _log.debug(f"Container {container_name} health status: {status}")
+        time.sleep(interval)
+    raise RuntimeError(f"Container {container_name} did not become healthy within {timeout}s")
 
 
 def stop_itest_ref(container_name: str, dry: bool) -> int:

--- a/python/lsst/qserv/admin/qservCli/launch.py
+++ b/python/lsst/qserv/admin/qservCli/launch.py
@@ -1610,7 +1610,7 @@ def up(
     args = ["docker", "compose", "-f", yaml_file]
     if project:
         args.extend(["-p", project])
-    args.extend(["up", "-d"])
+    args.extend(["up", "-d", "--wait"])
     env_override = {
         env_qserv_image.env_var: qserv_image,
         env_mariadb_image.env_var: mariadb_image,

--- a/python/lsst/qserv/admin/qservCli/opt.py
+++ b/python/lsst/qserv/admin/qservCli/opt.py
@@ -324,6 +324,7 @@ env_project = FlagEnvVal("--project", "QSERV_PROJECT", getpass.getuser())
 env_outdir = FlagEnvVal("--outdir", "OUTDIR", "/tmp")
 env_dashboard_port = FlagEnvVal("--dashboard-port", "QSERV_DASHBOARD_PORT", "25081")
 env_http_frontend_port = FlagEnvVal("--http-frontend-port", "QSERV_HTTP_FRONTEND_PORT", "4048")
+env_mysql_frontend_port = FlagEnvVal("--mysql-frontend-port", "QSERV_MYSQL_FRONTEND_PORT", "4040")
 env_ltd_user = EnvVal("QSERV_LTD_USERNAME", "CI only; the LSST The Docs user for pushing docs.")
 env_ltd_password = EnvVal(
     "QSERV_LTD_PASSWORD", "CI only; the LSST The Docs password for pushing docs.", private=True
@@ -531,6 +532,7 @@ qserv_env_vals = FlagEnvVals(
         env_project,
         env_dashboard_port,
         env_http_frontend_port,
+        env_mysql_frontend_port,
         env_ltd_user,
         env_ltd_password,
         env_gh_event_name,
@@ -676,6 +678,13 @@ option_http_frontend_port = partial(
     env_http_frontend_port.opt,
     help=env_http_frontend_port.help("The host port to use for the qserv HTTP frontend."),
     default=env_http_frontend_port.val(),
+)
+
+option_mysql_frontend_port = partial(
+    click.option,
+    env_mysql_frontend_port.opt,
+    help=env_mysql_frontend_port.help("The host port to use for the qserv MySQL frontend."),
+    default=env_mysql_frontend_port.val(),
 )
 
 

--- a/python/lsst/qserv/admin/qservCli/qserv_cli.py
+++ b/python/lsst/qserv/admin/qservCli/qserv_cli.py
@@ -67,6 +67,7 @@ from .opt import (
     option_do_build_image,
     option_dry,
     option_http_frontend_port,
+    option_mysql_frontend_port,
     option_itest_container_name,
     option_itest_file,
     option_itest_http_container_name,
@@ -827,6 +828,7 @@ def update_schema(
 @option_project()
 @option_dashboard_port()
 @option_http_frontend_port()
+@option_mysql_frontend_port()
 @option_dry()
 def up(
     yaml_file: str,
@@ -836,6 +838,7 @@ def up(
     mariadb_image: str,
     dashboard_port: int,
     http_frontend_port: int,
+    mysql_frontend_port: int,
 ) -> None:
     """Launch a docker compose cluster."""
     launch.up(
@@ -846,6 +849,7 @@ def up(
         mariadb_image=mariadb_image,
         dashboard_port=dashboard_port,
         http_frontend_port=http_frontend_port,
+        mysql_frontend_port=mysql_frontend_port,
     )
 
 


### PR DESCRIPTION
The arbitrary and annoying 180s sleep in the CI integration tests was driving me bonkers.  This PR leverages container health check gating built in to `docker compose` plus a vendor-provided health check script that comes with the stock MariaDB containers so the tooling now waits for (and only until) the test cluster is explicitly ready for use.

* `qserv up` now returns when, and not before, the compose cluster is ready for use.  This is accomplished by adding health (readiness) checks on MariaDB containers, adding wait conditions for healthy databases to database consumers, and adding a new overall `cluster-ready` container with a health check that doesn't return healthy until the http czar and expected workers are listed in the registry.

* Integration test tooling now also uses health check monitoring to wait for the reference db container to become available and ready, instead of falling back to exponential backoff connection retry which was noisy and slow.

* Compose cluster now exports mysql proxy port to host (in addition to dashboard and http czar ports previously exported) as a testing convenience.