### PR TITLE
DM-55996: Separate query/dispatch ScanTableInfo

### DIFF
--- a/src/ccontrol/UserQuerySelect.cc
+++ b/src/ccontrol/UserQuerySelect.cc
@@ -87,8 +87,9 @@
 #include "qmeta/Exceptions.h"
 #include "qmeta/QMeta.h"
 #include "qmeta/QProgress.h"
-#include "qproc/IndexMap.h"
 #include "qproc/QuerySession.h"
+#include "qproc/IndexMap.h"
+#include "query/ScanTableInfo.h"
 #include "query/ColumnRef.h"
 #include "query/FromList.h"
 #include "query/JoinRef.h"
@@ -245,7 +246,7 @@ void UserQuerySelect::submit() {
     }
 
     exec->setScanInteractive(_qSession->getScanInteractive());
-    exec->setScanInfo(_qSession->getScanInfo());
+    exec->setScanInfo(*_qSession->getScanInfo());
 
     string dbName("");
     bool dbNameSet = false;

--- a/src/css/ScanTableParams.h
+++ b/src/css/ScanTableParams.h
@@ -34,7 +34,7 @@ struct ScanTableParams {
     ScanTableParams(bool lockInMem_, int scanRating_) : lockInMem(lockInMem_), scanRating(scanRating_) {}
 
     bool lockInMem{false};  ///< True if table should be locked in memory for shared scan
-    int scanRating{0};      ///< Speed of shared scan. 1-fast, 2-medium, 3-slow
+    int scanRating{0};      ///< Speed of shared scan. @see lsst::qserv::protojson::ScanInfo::Rating
 };
 
 }  // namespace lsst::qserv::css

--- a/src/protojson/CMakeLists.txt
+++ b/src/protojson/CMakeLists.txt
@@ -53,4 +53,5 @@ protojson_tests(
 	testUberJobErrorMsg
     testUberJobReadyMsg
     testUberJobMsg
+    testScanTableInfo
 )

--- a/src/protojson/ScanTableInfo.h
+++ b/src/protojson/ScanTableInfo.h
@@ -25,12 +25,16 @@
 #define LSST_QSERV_PROTOJSON_SCANTABLEINFO_H
 
 // System headers
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <vector>
 
 // Third party headers
 #include "nlohmann/json.hpp"
