### PR TITLE
DM-56058: Minor changes to build base and run base images (backported from DM-56018)

### DIFF
--- a/deploy/docker/base/Dockerfile
+++ b/deploy/docker/base/Dockerfile
@@ -42,6 +42,7 @@ RUN dnf install -y 'dnf-command(config-manager)' \
         git \
         glib2-devel \
         glibc-langpack-en \
+        helm \
         java-devel \
         libcurl-devel \
         libevent-devel \
@@ -50,15 +51,16 @@ RUN dnf install -y 'dnf-command(config-manager)' \
         lsof \
         lua5.1-devel \
         make \
-        mariadb-connector-c-devel \
         mariadb-devel \
         netcat \
         openssl-devel \
         patch \
+        procps-ng \
         protobuf-compiler \
         protobuf-devel \
         python3.12 \
         python3.12-devel \
+        socat \
         tree \
         vim \
         zip \
@@ -97,10 +99,10 @@ RUN cd /tmp \
 RUN cd /tmp \
     && git clone https://github.com/apache/logging-log4cxx \
     && cd logging-log4cxx \
-    && git checkout rel/v1.3.1 \
+    && git checkout rel/v1.8.0 \
     && mkdir build \
     && cd build \
-    && cmake .. \
+    && cmake .. -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--as-needed" \
     && make -j8 \
     && make install \
     && cd /tmp \
@@ -177,7 +179,7 @@ RUN cd /tmp \
     && git checkout tags/1.11.729 \
     && mkdir build \
     && cd build \
-    && cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_ONLY="s3" -DUSE_TLS_V1_3=on -DCPP_STANDARD=17 \
+    && cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_ONLY="s3" -DUSE_TLS_V1_3=on -DCPP_STANDARD=23 \
     && make -j8 \
     && make install \
     && cd /tmp \
@@ -254,7 +256,7 @@ RUN dnf install -y 'dnf-command(config-manager)' \
         libevent \
         libuuid \
         lua5.1 \
-        mariadb-connector-c \
+        mariadb \
         openssl \
         procps-ng \
         protobuf \
@@ -264,8 +266,6 @@ RUN dnf install -y 'dnf-command(config-manager)' \
         lsof \
         strace \
         net-tools \
-        openldap \
-        mariadb-client-utils \
     && dnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
* Add `helm`, `procps-ng`, and `socat` to build base
* Update `log4cxx` to v1.8.0
* Have linker strip unneeded ldap dependency from `log4cxx`
* Set AWS sdk to build with C++23
* Use `mariadb` package instead of `mariadb-client-utils` in run base