### PR TITLE
DM-55959: add CertManager support to Helm chart

### DIFF
--- a/deploy/helm/templates/czar-certificate.yaml
+++ b/deploy/helm/templates/czar-certificate.yaml
@@ -1,0 +1,21 @@
+{{- $enabled := (include "qserv.enable" . | fromYaml) -}}
+{{- if and $enabled.czar .Values.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: czar-cert
+  labels:
+    {{- include "qserv.labels" . | nindent 4 }}
+    app.kubernetes.io/component: czar
+spec:
+  secretName: czar-cert
+  issuerRef:
+    {{- if not (empty .Values.certManager.issuerRef) }}
+    {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: selfsigned-issuer
+    kind: Issuer
+    {{- end }}
+  dnsNames:
+    {{- toYaml .Values.certManager.dnsNames | nindent 4 }}
+{{- end }}

--- a/deploy/helm/templates/czar-issuer.yaml
+++ b/deploy/helm/templates/czar-issuer.yaml
@@ -1,0 +1,12 @@
+{{- $enabled := (include "qserv.enable" . | fromYaml) -}}
+{{- if and $enabled.czar .Values.certManager.enabled (empty .Values.certManager.issuerRef) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  labels:
+    {{- include "qserv.labels" . | nindent 4 }}
+    app.kubernetes.io/component: czar
+spec:
+  selfSigned: {}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -40,3 +40,9 @@ ingest:
 
 czarExternalService:
   enable: false
+
+certManager:
+  enabled: false
+  # If empty, the chart creates a namespace-scoped self-signed Issuer
+  issuerRef: {}
+  dnsNames: []


### PR DESCRIPTION
Adds chart support for optional per-deployment use of CertManager to manage frontend SSL cert