+
+// Qserv headers
+#include "query/ScanTableInfo.h"
 
 namespace lsst::qserv::protojson {
 
@@ -66,12 +70,23 @@ public:
     ScanInfo() = default;
     ScanInfo(ScanInfo const&) = default;
 
+    /// Convert query analysis ScanInfo to the dispatch representation.
+    explicit ScanInfo(query::ScanInfo const& qScanInfo) : scanRating(qScanInfo.scanRating) {
+        infoTables.reserve(qScanInfo.infoTables.size());
+        for (auto const& qTbl : qScanInfo.infoTables) {
+            infoTables.emplace_back(qTbl.db, qTbl.table, qTbl.lockInMemory, qTbl.scanRating);
+        }
+    }
+
     static Ptr create() { return Ptr(new ScanInfo()); }
 
     static Ptr createFromJson(nlohmann::json const& ujJson);
 
     /// Return a json version of the contents of this class.
     nlohmann::json toJson() const;
+
+    /// @return a dispatch ScanInfo converted from query analysis ScanInfo.
+    static Ptr create(query::ScanInfo const& qScanInfo) { return Ptr(new ScanInfo(qScanInfo)); }
 
     void sortTablesSlowestFirst();
     int compareTables(ScanInfo const& rhs);

--- a/src/protojson/testScanTableInfo.cc
+++ b/src/protojson/testScanTableInfo.cc
@@ -1,0 +1,92 @@
+// -*- LSST-C++ -*-
+/*
+ * LSST Data Management System
+ * Copyright 2026 LSST.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Qserv headers
+#include "protojson/ScanTableInfo.h"
+#include "query/ScanTableInfo.h"
+
+// Boost unit test header
+#define BOOST_TEST_MODULE RequestQuery
+#include <boost/test/unit_test.hpp>
+
+using namespace lsst::qserv;
+
+BOOST_AUTO_TEST_SUITE(Suite)
+
+BOOST_AUTO_TEST_CASE(ScanInfoFromQueryScanInfo) {
+    query::ScanInfo qScanInfo;
+    qScanInfo.scanRating = 42;
+    qScanInfo.infoTables.emplace_back("db1", "table1", true, 10);
+    qScanInfo.infoTables.emplace_back("db2", "table2", false, 20);
+    qScanInfo.infoTables.emplace_back("db3", "table3", false, 30);
+
+    auto pjScanInfo = protojson::ScanInfo::create(qScanInfo);
+
+    BOOST_REQUIRE_EQUAL(pjScanInfo->scanRating, qScanInfo.scanRating);
+    BOOST_REQUIRE_EQUAL(pjScanInfo->infoTables.size(), qScanInfo.infoTables.size());
+    for (size_t j = 0; j < qScanInfo.infoTables.size(); ++j) {
+        auto const& qTbl = qScanInfo.infoTables[j];
+        auto const& pjTbl = pjScanInfo->infoTables[j];
+        BOOST_REQUIRE_EQUAL(pjTbl.db, qTbl.db);
+        BOOST_REQUIRE_EQUAL(pjTbl.table, qTbl.table);
+        BOOST_REQUIRE_EQUAL(pjTbl.lockInMemory, qTbl.lockInMemory);
+        BOOST_REQUIRE_EQUAL(pjTbl.scanRating, qTbl.scanRating);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ScanInfoJsonRoundTrip) {
+    auto scanInfo = protojson::ScanInfo::create();
+    scanInfo->scanRating = 7;
+    scanInfo->infoTables.emplace_back("db1", "table1", true, 30);
+    scanInfo->infoTables.emplace_back("db1", "table2", true, 10);
+    scanInfo->infoTables.emplace_back("db2", "table3", false, 99);
+    scanInfo->sortTablesSlowestFirst();
+
+    // to JSON
+    auto js = scanInfo->toJson();
+
+    // Check wire format keys explicitly
+    BOOST_REQUIRE_EQUAL(js.at("infoscanrating").get<int>(), 7);
+    auto const& jsTables = js.at("infotables");
+    BOOST_REQUIRE_EQUAL(jsTables.size(), 3u);
+    BOOST_REQUIRE_EQUAL(jsTables[0].at("sidb").get<std::string>(), "db1");
+    BOOST_REQUIRE_EQUAL(jsTables[0].at("sitable").get<std::string>(), "table1");
+    BOOST_REQUIRE_EQUAL(jsTables[0].at("sirating").get<int>(), 30);
+    BOOST_REQUIRE_EQUAL(jsTables[0].at("silockinmem").get<bool>(), true);
+
+    // and back
+    auto roundTripped = protojson::ScanInfo::createFromJson(js);
+
+    BOOST_REQUIRE_EQUAL(roundTripped->scanRating, scanInfo->scanRating);
+    BOOST_REQUIRE_EQUAL(roundTripped->infoTables.size(), scanInfo->infoTables.size());
+    for (size_t k = 0; k < scanInfo->infoTables.size(); ++k) {
+        auto const& orig = scanInfo->infoTables[k];
+        auto const& rt = roundTripped->infoTables[k];
+        BOOST_REQUIRE_EQUAL(rt.db, orig.db);
+        BOOST_REQUIRE_EQUAL(rt.table, orig.table);
+        BOOST_REQUIRE_EQUAL(rt.lockInMemory, orig.lockInMemory);
+        BOOST_REQUIRE_EQUAL(rt.scanRating, orig.scanRating);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/qana/ScanTablePlugin.cc
+++ b/src/qana/ScanTablePlugin.cc
@@ -92,8 +92,7 @@ StringPairVector filterPartitioned(query::TableRefList const& tList) {
     return vector;
 }
 
-protojson::ScanInfo::Ptr ScanTablePlugin::_findScanTables(query::SelectStmt& stmt,
-                                                          query::QueryContext& context) {
+query::ScanInfo::Ptr ScanTablePlugin::_findScanTables(query::SelectStmt& stmt, query::QueryContext& context) {
     // Might be better as a separate plugin
 
     // All tables of a query are scan tables if the statement both:
@@ -187,15 +186,14 @@ protojson::ScanInfo::Ptr ScanTablePlugin::_findScanTables(query::SelectStmt& stm
 
     // Ask css if any of the tables should be locked in memory and their scan rating.
     // Use this information to determine scanPriority.
-    auto scanInfo = protojson::ScanInfo::create();
-    for (auto& pair : scanTables) {
-        protojson::ScanTableInfo info(pair.first, pair.second);
+    auto scanInfo = query::ScanInfo::create();
+    for (auto const& pair : scanTables) {
+        query::ScanTableInfo info(pair.first, pair.second);
         css::ScanTableParams const params = context.css->getScanTableParams(info.db, info.table);
         info.lockInMemory = params.lockInMem;
         info.scanRating = params.scanRating;
         scanInfo->infoTables.push_back(info);
         scanInfo->scanRating = std::max(scanInfo->scanRating, info.scanRating);
-        scanInfo->scanRating = std::min(scanInfo->scanRating, static_cast<int>(protojson::ScanInfo::SLOWEST));
         LOGS(_log, LOG_LVL_INFO,
              "ScanInfo " << info.db << "." << info.table << " lockInMemory=" << info.lockInMemory
                          << " rating=" << info.scanRating);

--- a/src/qana/ScanTablePlugin.h
+++ b/src/qana/ScanTablePlugin.h
@@ -27,7 +27,7 @@
 #include "qana/QueryPlugin.h"
 
 // Qserv headers
-#include "protojson/ScanTableInfo.h"
+#include "query/ScanTableInfo.h"
 
 namespace lsst::qserv::qana {
 
@@ -55,8 +55,8 @@ public:
     std::string name() const override { return "ScanTablePlugin"; }
 
 private:
-    protojson::ScanInfo::Ptr _findScanTables(query::SelectStmt& stmt, query::QueryContext& context);
-    protojson::ScanInfo::Ptr _scanInfo;
+    query::ScanInfo::Ptr _findScanTables(query::SelectStmt& stmt, query::QueryContext& context);
+    query::ScanInfo::Ptr _scanInfo;
     int _interactiveChunkLimit;
 };
 

--- a/src/qana/testScanTablePlugin.cc
+++ b/src/qana/testScanTablePlugin.cc
@@ -59,8 +59,8 @@ struct TestFixture {
         css->setScanTableParams("Somedb", "Object", css::ScanTableParams(true, 1));
     }
 
-    protojson::ScanInfo::Ptr runScanTablePlugin(std::string const& query, int interactiveChunkLimit = 0,
-                                                int chunkCount = 0) {
+    query::ScanInfo::Ptr runScanTablePlugin(std::string const& query, int interactiveChunkLimit = 0,
+                                            int chunkCount = 0) {
         query::SelectStmt::Ptr selectStmt;
         BOOST_REQUIRE_NO_THROW(selectStmt = ccontrol::ParseRunner::makeSelectStmt(query));
         BOOST_REQUIRE(selectStmt != nullptr);

--- a/src/qdisp/Executive.h
+++ b/src/qdisp/Executive.h
@@ -219,7 +219,7 @@ public:
     void killIncompleteUberJobsOnWorker(std::string const& workerId);
 
     // Try to remove this and put in constructor
-    void setScanInfo(protojson::ScanInfo::Ptr const& scanInfo) { _scanInfo = scanInfo; }
+    void setScanInfo(query::ScanInfo const& scanInfo) { _scanInfo = protojson::ScanInfo::create(scanInfo); }
 
     /// Return a pointer to _scanInfo.
     protojson::ScanInfo::Ptr getScanInfo() { return _scanInfo; }

--- a/src/qproc/ChunkQuerySpec.h
+++ b/src/qproc/ChunkQuerySpec.h
@@ -29,6 +29,7 @@
  */
 
 // System headers
+#include <functional>
 #include <mutex>
 #include <ostream>
 #include <string>
@@ -39,8 +40,8 @@
 
 // Qserv headers
 #include "global/DbTable.h"
+#include "query/ScanTableInfo.h"
 #include "global/stringTypes.h"
-#include "protojson/ScanTableInfo.h"
 
 namespace lsst::qserv::qproc {
 
@@ -86,7 +87,7 @@ public:
     using Ptr = std::shared_ptr<ChunkQuerySpec>;
 
     ChunkQuerySpec() {}
-    ChunkQuerySpec(std::string const& db_, int chunkId_, protojson::ScanInfo::Ptr const& scanInfo_,
+    ChunkQuerySpec(std::string const& db_, int chunkId_, query::ScanInfo::Ptr const& scanInfo_,
                    bool scanInteractive_)
             : db(db_), chunkId(chunkId_), scanInfo(scanInfo_), scanInteractive(scanInteractive_) {}
 
@@ -94,7 +95,7 @@ public:
     std::string db{
             ""};  ///< dominant db (any database if there are multiple databases referenced in the query)
     int chunkId{0};
-    protojson::ScanInfo::Ptr scanInfo;  ///< shared-scan candidates
+    query::ScanInfo::Ptr scanInfo;  ///< shared-scan candidates
     // Consider saving subChunkTable templates, and substituting the chunkIds
     // and subChunkIds into them on-the-fly.
     bool scanInteractive{false};

--- a/src/qproc/QuerySession.cc
+++ b/src/qproc/QuerySession.cc
@@ -436,7 +436,7 @@ std::ostream& operator<<(std::ostream& out, QuerySession const& querySession) {
     return out;
 }
 
-protojson::ScanInfo::Ptr QuerySession::getScanInfo() const { return _context->scanInfo; }
+query::ScanInfo::Ptr QuerySession::getScanInfo() const { return _context->scanInfo; }
 
 ChunkQuerySpec::Ptr QuerySession::buildChunkQuerySpec(query::QueryTemplate::Vect const& queryTemplates,
                                                       ChunkSpec const& chunkSpec,

--- a/src/qproc/QuerySession.h
+++ b/src/qproc/QuerySession.h
@@ -187,7 +187,7 @@ public:
     void setScanInteractive();
     bool getScanInteractive() const { return _scanInteractive; }
 
-    protojson::ScanInfo::Ptr getScanInfo() const;
+    query::ScanInfo::Ptr getScanInfo() const;
 
     /**
      *  Print query session to stream.

--- a/src/query/QueryContext.h
+++ b/src/query/QueryContext.h
@@ -39,7 +39,7 @@
 // Local headers
 #include "css/CssAccess.h"
 #include "global/stringTypes.h"
-#include "protojson/ScanTableInfo.h"
+#include "query/ScanTableInfo.h"
 #include "qana/QueryMapping.h"
 #include "query/FromList.h"
 #include "query/typedefs.h"
@@ -84,7 +84,7 @@ public:
 
     std::shared_ptr<qproc::DatabaseModels> databaseModels;  ///< contains database schema information.
 
-    protojson::ScanInfo::Ptr scanInfo{protojson::ScanInfo::create()};  // Tables scanned (for shared scans)
+    ScanInfo::Ptr scanInfo{ScanInfo::create()};  // Tables scanned (for shared scans)
 
     /**
      * @brief Add a TableRef to the list of tables used by this query.

--- a/src/query/ScanTableInfo.h
+++ b/src/query/ScanTableInfo.h
@@ -1,0 +1,59 @@
+// -*- LSST-C++ -*-
+/*
+ * LSST Data Management System
+ * Copyright 2016-2026 LSST Corporation.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_QSERV_QUERY_SCANTABLEINFO_H
+#define LSST_QSERV_QUERY_SCANTABLEINFO_H
+
+// System headers
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace lsst::qserv::query {
+
+/// Shared scan information for a single table, produced by query analysis
+struct ScanTableInfo {
+    ScanTableInfo(std::string const& db_, std::string const& table_) : db(db_), table(table_) {}
+    ScanTableInfo(std::string const& db_, std::string const& table_, bool lockInMemory_, int scanRating_)
+            : db{db_}, table{table_}, lockInMemory{lockInMemory_}, scanRating{scanRating_} {}
+
+    std::string db;
+    std::string table;
+    bool lockInMemory{false};
+    int scanRating{0};
+};
+
+/// This class stores information about database table ratings for a user query.
+class ScanInfo {
+public:
+    using Ptr = std::shared_ptr<ScanInfo>;
+
+    static Ptr create() { return Ptr(new ScanInfo()); }
+
+    std::vector<ScanTableInfo> infoTables;
+    int scanRating{0};
+};
+
+}  // namespace lsst::qserv::query
+
+#endif  // LSST_QSERV_QUERY_SCANTABLEINFO_H


### PR DESCRIPTION
`ScanTableInfo` / `ScanInfo` previously were located in the `protojson` module and were used for both query analysis **AND** dispatch. This means that the query analysis layer had a dependency on a type that was being used primarily on the backend / dispatch side of the system. Beyond simply keeping concerns separate, this could cause issues when migrating functionality to the xrd branch which has a different dispatch backend.

This PR splits it into two separate types:
* `query::ScanTableInfo` (new): a struct to hold scan information
* `protojson::ScanTableInfo` (existing): dispatch-side representation, now with a conversion constructor that builds from the query-side type.

The crossover point between these layers is in `qdisp::Executive::setScanInfo()`